### PR TITLE
Improving windows data path

### DIFF
--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -5,19 +5,16 @@ import os
 import appdirs
 
 # Setup data directory
-try:
-    USER_DATA_PATH = appdirs.user_data_dir(
-        appname="ansys_mapdl_core", appauthor="Ansys"
-    )
-    if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
-        os.makedirs(USER_DATA_PATH)
+USER_DATA_PATH = appdirs.user_data_dir(
+    appname="ansys_mapdl_core", appauthor="Ansys"
+)
+if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
+    os.makedirs(USER_DATA_PATH)
 
-    EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
-    if not os.path.exists(EXAMPLES_PATH):  # pragma: no cover
-        os.makedirs(EXAMPLES_PATH)
+EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
+if not os.path.exists(EXAMPLES_PATH):  # pragma: no cover
+    os.makedirs(EXAMPLES_PATH)
 
-except:  # pragma: no cover
-    pass
 
 from ansys.mapdl.core.logging import Logger
 

--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -5,9 +5,7 @@ import os
 import appdirs
 
 # Setup data directory
-USER_DATA_PATH = appdirs.user_data_dir(
-    appname="ansys_mapdl_core", appauthor="Ansys"
-)
+USER_DATA_PATH = appdirs.user_data_dir(appname="ansys_mapdl_core", appauthor="Ansys")
 if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
     os.makedirs(USER_DATA_PATH)
 

--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -57,7 +57,9 @@ _HAS_ANSYS = _check_has_ansys()
 
 # Setup data directory
 try:
-    USER_DATA_PATH = appdirs.user_data_dir("ansys_mapdl_core")
+    USER_DATA_PATH = appdirs.user_data_dir(
+        appname="ansys_mapdl_core", appauthor="Ansys"
+    )
     if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
         os.makedirs(USER_DATA_PATH)
 

--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -4,6 +4,21 @@ import os
 
 import appdirs
 
+# Setup data directory
+try:
+    USER_DATA_PATH = appdirs.user_data_dir(
+        appname="ansys_mapdl_core", appauthor="Ansys"
+    )
+    if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
+        os.makedirs(USER_DATA_PATH)
+
+    EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
+    if not os.path.exists(EXAMPLES_PATH):  # pragma: no cover
+        os.makedirs(EXAMPLES_PATH)
+
+except:  # pragma: no cover
+    pass
+
 from ansys.mapdl.core.logging import Logger
 
 LOG = Logger(level=logging.ERROR, to_file=False, to_stdout=True)
@@ -54,21 +69,6 @@ from ansys.mapdl.core.pool import LocalMapdlPool
 from ansys.mapdl.core.theme import MapdlTheme
 
 _HAS_ANSYS = _check_has_ansys()
-
-# Setup data directory
-try:
-    USER_DATA_PATH = appdirs.user_data_dir(
-        appname="ansys_mapdl_core", appauthor="Ansys"
-    )
-    if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
-        os.makedirs(USER_DATA_PATH)
-
-    EXAMPLES_PATH = os.path.join(USER_DATA_PATH, "examples")
-    if not os.path.exists(EXAMPLES_PATH):  # pragma: no cover
-        os.makedirs(EXAMPLES_PATH)
-
-except:  # pragma: no cover
-    pass
 
 BUILDING_GALLERY = False
 RUNNING_TESTS = False

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -20,7 +20,6 @@ except ModuleNotFoundError:  # pragma: no cover
     _HAS_PIM = False
 
 from ansys.tools.path import find_ansys, get_ansys_path, version_from_path
-import appdirs
 
 from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core import LOG

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -44,7 +44,7 @@ from ansys.mapdl.core.misc import (
 )
 
 # settings directory
-SETTINGS_DIR = appdirs.user_data_dir("ansys_mapdl_core")
+SETTINGS_DIR = pymapdl.USER_DATA_PATH
 if not os.path.isdir(SETTINGS_DIR):
     try:
         os.makedirs(SETTINGS_DIR)


### PR DESCRIPTION
Related to these relatively minor issues https://github.com/ansys/pyfluent/issues/1588, particularly the second one

`appdirs.user_data_dir("ansys_mapdl_core")` on Windows returns `%LocalAppData%\ansys_mapdl_core\ansys_mapdl_core`, which I don't think is what the original developer intended (note the repeated nested dir). On Linux it returns `~/.local/share/ansys_mapdl_core`. 

As in the appdirs documentation (https://github.com/ActiveState/appdirs/blob/master/appdirs.py#L44), if an `appauthor` is not specified, then by default on Windows it uses `appauthor=appname`. 

My suggestion is to use `user_data_dir(appname="ansys_mapdl_core", appauthor="Ansys")`, so that the path on Windows then is `%LocalAppData%\Ansys\ansys_mapdl_core` which is how apps more commonly do this on Windows in my understanding, and at least the Ansys Fluent setup already creates and uses the `%LocalAppData%\Ansys` root folder. This is also what we are currently using on PyFluent. Perhaps it would be a good idea for other PyAnsys modules to use the same naming scheme, so that all of their appdata files end up inside the `%LocalAppData%\Ansys` root folder and don't clutter the user's appdata folder? 

edit: this does not change the folder on Linux, only on Windows

In the commit I also changed the `SETTINGS_DIR` to point to `USER_DATA_PATH`, rather than calling `appdirs.user_data_dir` again, as they were set to the same value and I assume you want them to always be the same.

Additionally, in your `__init__.py` file you are creating the `USER_DATA_PATH` and `EXAMPLES_PATH` directories immediately when pymapdl is first imported, regardless of what pymapdl is actually going to be used for, creating potentially unnecessary/useless folders. I would expect users often won't use either directory and would rather save files to their own working directory. I haven't touched this behavior in this commit, perhaps another PR would be better for this change.