### PR TITLE
Fixing missing full file

### DIFF
--- a/examples/01-apdlmath-examples/eigen_solve.py
+++ b/examples/01-apdlmath-examples/eigen_solve.py
@@ -28,9 +28,9 @@ mm = mapdl.math
 # after running the input file from Verification Manual 153
 #
 out = mapdl.input(vmfiles["vm153"])
-
-k = mm.stiff(fname="PRSMEMB.full")
-m = mm.mass(fname="PRSMEMB.full")
+fullfile = mapdl.jobname + ".full"
+k = mm.stiff(fname=fullfile)
+m = mm.mass(fname=fullfile)
 
 
 ###############################################################################

--- a/examples/01-apdlmath-examples/scipy_sparse_matrix.py
+++ b/examples/01-apdlmath-examples/scipy_sparse_matrix.py
@@ -20,7 +20,8 @@ mm = mapdl.math
 # Load and solve verification manual example 153.  Then load the
 # stiffness matrix into APDLmath.
 out = mapdl.input(vmfiles["vm153"])
-k = mm.stiff(fname="PRSMEMB.full")
+fullfile = mapdl.jobname + ".full"
+k = mm.stiff(fname=fullfile)
 k
 
 ################################################################################

--- a/examples/01-apdlmath-examples/solve_sparse_matrix.py
+++ b/examples/01-apdlmath-examples/solve_sparse_matrix.py
@@ -23,7 +23,7 @@ mm = mapdl.math
 # After a solve command, the full contains the assemblied stiffness
 # matrix, mass matrix, and the load vector.
 #
-out = mapdl.input(vmfiles["vm153"])
+out = mapdl.input(vmfiles["vm152"])
 
 ###############################################################################
 # List the files in current directory

--- a/examples/01-apdlmath-examples/solve_sparse_matrix.py
+++ b/examples/01-apdlmath-examples/solve_sparse_matrix.py
@@ -38,7 +38,8 @@ mapdl.list_files()
 #
 # Printout the dimensions of this Sparse Matrix
 #
-k = mm.stiff(fname="PRSMEMB.full")
+fullfile = mapdl.jobname + ".full"
+k = mm.stiff(fname=fullfile)
 k
 
 ###############################################################################
@@ -52,7 +53,7 @@ ky
 #
 # Printout the norm of this vector.
 #
-b = mm.rhs(fname="PRSMEMB.full")
+b = mm.rhs(fname=fullfile)
 b.norm()
 
 ###############################################################################

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -20,7 +20,7 @@ import numpy as np
 
 from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core import _HAS_PYVISTA, LOG
-from ansys.mapdl.core.errors import MapdlExitedError
+from ansys.mapdl.core.errors import MapdlExitedError, MapdlRuntimeError
 
 try:
     import ansys.tools.report as pyansys_report
@@ -548,14 +548,14 @@ def load_file(mapdl, fname, priority_mapdl_file=None):
     base_fname = os.path.basename(fname)
     if not os.path.exists(fname) and base_fname not in mapdl.list_files():
         raise FileNotFoundError(
-            f"The file {fname} could not be found in the Python working directory ('{os.getcwd()}')"
+            f"The file {fname} could not be found in the Python working directory ('{os.getcwd()}') "
             f"nor in the MAPDL working directory ('{mapdl.directory}')."
         )
 
     elif os.path.exists(fname) and base_fname in mapdl.list_files():  # pragma: no cover
         if priority_mapdl_file is None:
             warn(
-                f"The file '{base_fname}' is present in both, the python working directory ('{os.getcwd()}')"
+                f"The file '{base_fname}' is present in both, the python working directory ('{os.getcwd()}') "
                 f"and in the MAPDL working directory ('{mapdl.directory}'). "
                 "Using the one already in the MAPDL directory.\n"
                 "If you prefer to use the file in the Python directory, you shall remove the file in the MAPDL directory."
@@ -1206,8 +1206,8 @@ def wrap_point_SEL(entity="node"):
 
                 if vmax or vinc:
                     raise ValueError(
-                        "If an iterable is used as 'vmin' argument,"
-                        " it is not allowed to use 'vmax' or 'vinc' arguments."
+                        "If an iterable is used as 'vmin' argument, "
+                        "it is not allowed to use 'vmax' or 'vinc' arguments."
                     )
 
                 if len(vmin) == 0 and type_ == "S":


### PR DESCRIPTION
It seems that the old ``vm153.dat`` had the full file name embedded.

When the vms were updated in #2045, the command which changed the full file was deleted:

<img width="820" alt="image" src="https://github.com/ansys/pymapdl/assets/28149841/d7cd921b-5ce9-40f4-804d-eafa615e689a">

CICD should have catch this, but it reused the cached examples. I'm not sure how to solve that. I will open a different issue for that.

Close #2078