### PR TITLE
Dropping Python 3.7 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -95,7 +95,6 @@ body:
       description: Run `python --version` to verify your Python version
       multiple: false
       options:
-       - '3.7'
        - '3.8'
        - '3.9'
        - '3.10'

--- a/.github/ISSUE_TEMPLATE/examples.yml
+++ b/.github/ISSUE_TEMPLATE/examples.yml
@@ -56,7 +56,6 @@ body:
       description: Run `python --version` to verify your Python version
       multiple: false
       options:
-       - '3.7'
        - '3.8'
        - '3.9'
        - '3.10'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         # Only perform wheelhouse builds for macOS when releasing
         should-release: 
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}

--- a/README.rst
+++ b/README.rst
@@ -90,8 +90,8 @@ For more information on each project, visit their GitHub pages.
 
 Installation
 ------------
-The ``ansys-mapdl-core`` package currently supports Python 3.7 through
-Python 3.10 on Windows, Mac OS, and Linux.
+The ``ansys-mapdl-core`` package currently supports Python 3.8 through
+Python 3.11 on Windows, Mac OS, and Linux.
 
 Install the latest release from `PyPi
 <https://pypi.org/project/ansys-mapdl-core/>`_ with:
@@ -125,14 +125,14 @@ Page <https://github.com/pyansys/pymapdl/releases>`_ for your corresponding
 machine architecture.
 
 Each wheelhouse archive contains all the python wheels necessary to install
-PyMAPDL from scratch on Windows and Linux for Python 3.7 and 3.9. You can install
+PyMAPDL from scratch on Windows and Linux for Python 3.8 and 3.11. You can install
 this on an isolated system with a fresh python or on a virtual environment.
 
-For example, on Linux with Python 3.7, unzip it and install it with the following:
+For example, on Linux with Python 3.8, unzip it and install it with the following:
 
 .. code:: console
 
-   unzip PyMAPDL-v0.62.dev1-wheelhouse-Linux-3.7.zip wheelhouse
+   unzip PyMAPDL-v0.62.dev1-wheelhouse-Linux-3.8.zip wheelhouse
    pip install ansys-mapdl-core -f wheelhouse --no-index --upgrade --ignore-installed
 
 If you're on Windows with Python 3.9, unzip to a ``wheelhouse`` directory and

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -32,8 +32,8 @@ Installation
 
 Python module
 ~~~~~~~~~~~~~
-The ``ansys.mapdl.core`` package currently supports Python 3.7 through
-Python 3.10 on Windows, Mac OS, and Linux.
+The ``ansys.mapdl.core`` package currently supports Python 3.8 through
+Python 3.11 on Windows, Mac OS, and Linux.
 
 Install the latest release from 
 `PyPi <pymapdl_pypi_>`_ with:
@@ -71,14 +71,14 @@ of installing PyMAPDL is downloading the wheelhouse archive from the
 machine architecture.
 
 Each wheelhouse archive contains all the Python wheels necessary to install
-PyMAPDL from scratch on Windows and Linux for Python 3.7 and 3.9. You can install
+PyMAPDL from scratch on Windows and Linux for Python 3.8 and 3.9. You can install
 this on an isolated system with a fresh Python or on a virtual environment.
 
-For example, on Linux with Python 3.7, unzip it and install it with the following:
+For example, on Linux with Python 3.8, unzip it and install it with the following:
 
 .. code:: console
 
-   unzip PyMAPDL-v0.62.dev1-wheelhouse-Linux-3.7.zip wheelhouse
+   unzip PyMAPDL-v0.62.dev1-wheelhouse-Linux-3.8.zip wheelhouse
    pip install ansys-mapdl-core -f wheelhouse --no-index --upgrade --ignore-installed
 
 If you're on Windows with Python 3.9, unzip to a ``wheelhouse`` directory and

--- a/doc/source/user_guide/upf.rst
+++ b/doc/source/user_guide/upf.rst
@@ -9,8 +9,8 @@ Python language to code user programmable subroutines. A subset of the
 documented UPF subroutines support the Python UPF capability. For more information,
 see `Supported UPF subroutines`_).
 
-You must install a Python distribution before using this feature. Python 3.6
-through Python 3.7 are supported.
+You must install a Python distribution before using this feature. Python 3.8
+through Python 3.11 are supported.
 
 Python UPFs are only supported on Linux.
 
@@ -172,7 +172,7 @@ server:
 
     Python UPF Detected
 
-    PYTHON VERSION : 3.6
+    PYTHON VERSION : 3.8
     >>
     >> START PYTHON GRPC SERVER
     >>

--- a/doc/source/user_guide/upf.rst
+++ b/doc/source/user_guide/upf.rst
@@ -172,7 +172,7 @@ server:
 
     Python UPF Detected
 
-    PYTHON VERSION : 3.8
+    PYTHON VERSION : 3.10
     >>
     >> START PYTHON GRPC SERVER
     >>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-mapdl-core"
 version = "0.66.dev0"
 description = "A Python wrapper for Ansys MAPDL."
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {file = "LICENSE"}
 authors = [
     {name = "Ansys, Inc.", email = "pyansys.maintainers@ansys.com"},
@@ -46,7 +46,6 @@ classifiers = [
     "Operating System :: Microsoft :: Windows",
     "Operating System :: POSIX",
     "Operating System :: MacOS",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,10 @@ isolated_build_env = build
 [testenv]
 description = Checks for project unit tests and coverage (if desired)
 basepython =
-    py37: python3.7
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py311: python3.11
     py: python3
     {style,reformat,doc}: python3
 setenv =


### PR DESCRIPTION
This would follow https://github.com/ansys/pyansys/pull/228. 