### PR TITLE
replace appdirs by platformdirs

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: marcoroth/dependabot-bump-together-action@main
         with:
-          dependencies: ansys-api-mapdl, vtk, ansys-corba, ansys-dpf-core, ansys-mapdl-reader, ansys-platform-instancemanagement, ansys-sphinx-theme, pyansys-tools-report, appdirs, autopep8, click, imageio-ffmpeg, imageio, importlib-metadata, jupyter_sphinx, jupyterlab, matplotlib, numpy, numpydoc, pandas, pexpect, plotly, protobuf, pyiges, pypandoc, pytest-cov, pytest-rerunfailures, pytest-sphinx, pytest, pythreejs, pyvista, scipy, setuptools, sphinx-autobuild, sphinx-autodoc-typehints, sphinx-copybutton, sphinx-gallery, sphinx-notfound-page, sphinxcontrib-websupport, sphinxemoji, tqdm, wheel
+          dependencies: ansys-api-mapdl, vtk, ansys-corba, ansys-dpf-core, ansys-mapdl-reader, ansys-platform-instancemanagement, ansys-sphinx-theme, pyansys-tools-report, platformdirs, autopep8, click, imageio-ffmpeg, imageio, importlib-metadata, jupyter_sphinx, jupyterlab, matplotlib, numpy, numpydoc, pandas, pexpect, plotly, protobuf, pyiges, pypandoc, pytest-cov, pytest-rerunfailures, pytest-sphinx, pytest, pythreejs, pyvista, scipy, setuptools, sphinx-autobuild, sphinx-autodoc-typehints, sphinx-copybutton, sphinx-gallery, sphinx-notfound-page, sphinxcontrib-websupport, sphinxemoji, tqdm, wheel
           package_managers: pip
           directory: /
           branch: main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "ansys-mapdl-reader>=0.51.7",
     "ansys-math-core>=0.1.2",
     "ansys-platform-instancemanagement~=1.0",
-    "appdirs>=1.4.0",
+    "platformdirs>=3.6.0",
     "click>=8.1.3", # for CLI interface
     "grpcio>=1.30.0",  # tested up to grpcio==1.35
     "importlib-metadata>=4.0",

--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -2,10 +2,12 @@
 import logging
 import os
 
-import appdirs
+import platformdirs
 
 # Setup data directory
-USER_DATA_PATH = appdirs.user_data_dir(appname="ansys_mapdl_core", appauthor="Ansys")
+USER_DATA_PATH = platformdirs.user_data_dir(
+    appname="ansys_mapdl_core", appauthor="Ansys"
+)
 if not os.path.exists(USER_DATA_PATH):  # pragma: no cover
     os.makedirs(USER_DATA_PATH)
 

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -274,7 +274,7 @@ class Report(base_report_class):
         core = [
             "ansys.mapdl.core",
             "numpy",
-            "appdirs",
+            "platformdirs",
             "scipy",
             "grpc",  # grpcio
             "ansys.api.mapdl.v0",  # ansys-api-mapdl-v0


### PR DESCRIPTION
In February 2023 [appdirs has been deprecated](https://github.com/ActiveState/appdirs)
The developers suggest to move to [platformdirs](https://pypi.org/project/platformdirs/) which is a more active fork of appdirs