### PR TITLE
Detaching `examples`

### DIFF
--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -53,7 +53,6 @@ from ansys.tools.path.path import (
     save_ansys_path,
 )
 
-from ansys.mapdl.core import examples
 from ansys.mapdl.core._version import SUPPORTED_ANSYS_VERSIONS
 from ansys.mapdl.core.convert import convert_apdl_block, convert_script
 from ansys.mapdl.core.launcher import close_all_local_instances

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,5 +1,6 @@
 import os
 import re
+from subprocess import PIPE, STDOUT, Popen
 
 import pytest
 
@@ -127,3 +128,32 @@ def test_download_tech_demo_data(running_test):
             download_tech_demo_data("td-21", "ring_stiffened_cylinder_mesh_file.cdb")
             is True
         )
+
+
+def test_detach_examples_submodule():
+    cmd = """
+import sys
+
+assert "ansys.mapdl.core" not in sys.modules
+assert "requests" not in sys.modules
+assert "ansys.mapdl.core.examples" not in sys.modules
+
+from ansys.mapdl import core as pymapdl
+
+assert "ansys.mapdl.core" in sys.modules
+assert "ansys.mapdl.core.examples" not in sys.modules
+assert "requests" not in sys.modules
+
+from ansys.mapdl.core.examples import vmfiles
+
+assert "ansys.mapdl.core.examples" in sys.modules
+assert "requests" in sys.modules
+
+print("Everything went well")
+"""
+
+    cmd_line = f"""python -c '{cmd}' """
+    p = Popen(cmd_line, shell=True, stdout=PIPE, stderr=STDOUT)
+    out = p.communicate()[0].decode()
+
+    assert out.strip() == "Everything went well"


### PR DESCRIPTION

Close #2191 


## Testing:
I will look into adding some unit tests, but it seems difficult to achieve.

```pycon
In [2]: import sys

In [3]: "ansys.mapdl.core" in sys.modules
Out[3]: False

In [4]: "requests" in sys.modules
Out[4]: False

In [5]: "ansys.mapdl.core.examples" in sys.modules
Out[5]: False

In [6]: from ansys.mapdl import core as pymapdl

In [7]: "ansys.mapdl.core" in sys.modules
Out[7]: True

In [8]: "ansys.mapdl.core.examples" in sys.modules
Out[8]: False

In [9]: "requests" in sys.modules
Out[9]: False

In [10]: from ansys.mapdl.core.examples import vmfiles

In [11]: "ansys.mapdl.core.examples" in sys.modules
Out[11]: True

In [12]: "requests" in sys.modules
Out[12]: True
```

