### PR TITLE
Removing xfails.

### DIFF
--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -269,7 +269,7 @@ def test_env_injection():
         [None, False, "Working directory is NOT in the pytest directory."],
         [True, None, "There is a result file, and WDIR is a temp dir."],
         pytest.param(
-            True, True, "Both options (`True`) is not allowed.", marks=pytest.mark.xfail
+            True, True, "Both options (`True`) is not allowed.", marks=pytest.mark.fail
         ),
         [True, False, "There is a result file, and WDIR is in a temp dir."],
         [False, None, "There is NOT a result file, and WDIR is in a temp dir."],

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -860,7 +860,6 @@ def test_load_array(mapdl, dimx, dimy):
 @pytest.mark.parametrize(
     "array",
     [
-        pytest.param([1, 3, 10], marks=pytest.mark.xfail),
         np.zeros(
             3,
         ),

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -38,12 +38,16 @@ def test_report():
         "LOCALhost",
         "192.1.1.1",
         "127.0.0.01",
-        pytest.param("asdf", marks=pytest.mark.xfail),
-        pytest.param("300.2.2.2", marks=pytest.mark.xfail),
     ],
 )
 def test_check_valid_ip(ip):
     check_valid_ip(ip)
+
+
+@pytest.mark.parametrize("ip", ["asdf", "300.2.2.2"])
+def test_check_valid_ip_error(ip):
+    with pytest.raises(OSError):
+        check_valid_ip(ip)
 
 
 @pytest.mark.parametrize(
@@ -52,14 +56,24 @@ def test_check_valid_ip(ip):
         5000,
         50053,
         10000,
-        pytest.param("asdf", marks=pytest.mark.xfail),
-        pytest.param("2323", marks=pytest.mark.xfail),
-        pytest.param(1, marks=pytest.mark.xfail),
-        pytest.param(1e9, marks=pytest.mark.xfail),
     ],
 )
 def test_check_valid_port(port):
     check_valid_port(port)
+
+
+@pytest.mark.parametrize(
+    "port",
+    [
+        "asdf",
+        "2323",
+        1,
+        1e9,
+    ],
+)
+def test_check_valid_port_error(port):
+    with pytest.raises(ValueError):
+        check_valid_port(port)
 
 
 @pytest.mark.parametrize(
@@ -70,14 +84,24 @@ def test_check_valid_port(port):
         "False",
         True,
         False,
-        pytest.param("asdf", marks=pytest.mark.xfail),
-        pytest.param("2323", marks=pytest.mark.xfail),
-        pytest.param(1, marks=pytest.mark.xfail),
-        pytest.param(1e9, marks=pytest.mark.xfail),
     ],
 )
 def test_check_valid_start_instance(start_instance):
     check_valid_start_instance(start_instance)
+
+
+@pytest.mark.parametrize(
+    "start_instance",
+    [
+        "asdf",
+        "2323",
+        1,
+        1e9,
+    ],
+)
+def test_check_valid_start_instance_error(start_instance):
+    with pytest.raises(ValueError):
+        check_valid_start_instance(start_instance)
 
 
 def test_creation_time(tmpdir):

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -119,132 +119,7 @@ def test__get_parameter_array(mapdl, number):
         mapdl.parameters._get_parameter_array(name, shape)
 
 
-# We use also 'run' and 'get' to be more confident.
-@pytest.mark.parametrize("func", ["run", "get", "_check_parameter_name", "parameters"])
-@pytest.mark.parametrize(
-    "par_name",
-    [
-        "asdf124",
-        "asd",
-        "a12345",
-        "a12345_",
-        "_a12345_",
-        "_array2d_(1,1)",
-        "array3d_(1,1,1)",
-        pytest.param(
-            "_a12345",
-            marks=pytest.mark.xfail,
-            id="Starting by underscore, but not ending",
-        ),
-        pytest.param(
-            "_asdf(1)_",
-            marks=pytest.mark.xfail,
-            id="Indexing before underscore",
-        ),
-        pytest.param(
-            "_a12345",
-            marks=pytest.mark.xfail,
-            id="Starting by underscore, but not ending",
-        ),
-        pytest.param(
-            "_array2d(1,1)",
-            marks=pytest.mark.xfail,
-            id="Starting by underscore, but not ending",
-        ),
-        pytest.param("1asdf", marks=pytest.mark.xfail, id="Starting by number"),
-        pytest.param(
-            "123asdf", marks=pytest.mark.xfail, id="Starting by several numbers"
-        ),
-        pytest.param(
-            "asa12df+",
-            marks=pytest.mark.xfail,
-            id="Invalid symbol in parameter name.",
-        ),
-        # function args
-        pytest.param(
-            "AR0",
-            marks=pytest.mark.xfail,
-            id="Using `AR0` with is reserved for functions/macros",
-        ),
-        pytest.param(
-            "AR1",
-            marks=pytest.mark.xfail,
-            id="Using `AR1` with is reserved for functions/macros",
-        ),
-        pytest.param(
-            "AR10",
-            marks=pytest.mark.xfail,
-            id="Using `AR10` with is reserved for functions/macros",
-        ),
-        pytest.param(
-            "AR99",
-            marks=pytest.mark.xfail,
-            id="Using `AR99` with is reserved for functions/macros",
-        ),
-        pytest.param(
-            "AR111",
-            marks=pytest.mark.xfail,
-            id="Using `AR111` with is reserved for functions/macros",
-        ),
-        pytest.param(
-            "AR999",
-            marks=pytest.mark.xfail,
-            id="Using `AR999` with is reserved for functions/macros",
-        ),
-        pytest.param(
-            "ARG0",
-            marks=pytest.mark.xfail,
-            id="Using `ARG0` with is reserved for functions/macros",
-        ),
-        pytest.param(
-            "ARG1",
-            marks=pytest.mark.xfail,
-            id="Using `ARG1` with is reserved for functions/macros",
-        ),
-        pytest.param(
-            "ARG10",
-            marks=pytest.mark.xfail,
-            id="Using `ARG10` with is reserved for functions/macros",
-        ),
-        pytest.param(
-            "ARG99",
-            marks=pytest.mark.xfail,
-            id="Using `ARG99` with is reserved for functions/macros",
-        ),
-        pytest.param(
-            "ARG111",
-            marks=pytest.mark.xfail,
-            id="Using `ARG111` with is reserved for functions/macros",
-        ),
-        pytest.param(
-            "ARG999",
-            marks=pytest.mark.xfail,
-            id="Using `ARG999` with is reserved for functions/macros",
-        ),
-        # length
-        pytest.param(
-            "a23456789012345678901234567890123",
-            marks=pytest.mark.xfail,
-            id="Name too long",
-        ),
-        pytest.param(
-            "aasdf234asdf5678901-2345",
-            marks=pytest.mark.xfail,
-            id="Not valid sign -",
-        ),
-        pytest.param(
-            "aasdf234asdf5678901+2345",
-            marks=pytest.mark.xfail,
-            id="Not valid sign +",
-        ),
-        pytest.param(
-            "aasdf234a?sdf5678901?2345",
-            marks=pytest.mark.xfail,
-            id="Not valid sign ?",
-        ),
-    ],
-)
-def test_parameters_name(mapdl, func, par_name):
+def parameters_name(mapdl, func, par_name):
     if "_array2d_" in par_name:
         mapdl.dim("_array2d_", "array", 2, 2)
 
@@ -269,6 +144,124 @@ def test_parameters_name(mapdl, func, par_name):
         # Avoiding check if indexing or starting and ending with _.
         assert mapdl.parameters[par_name]
         assert isinstance(mapdl.parameters[par_name], float)
+
+
+# We use also 'run' and 'get' to be more confident.
+@pytest.mark.parametrize("func", ["run", "get", "_check_parameter_name", "parameters"])
+@pytest.mark.parametrize(
+    "par_name",
+    [
+        "asdf124",
+        "asd",
+        "a12345",
+        "a12345_",
+        "_a12345_",
+        "_array2d_(1,1)",
+        "array3d_(1,1,1)",
+    ],
+)
+def test_parameters_name(mapdl, func, par_name):
+    parameters_name(mapdl, func, par_name)
+
+
+# We use also 'run' and 'get' to be more confident.
+@pytest.mark.parametrize("func", ["run", "get", "_check_parameter_name", "parameters"])
+@pytest.mark.parametrize(
+    "par_name",
+    [
+        pytest.param(
+            "_a12345",
+            id="Starting by underscore, but not ending",
+        ),
+        pytest.param(
+            "_asdf(1)_",
+            id="Indexing before underscore",
+        ),
+        pytest.param(
+            "_a12345",
+            id="Starting by underscore, but not ending",
+        ),
+        pytest.param(
+            "_array2d(1,1)",
+            id="Starting by underscore, but not ending",
+        ),
+        pytest.param("1asdf", id="Starting by number"),
+        pytest.param("123asdf", id="Starting by several numbers"),
+        pytest.param(
+            "asa12df+",
+            id="Invalid symbol in parameter name.",
+        ),
+        # function args
+        pytest.param(
+            "AR0",
+            id="Using `AR0` with is reserved for functions/macros",
+        ),
+        pytest.param(
+            "AR1",
+            id="Using `AR1` with is reserved for functions/macros",
+        ),
+        pytest.param(
+            "AR10",
+            id="Using `AR10` with is reserved for functions/macros",
+        ),
+        pytest.param(
+            "AR99",
+            id="Using `AR99` with is reserved for functions/macros",
+        ),
+        pytest.param(
+            "AR111",
+            id="Using `AR111` with is reserved for functions/macros",
+        ),
+        pytest.param(
+            "AR999",
+            id="Using `AR999` with is reserved for functions/macros",
+        ),
+        pytest.param(
+            "ARG0",
+            id="Using `ARG0` with is reserved for functions/macros",
+        ),
+        pytest.param(
+            "ARG1",
+            id="Using `ARG1` with is reserved for functions/macros",
+        ),
+        pytest.param(
+            "ARG10",
+            id="Using `ARG10` with is reserved for functions/macros",
+        ),
+        pytest.param(
+            "ARG99",
+            id="Using `ARG99` with is reserved for functions/macros",
+        ),
+        pytest.param(
+            "ARG111",
+            id="Using `ARG111` with is reserved for functions/macros",
+        ),
+        pytest.param(
+            "ARG999",
+            id="Using `ARG999` with is reserved for functions/macros",
+        ),
+        # length
+        pytest.param(
+            "a23456789012345678901234567890123",
+            id="Name too long",
+        ),
+        pytest.param(
+            "aasdf234asdf5678901-2345",
+            id="Not valid sign -",
+        ),
+        pytest.param(
+            "aasdf234asdf5678901+2345",
+            id="Not valid sign +",
+        ),
+        pytest.param(
+            "aasdf234a?sdf5678901?2345",
+            id="Not valid sign ?",
+        ),
+    ],
+)
+def test_parameters_name_error(mapdl, func, par_name):
+    with pytest.raises(ValueError):
+        parameters_name(mapdl, func, par_name)
 
 
 def test_contain_iter(mapdl, cleared):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -167,8 +167,6 @@ def test_bc_plot_options(
         "ux",
         "UX",
         ["UX", "UY"],
-        pytest.param("error", marks=pytest.mark.xfail),
-        pytest.param(["UX", "error"], marks=pytest.mark.xfail),
         "CSGZ",
     ],
 )
@@ -184,14 +182,28 @@ def test_bc_plot_bc_labels(mapdl, bc_example, bc_labels):
 
 @skip_no_xserver
 @pytest.mark.parametrize(
+    "bc_labels",
+    [
+        "error",
+        ["UX", "error"],
+    ],
+)
+def test_bc_plot_bc_labels_error(mapdl, bc_example, bc_labels):
+    with pytest.raises(ValueError):
+        p = mapdl.nplot(
+            return_plotter=True,
+            plot_bc=True,
+            plot_bc_labels=True,
+            bc_labels=bc_labels,
+        )
+
+
+@skip_no_xserver
+@pytest.mark.parametrize(
     "bc_target",
     [
         "Nodes",
         "NOdes",
-        pytest.param(["NOdes"], marks=pytest.mark.xfail),
-        pytest.param("error", marks=pytest.mark.xfail),
-        pytest.param(["error"], marks=pytest.mark.xfail),
-        pytest.param({"error": "Not accepting dicts"}, marks=pytest.mark.xfail),
     ],
 )
 def test_bc_plot_bc_target(mapdl, bc_example, bc_target):
@@ -202,6 +214,26 @@ def test_bc_plot_bc_target(mapdl, bc_example, bc_target):
         bc_target=bc_target,
     )
     assert isinstance(p, Plotter)
+
+
+@skip_no_xserver
+@pytest.mark.parametrize(
+    "bc_target",
+    [
+        ["NOdes"],
+        "error",
+        ["error"],
+        {"error": "Not accepting dicts"},
+    ],
+)
+def test_bc_plot_bc_target_error(mapdl, bc_example, bc_target):
+    with pytest.raises(ValueError):
+        p = mapdl.nplot(
+            return_plotter=True,
+            plot_bc=True,
+            plot_bc_labels=True,
+            bc_target=bc_target,
+        )
 
 
 def test_bc_no_mapdl(mapdl):


### PR DESCRIPTION
The `pytest.mark.xfail` should be used when the implementation is not correct, or similar. So eventually, this will get fixed.

``XFAIL`` should not be used as a default when the test raises an exception because in that case, the implementation is behaving as expected and it should be a ``PASS``.