### PR TITLE
Fix reminder bot

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -89,3 +89,7 @@
 - name: Won't fix
   description: ""
   color: ffffff
+
+- name: reminder
+  description: "Label for the reminder bot"
+  color: c5def5


### PR DESCRIPTION
It seems that github bot removes the reminder bot label. I hope adding this label to the labels file should fix it.