### PR TITLE
Added distributed test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -339,7 +339,7 @@ def mapdl(request, tmpdir_factory):
         run_location=run_path,
         cleanup_on_exit=cleanup,
         license_server_check=False,
-        additional_switches="-smp",
+        # additional_switches="-smp",
         start_timeout=50,
     )
     mapdl._show_matplotlib_figures = False  # CI: don't show matplotlib figures

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -27,6 +27,7 @@ from ansys.mapdl.core.launcher import launch_mapdl
 from ansys.mapdl.core.mapdl_grpc import SESSION_ID_NAME
 from ansys.mapdl.core.misc import random_string
 from conftest import (
+    ON_LOCAL,
     skip_if_not_local,
     skip_if_on_cicd,
     skip_no_xserver,
@@ -2121,3 +2122,10 @@ def test_ip(mapdl):
 def test_port(mapdl):
     assert mapdl.port == mapdl._port
     assert isinstance(mapdl.port, int)
+
+
+def test_distributed(mapdl):
+    if ON_LOCAL:
+        assert mapdl._distributed
+    else:
+        assert not mapdl._distributed  # assuming remote is using -smp


### PR DESCRIPTION
Test that `ON_LOCAL` is running on distributed (`-DMP`).

Assumes that `ON_REMOTE` distributed should be `False` (because we specify `-SMP` when launching the docker image) and `ON_LOCAL` distributed should be `True` (because it is the default for MAPDL, and we dont specify `-SMP`).

To test if we are running distribute, we use the `*GET` command with `active` and `numcpu`:

https://github.com/ansys/pymapdl/blob/6916e19d2918fc476e299495b3a865f66e50918f/src/ansys/mapdl/core/parameters.py#L124-L125

I believe this is the right way.