### PR TITLE
Fixing `post_processing` plots

### DIFF
--- a/src/ansys/mapdl/core/plotting.py
+++ b/src/ansys/mapdl/core/plotting.py
@@ -398,6 +398,9 @@ def _general_plotter(
                 UserWarning,
             )
 
+    if not cmap:
+        cmap = "bwr"
+
     if background:
         plotter.set_background(background)
 
@@ -442,7 +445,7 @@ def _general_plotter(
         for each_mesh in mesh_:
             plotter.add_mesh(
                 each_mesh,
-                scalars=None,  # scalars,
+                scalars=scalars,
                 scalar_bar_args=scalar_bar_args,
                 color="w",  # mesh.get("color", color),
                 style=mesh.get("style", style),

--- a/src/ansys/mapdl/core/post.py
+++ b/src/ansys/mapdl/core/post.py
@@ -602,7 +602,8 @@ class PostProcessing:
 
         # we can directly the node numbers as the array of selected
         # nodes will be a mask sized to the highest node index - 1
-        surf = self._mapdl.mesh._surf
+        # surf = self._mapdl.mesh._surf
+        surf = self._mapdl.mesh.grid
         node_id = surf["ansys_node_num"].astype(np.int32) - 1
         all_scalars = all_scalars[node_id]
 

--- a/src/ansys/mapdl/core/post.py
+++ b/src/ansys/mapdl/core/post.py
@@ -602,8 +602,7 @@ class PostProcessing:
 
         # we can directly the node numbers as the array of selected
         # nodes will be a mask sized to the highest node index - 1
-        # surf = self._mapdl.mesh._surf
-        surf = self._mapdl.mesh.grid
+        surf = self._mapdl.mesh._surf
         node_id = surf["ansys_node_num"].astype(np.int32) - 1
         all_scalars = all_scalars[node_id]
 


### PR DESCRIPTION
Fix the following issues:

* Empty `post_processing` plots #2288. Bug introduced in https://github.com/ansys/pymapdl/pull/2207
* Buggy colormaps plots #2296. It seems an issue with new PyVista API. It seems that passing `None` as cmap creates a buggy plot. We are avoiding this by setting a colormap (`bwr`) if no colormap is used.

### Notes
PyMAPDL cmap does not work as cmap in `pyvista.Plotter.add_mesh`. We should fix that.

Close #2288 
Close #2296