### PR TITLE
Adding bot which open an issue if the scheduled build fails

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -93,3 +93,7 @@
 - name: reminder
   description: "Label for the reminder bot"
   color: c5def5
+
+- name: Nightly build failed
+  description: "Label for the nightly fails"
+  color: b5f226

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,3 +638,16 @@ jobs:
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
+  
+  notify:
+    name: Notify failed build
+    needs: [upload-dev-docs]
+    if: failure() && github.event.pull_request == null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open issue
+        uses: jayqi/failed-build-issue-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          title-template: "Failed scheduled build"
+          label-name: "Nightly build failed"


### PR DESCRIPTION
As the title. 

Just to keep a better track of the issues in the nightly/scheduled.