### PR TITLE
Adding option to pytest to skip regression tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,12 @@ def pytest_addoption(parser):
         default=False,
         help="run only GUI tests",
     )
+    parser.addoption(
+        "--skip-regression-check",
+        action="store_true",
+        default=False,
+        help="Avoid checking the image regression check in all tests",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -202,7 +208,10 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture(autouse=True)
-def wrapped_verify_image_cache(verify_image_cache):
+def wrapped_verify_image_cache(verify_image_cache, pytestconfig):
+    skip_regression_check = pytestconfig.option.skip_regression_check
+    if skip_regression_check:
+        verify_image_cache.skip = True
     return verify_image_cache
 
 


### PR DESCRIPTION
Add argument to pytest CLI to skip image regresion check in all tests.