### PR TITLE
maint: updating `ansys-sphinx-theme` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ doc = [
     "sphinx==7.2.6",
     "ansys-dpf-core==0.9.0",
     "ansys-mapdl-reader==0.52.20",
-    "ansys-sphinx-theme==0.12.2",
+    "ansys-sphinx-theme==0.12.3",
     "grpcio==1.51.1",
     "imageio-ffmpeg==0.4.9",
     "imageio==2.31.5",


### PR DESCRIPTION
The search engine is not running correctly on the stable branch. This should fix the issue. 
Pinging @Revathyvenugopal162 for visibility.

Close #2404