### PR TITLE
Fix `mapdl.get` always asking for multiline output when using `item3`

### DIFF
--- a/src/ansys/mapdl/core/mapdl.py
+++ b/src/ansys/mapdl/core/mapdl.py
@@ -2860,9 +2860,10 @@ class _MapdlCore(Commands):
 
         value = response.split("=")[-1].strip()
         if item3:
-            self._log.info(
-                f"The command '{command}' is showing the next message: '{value.splitlines()[1].strip()}'"
-            )
+            if len(value.splitlines()) > 1:
+                self._log.info(
+                    f"The command '{command}' is showing the next message: '{value.splitlines()[1].strip()}'"
+                )
             value = value.splitlines()[0]
 
         try:  # always either a float or string


### PR DESCRIPTION
Close #2430