### PR TITLE
Delaying codecov report until CI is finished

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -29,3 +29,7 @@ coverage:
 codecov:
   notify:
     wait_for_ci: yes
+    # do not notify until at least 5 builds have been uploaded from the CI pipeline
+    after_n_builds: 5
+  comment:
+    after_n_builds: 5

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,3 +25,7 @@ coverage:
         if_ci_failed: error
         if_no_uploads: error
         threshold: 4%  # Because some tests are flaky.
+
+codecov:
+  notify:
+    wait_for_ci: yes


### PR DESCRIPTION
It is quite annoying to see a failed job because a slow job hasn't yet submitted its coverage report yet.