### PR TITLE
Fixing CICD: Adding missing `libgomp1` dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,6 +629,10 @@ jobs:
           python -m pip install -r minimum_requirements.txt
           python -c "from ansys.mapdl import core as pymapdl; print('Import successfull')"
 
+      - name: "Test MAPDL launching"
+        run: |
+          /ansys_inc/v222/ansys/bin/ansys222 -grpc
+
       - name: "Test launching"
         shell: python
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,7 +632,7 @@ jobs:
       - name: "Updating package"
         run: |
           sudo apt-get update
-          sudo apt-get install libgomp1
+          sudo apt-get install -y libgomp1
       
       - name: "Test MAPDL launching"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ env:
   DOCKER_PACKAGE: ghcr.io/ansys/mapdl
   DOCKER_IMAGE_VERSION_DOCS_BUILD: v23.1.0
   ON_CI: True
-  PYTEST_ARGUMENTS: '-vv --durations=10 --maxfail=1 --reruns 7 --reruns-delay 5 --cov=ansys.mapdl.core --cov-report=html'
+  PYTEST_ARGUMENTS: '-vv --durations=10 --maxfail=1 --reruns 1 --reruns-delay 1 --cov=ansys.mapdl.core --cov-report=html'
 
   # Following env vars when changed will "reset" the mentioned cache,
   # by changing the cache file name. It is rendered as ...-v%RESET_XXX%-...
@@ -516,6 +516,15 @@ jobs:
           python -m pip install dist/*.whl
           xvfb-run python -c "from ansys.mapdl import core as pymapdl; print(pymapdl.Report())"
 
+      - name: "Test launching"
+        shell: python
+        run: |
+          from ansys.mapdl.core import launch_mapdl
+          mapdl = launch_mapdl(start_timeout=100)
+          print(mapdl.prep7())
+          print("Everything OK")
+          mapdl.exit()
+          
       - name: "Unit testing requirements installation"
         run: |
           python -m pip install .[tests]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ env:
   DOCKER_PACKAGE: ghcr.io/ansys/mapdl
   DOCKER_IMAGE_VERSION_DOCS_BUILD: v23.1.0
   ON_CI: True
-  PYTEST_ARGUMENTS: '-vv --durations=10 --maxfail=10 --reruns 7 --reruns-delay 5 --cov=ansys.mapdl.core --cov-report=html'
+  PYTEST_ARGUMENTS: '-vv --durations=10 --maxfail=1 --reruns 7 --reruns-delay 5 --cov=ansys.mapdl.core --cov-report=html'
 
   # Following env vars when changed will "reset" the mentioned cache,
   # by changing the cache file name. It is rendered as ...-v%RESET_XXX%-...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,7 +502,7 @@ jobs:
       - name: "Install OS packages"
         run: |
           apt update
-          apt install -y libgl1-mesa-glx xvfb
+          apt install -y libgl1-mesa-glx xvfb libgomp1
 
       - name: "Test virtual framebuffer"
         run: |
@@ -629,7 +629,7 @@ jobs:
           python -m pip install -r minimum_requirements.txt
           python -c "from ansys.mapdl import core as pymapdl; print('Import successfull')"
 
-      - name: "Updating package"
+      - name: "Installing missing package"
         run: |
           sudo apt-get update
           sudo apt-get install -y libgomp1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,15 +515,6 @@ jobs:
           python -m build
           python -m pip install dist/*.whl
           xvfb-run python -c "from ansys.mapdl import core as pymapdl; print(pymapdl.Report())"
-
-      - name: "Test launching"
-        shell: python
-        run: |
-          from ansys.mapdl.core import launch_mapdl
-          mapdl = launch_mapdl(start_timeout=100)
-          print(mapdl.prep7())
-          print("Everything OK")
-          mapdl.exit()
           
       - name: "Unit testing requirements installation"
         run: |
@@ -637,6 +628,15 @@ jobs:
           python -m pip install . --no-deps
           python -m pip install -r minimum_requirements.txt
           python -c "from ansys.mapdl import core as pymapdl; print('Import successfull')"
+
+      - name: "Test launching"
+        shell: python
+        run: |
+          from ansys.mapdl.core import launch_mapdl
+          mapdl = launch_mapdl(start_timeout=100)
+          print(mapdl.prep7())
+          print("Everything OK")
+          mapdl.exit()
 
       - name: "Unit testing requirements installation"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,9 +629,13 @@ jobs:
           python -m pip install -r minimum_requirements.txt
           python -c "from ansys.mapdl import core as pymapdl; print('Import successfull')"
 
+      - name: "Updating package"
+        run: |
+          sudo apt-get update
+          sudo apt-get install libgomp1
+      
       - name: "Test MAPDL launching"
         run: |
-          sudo apt-get install libgomp1
           /ansys_inc/v222/ansys/bin/ansys222 -grpc
 
       - name: "Test launching"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -631,6 +631,7 @@ jobs:
 
       - name: "Test MAPDL launching"
         run: |
+          sudo apt-get install libgomp1
           /ansys_inc/v222/ansys/bin/ansys222 -grpc
 
       - name: "Test launching"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ env:
   DOCKER_PACKAGE: ghcr.io/ansys/mapdl
   DOCKER_IMAGE_VERSION_DOCS_BUILD: v23.1.0
   ON_CI: True
-  PYTEST_ARGUMENTS: '-vv --durations=10 --maxfail=1 --reruns 1 --reruns-delay 1 --cov=ansys.mapdl.core --cov-report=html'
+  PYTEST_ARGUMENTS: '-vv --durations=10 --maxfail=10 --reruns 7 --reruns-delay 5 --cov=ansys.mapdl.core --cov-report=html'
 
   # Following env vars when changed will "reset" the mentioned cache,
   # by changing the cache file name. It is rendered as ...-v%RESET_XXX%-...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -634,18 +634,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgomp1
       
-      - name: "Test MAPDL launching"
-        run: |
-          /ansys_inc/v222/ansys/bin/ansys222 -grpc
+      # - name: "Test MAPDL launching"
+      #   run: |
+      #     /ansys_inc/v222/ansys/bin/ansys222 -grpc
 
-      - name: "Test launching"
-        shell: python
-        run: |
-          from ansys.mapdl.core import launch_mapdl
-          mapdl = launch_mapdl(start_timeout=100)
-          print(mapdl.prep7())
-          print("Everything OK")
-          mapdl.exit()
+      # - name: "Test launching"
+      #   shell: python
+      #   run: |
+      #     from ansys.mapdl.core import launch_mapdl
+      #     mapdl = launch_mapdl(start_timeout=100)
+      #     print(mapdl.prep7())
+      #     print("Everything OK")
+      #     mapdl.exit()
 
       - name: "Unit testing requirements installation"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,7 +515,7 @@ jobs:
           python -m build
           python -m pip install dist/*.whl
           xvfb-run python -c "from ansys.mapdl import core as pymapdl; print(pymapdl.Report())"
-          
+
       - name: "Unit testing requirements installation"
         run: |
           python -m pip install .[tests]
@@ -633,19 +633,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgomp1
-      
-      # - name: "Test MAPDL launching"
-      #   run: |
-      #     /ansys_inc/v222/ansys/bin/ansys222 -grpc
-
-      # - name: "Test launching"
-      #   shell: python
-      #   run: |
-      #     from ansys.mapdl.core import launch_mapdl
-      #     mapdl = launch_mapdl(start_timeout=100)
-      #     print(mapdl.prep7())
-      #     print("Everything OK")
-      #     mapdl.exit()
 
       - name: "Unit testing requirements installation"
         run: |


### PR DESCRIPTION
It seems that CICD is failing, not being able to run succesfully even a single test.

Fixed. See https://github.com/ansys/pymapdl/pull/2514#issuecomment-1818993728