### PR TITLE
Not running auto approver by default

### DIFF
--- a/.github/workflows/approver.yml
+++ b/.github/workflows/approver.yml
@@ -4,22 +4,19 @@ on:
   issue_comment:                                     
     types: [created, edited]
 
-env:
-  # sintax: ("germa89" "author2")
-  ALLOWED_AUTHORS: ("germa89")
-
 jobs:
   autoapprove:
     # This job only runs for pull request comments
     name: PR comment
-    if: ${{ github.event.issue.pull_request }}
+    if: github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@pyansys-ci-bot LGTM') && (
+          github.event.comment.user.login == 'germa89'
+        )
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@v3
-        if: |
-          contains(github.event.comment.body, 'LGTM') && contains(env.ALLOWED_AUTHORS, github.event.comment.user.login)
         with:
           review-message: ":white_check_mark: Approving this PR because [${{ github.event.comment.user.login }}](https://github.com/${{ github.event.comment.user.login }}) said so in [here](${{ github.event.comment.html_url }}) :grimacing:"
           pull-request-number: ${{ github.event.issue.number }}


### PR DESCRIPTION
* Improving autoapprover so it does not run unless some user/comment is fulfilled. Moving the 'if' logic to the job level, instead of the step level.