### PR TITLE
Fixing MPI message

### DIFF
--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -703,7 +703,8 @@ def _get_std_output(std_queue, timeout=1):
     t0 = time.time()
     while (not reach_empty) or (time.time() < (t0 + timeout)):
         try:
-            lines.append(std_queue.get_nowait().decode())
+            message = std_queue.get_nowait().decode(encoding="utf-8", errors="replace")
+            lines.append(message)
         except Empty:
             reach_empty = True
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1776,13 +1776,14 @@ def test_deprecation_allow_ignore_errors_mapping(mapdl):
 
 def test_check_stds(mapdl):
     mapdl._stdout = "everything is going ok"
+    mapdl._stderr = ""
+
     mapdl._check_stds()
 
     mapdl._stdout = "one error"
     with pytest.raises(MapdlConnectionError, match="one error"):
         mapdl._check_stds()
 
-    mapdl._stderr = ""
     mapdl._stdout = None  # resetting
     mapdl._check_stds()
 


### PR DESCRIPTION
One test (``test_check_stds``) was raising the following exception:

```text
E           ansys.mapdl.core.errors.MapdlConnectionError: [libprotobuf ERROR /home/staff/kkripa/tfsagent/_work/20/b/.conan/data/protobuf/3.10.1.3/thirdparty/stable/build/2a45a8e4e8f3a96579715eed8e14250652eeb4d4/protobuf/src/google/protobuf/wire_format_lite.cc:578] String field 'ansys.api.mapdl.v0.CmdResponse.response' contains invalid UTF-8 data when serializing a protocol buffer. Use the 'bytes' type if you intend to send raw bytes. 
E           Attempting to use an MPI routine after finalizing MPICH
```
However I'm quite sure it wasn't because of this test. Very likely it was in a previous tests, and it was just caught here.
This error only affected the ubuntu MAPDL v23.2 image.

I might check later (on day) what was the issue (recorded in #2664)

