### PR TITLE
Deriving all custom error from Exception and related

### DIFF
--- a/src/ansys/mapdl/core/common_grpc.py
+++ b/src/ansys/mapdl/core/common_grpc.py
@@ -25,7 +25,7 @@ from typing import List, Literal, get_args
 
 import numpy as np
 
-from ansys.mapdl.core.errors import MapdlConnectionError
+from ansys.mapdl.core.errors import MapdlConnectionError, MapdlRuntimeError
 
 # chunk sizes for streaming and file streaming
 DEFAULT_CHUNKSIZE = 256 * 1024  # 256 kB
@@ -85,11 +85,11 @@ VGET_NODE_ENTITY_TYPES = {
 }
 
 
-class GrpcError(RuntimeError):
+class GrpcError(MapdlRuntimeError):
     """Raised when gRPC fails"""
 
     def __init__(self, msg=""):
-        RuntimeError.__init__(self, msg)
+        MapdlRuntimeError.__init__(self, msg)
 
 
 def check_vget_input(entity: str, item: str, itnum: str) -> str:

--- a/src/ansys/mapdl/core/common_grpc.py
+++ b/src/ansys/mapdl/core/common_grpc.py
@@ -89,7 +89,7 @@ class GrpcError(MapdlRuntimeError):
     """Raised when gRPC fails"""
 
     def __init__(self, msg=""):
-        MapdlRuntimeError.__init__(self, msg)
+        super().__init__(self, msg)
 
 
 def check_vget_input(entity: str, item: str, itnum: str) -> str:

--- a/src/ansys/mapdl/core/errors.py
+++ b/src/ansys/mapdl/core/errors.py
@@ -262,7 +262,7 @@ class ComponentDoesNotExits(MapdlException):
         MapdlException.__init__(self, msg)
 
 
-class CommandDeprecated(MapdlException, DeprecationError):
+class CommandDeprecated(DeprecationError):
     """Raised when a command is deprecated"""
 
     def __init__(self, msg=""):

--- a/src/ansys/mapdl/core/errors.py
+++ b/src/ansys/mapdl/core/errors.py
@@ -49,52 +49,76 @@ TYPE_MSG = (
 )
 
 
-class ANSYSDataTypeError(ValueError):
-    """Raised when and invalid data type is sent to APDLMath"""
+## Abraham class
+class MapdlException(Exception):
+    def __init__(self, msg=""):
+        Exception.__init__(self, msg)
 
-    def __init__(self, msg=TYPE_MSG):
+
+## Main subclasses
+class MapdlValueError(MapdlException, ValueError):
+    def __init__(self, msg=""):
         ValueError.__init__(self, msg)
 
 
-class VersionError(ValueError):
-    """Raised when MAPDL is the wrong version"""
-
-    def __init__(self, msg="Invalid MAPDL version"):
-        ValueError.__init__(self, msg)
-
-
-class NoDistributedFiles(FileNotFoundError):
-    """Unable to find any distributed result files"""
-
-    def __init__(self, msg="Unable to find any distributed result files"):
+class MapdlFileNotFoundError(MapdlException, FileNotFoundError):
+    def __init__(self, msg=""):
         FileNotFoundError.__init__(self, msg)
 
 
-class MapdlRuntimeError(RuntimeError):
+class MapdlRuntimeError(MapdlException, RuntimeError):
     """Raised when MAPDL passes an error"""
 
-    pass
+    def __init__(self, msg=""):
+        RuntimeError.__init__(self, msg)
 
 
-class MapdlInvalidRoutineError(RuntimeError):
+class MapdlDeprecationError(MapdlException, DeprecationError):
+    def __init__(self, msg=""):
+        DeprecationError.__init__(self, msg)
+
+
+## Inheritated
+class ANSYSDataTypeError(MapdlValueError):
+    """Raised when and invalid data type is sent to APDLMath"""
+
+    def __init__(self, msg=TYPE_MSG):
+        MapdlValueError.__init__(self, msg)
+
+
+class VersionError(MapdlValueError):
+    """Raised when MAPDL is the wrong version"""
+
+    def __init__(self, msg="Invalid MAPDL version"):
+        MapdlValueError.__init__(self, msg)
+
+
+class NoDistributedFiles(MapdlFileNotFoundError):
+    """Unable to find any distributed result files"""
+
+    def __init__(self, msg="Unable to find any distributed result files"):
+        MapdlFileNotFoundError.__init__(self, msg)
+
+
+class MapdlInvalidRoutineError(MapdlRuntimeError):
     """Raised when MAPDL is in the wrong routine"""
 
     def __init__(self, msg=""):
-        RuntimeError.__init__(self, msg)
+        MapdlRuntimeError.__init__(self, msg)
 
 
-class MapdlCommandIgnoredError(RuntimeError):
+class MapdlCommandIgnoredError(MapdlRuntimeError):
     """Raised when MAPDL ignores a command."""
 
     def __init__(self, msg=""):
-        RuntimeError.__init__(self, msg)
+        MapdlRuntimeError.__init__(self, msg)
 
 
-class MapdlExitedError(RuntimeError):
+class MapdlExitedError(MapdlRuntimeError):
     """Raised when MAPDL has exited"""
 
     def __init__(self, msg="MAPDL has exited"):
-        RuntimeError.__init__(self, msg)
+        MapdlRuntimeError.__init__(self, msg)
 
 
 class NotEnoughResources(MapdlExitedError):
@@ -108,18 +132,18 @@ class NotEnoughResources(MapdlExitedError):
         MapdlExitedError.__init__(self, msg.format(resource=resource))
 
 
-class LockFileException(RuntimeError):
+class LockFileException(MapdlRuntimeError):
     """Error message when the lockfile has not been removed"""
 
     def __init__(self, msg=LOCKFILE_MSG):
-        RuntimeError.__init__(self, msg)
+        MapdlRuntimeError.__init__(self, msg)
 
 
-class MapdlDidNotStart(RuntimeError):
+class MapdlDidNotStart(MapdlRuntimeError):
     """Error when the MAPDL process does not start"""
 
     def __init__(self, msg=""):
-        RuntimeError.__init__(self, msg)
+        MapdlRuntimeError.__init__(self, msg)
 
 
 class PortAlreadyInUse(MapdlDidNotStart):
@@ -138,11 +162,11 @@ class PortAlreadyInUseByAnMAPDLInstance(PortAlreadyInUse):
         PortAlreadyInUse.__init__(self, msg.format(port=port))
 
 
-class MapdlConnectionError(RuntimeError):
+class MapdlConnectionError(MapdlRuntimeError):
     """Provides the error when connecting to the MAPDL instance fails."""
 
     def __init__(self, msg=""):
-        RuntimeError.__init__(self, msg)
+        MapdlRuntimeError.__init__(self, msg)
 
 
 class LicenseServerConnectionError(MapdlDidNotStart):
@@ -161,87 +185,15 @@ class IncorrectWorkingDirectory(OSError, MapdlRuntimeError):
         MapdlRuntimeError.__init__(self, msg)
 
 
-class DifferentSessionConnectionError(RuntimeError):
+class DifferentSessionConnectionError(MapdlRuntimeError):
     """Provides the error when connecting to the MAPDL instance fails."""
 
     def __init__(self, msg=""):
-        RuntimeError.__init__(self, msg)
+        MapdlRuntimeError.__init__(self, msg)
 
 
-class DeprecationError(RuntimeError):
+class DeprecationError(MapdlRuntimeError):
     """Provides the error for deprecated commands, classes, interfaces, etc"""
-
-    def __init__(self, msg=""):
-        RuntimeError.__init__(self, msg)
-
-
-# handler for protect_grpc
-def handler(sig, frame):  # pragma: no cover
-    """Pass signal to custom interrupt handler."""
-    logger.info(
-        "KeyboardInterrupt received.  Waiting until MAPDL " "execution finishes"
-    )
-    SIGINT_TRACKER.append(True)
-
-
-def protect_grpc(func):
-    """Capture gRPC exceptions and return a more succinct error message
-
-    Capture KeyboardInterrupt to avoid segfaulting MAPDL.
-
-    This works some of the time, but not all the time.  For some
-    reason gRPC still captures SIGINT.
-
-    """
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        """Capture gRPC exceptions and KeyboardInterrupt"""
-
-        # capture KeyboardInterrupt
-        old_handler = None
-        if threading.current_thread().__class__.__name__ == "_MainThread":
-            if threading.current_thread().is_alive():
-                old_handler = signal.signal(signal.SIGINT, handler)
-
-        # Capture gRPC exceptions
-        try:
-            out = func(*args, **kwargs)
-        except (_InactiveRpcError, _MultiThreadedRendezvous) as error:
-            # can't use isinstance here due to circular imports
-            try:
-                class_name = args[0].__class__.__name__
-            except:
-                class_name = ""
-
-            if class_name == "MapdlGrpc":
-                mapdl = args[0]
-            elif hasattr(args[0], "_mapdl"):
-                mapdl = args[0]._mapdl
-
-            # Must close unfinished processes
-            mapdl._close_process()
-            raise MapdlExitedError("MAPDL server connection terminated") from None
-
-        if threading.current_thread().__class__.__name__ == "_MainThread":
-            received_interrupt = bool(SIGINT_TRACKER)
-
-            # always clear and revert to old handler
-            SIGINT_TRACKER.clear()
-            if old_handler:
-                signal.signal(signal.SIGINT, old_handler)
-
-            if received_interrupt:  # pragma: no cover
-                raise KeyboardInterrupt("Interrupted during MAPDL execution")
-
-        return out
-
-    return wrapper
-
-
-class MapdlException(MapdlRuntimeError):
-
-    """General MAPDL exception."""
 
     def __init__(self, msg=""):
         MapdlRuntimeError.__init__(self, msg)
@@ -320,3 +272,67 @@ class CommandDeprecated(MapdlException, DeprecationError):
 
     def __init__(self, msg=""):
         MapdlException.__init__(self, msg)
+
+
+# handler for protect_grpc
+def handler(sig, frame):  # pragma: no cover
+    """Pass signal to custom interrupt handler."""
+    logger.info(
+        "KeyboardInterrupt received.  Waiting until MAPDL " "execution finishes"
+    )
+    SIGINT_TRACKER.append(True)
+
+
+def protect_grpc(func):
+    """Capture gRPC exceptions and return a more succinct error message
+
+    Capture KeyboardInterrupt to avoid segfaulting MAPDL.
+
+    This works some of the time, but not all the time.  For some
+    reason gRPC still captures SIGINT.
+
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        """Capture gRPC exceptions and KeyboardInterrupt"""
+
+        # capture KeyboardInterrupt
+        old_handler = None
+        if threading.current_thread().__class__.__name__ == "_MainThread":
+            if threading.current_thread().is_alive():
+                old_handler = signal.signal(signal.SIGINT, handler)
+
+        # Capture gRPC exceptions
+        try:
+            out = func(*args, **kwargs)
+        except (_InactiveRpcError, _MultiThreadedRendezvous) as error:
+            # can't use isinstance here due to circular imports
+            try:
+                class_name = args[0].__class__.__name__
+            except:
+                class_name = ""
+
+            if class_name == "MapdlGrpc":
+                mapdl = args[0]
+            elif hasattr(args[0], "_mapdl"):
+                mapdl = args[0]._mapdl
+
+            # Must close unfinished processes
+            mapdl._close_process()
+            raise MapdlExitedError("MAPDL server connection terminated") from None
+
+        if threading.current_thread().__class__.__name__ == "_MainThread":
+            received_interrupt = bool(SIGINT_TRACKER)
+
+            # always clear and revert to old handler
+            SIGINT_TRACKER.clear()
+            if old_handler:
+                signal.signal(signal.SIGINT, old_handler)
+
+            if received_interrupt:  # pragma: no cover
+                raise KeyboardInterrupt("Interrupted during MAPDL execution")
+
+        return out
+
+    return wrapper

--- a/src/ansys/mapdl/core/errors.py
+++ b/src/ansys/mapdl/core/errors.py
@@ -73,11 +73,6 @@ class MapdlRuntimeError(MapdlException, RuntimeError):
         RuntimeError.__init__(self, msg)
 
 
-class MapdlDeprecationError(MapdlException, DeprecationError):
-    def __init__(self, msg=""):
-        DeprecationError.__init__(self, msg)
-
-
 ## Inheritated
 class ANSYSDataTypeError(MapdlValueError):
     """Raised when and invalid data type is sent to APDLMath"""

--- a/src/ansys/mapdl/core/errors.py
+++ b/src/ansys/mapdl/core/errors.py
@@ -51,17 +51,23 @@ TYPE_MSG = (
 
 ## Abraham class
 class MapdlException(Exception):
+    """MAPDL general exception"""
+
     def __init__(self, msg=""):
         super().__init__(msg)
 
 
 ## Main subclasses
 class MapdlValueError(MapdlException, ValueError):
+    """MAPDL Value error"""
+
     def __init__(self, msg=""):
         super().__init__(msg)
 
 
 class MapdlFileNotFoundError(MapdlException, FileNotFoundError):
+    """Error when file is not found"""
+
     def __init__(self, msg=""):
         super().__init__(msg)
 
@@ -233,7 +239,7 @@ class MapdlVersionError(MapdlException):
         super().__init__(msg)
 
 
-class EmptyRecordError(RuntimeError):
+class EmptyRecordError(MapdlRuntimeError):
     """Raised when a record is empty"""
 
     def __init__(self, msg=""):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -24,15 +24,9 @@ import pytest
 
 from ansys.mapdl.core.errors import (
     MapdlCommandIgnoredError,
-    MapdlDidNotStart,
-    MapdlError,
     MapdlException,
-    MapdlInfo,
     MapdlInvalidRoutineError,
-    MapdlNote,
     MapdlRuntimeError,
-    MapdlVersionError,
-    MapdlWarning,
 )
 
 error_shape_error_limits = """
@@ -114,24 +108,27 @@ def test_raise_output_errors(mapdl, response, expected_error):
         mapdl._raise_output_errors(response)
 
 
-@pytest.mark.parametrize(
-    "error_class",
-    [
-        MapdlDidNotStart,
-        MapdlException,
-        MapdlError,
-        MapdlWarning,
-        MapdlNote,
-        MapdlInfo,
-        MapdlVersionError,
-        MapdlInvalidRoutineError,
-        MapdlCommandIgnoredError,
-        MapdlRuntimeError,
-    ],
-)
+def get_error_classes():
+    from ansys.mapdl.core import errors
+
+    def is_exception_class(obj):
+        try:
+            return issubclass(obj, MapdlException)
+        except TypeError:
+            return False
+
+    errors_to_tests = []
+    for each in dir(errors):
+        obj = getattr(errors, each)
+        if not each.startswith("_") and is_exception_class(obj):
+            errors_to_tests.append(obj)
+    return errors_to_tests
+
+
+@pytest.mark.parametrize("error_class", get_error_classes())
 def test_exception_classes(error_class):
     message = "Exception message"
-    with pytest.raises(error_class):
+    with pytest.raises(error_class, match=message):
         raise error_class(message)
 
 


### PR DESCRIPTION
I'm not very convinced on this one...

The idea is to have all the MAPDL error classes deriving from one (``MapdlException``), so we can do something like:

```py
try:
    mapdl = launch_mapdl()
except MapdlException:
    # Exception raised by PyMAPDL handleing this different
    handle_pymapdl_exception()
except Exception:
    # handles everything else
```

With the current implementation, you can do this too:
```py
try:
    raise MapdlValueError
except MapdlValueError:
    # this is activated (ofc)
    handle_value_error()
except MapdlException:
    # this could be also activated
    handle_value_error()
except MapdlException:
    # this could be also activated
    handle_value_error()
except Exception:
    # this could be also activated
    handle_value_error()
```

I think it could add value, but it does generate maybe complicated inheritance relationships:

```mermaid
graph TD;
    Exception-->ValueError;
    Exception-->MapdlException;
    ValueError-->MapdlValueError;
    MapdlException--> MapdlValueError;
```

Because ``MapdlValueError`` inheritates from ``ValueError``(which inheritates from ``Exception``) and from ``MapdlException`` (which inheritates from ``Exception``).
This creates a "diamond" which is not recommended [diamond problem](https://en.wikipedia.org/wiki/Multiple_inheritance#The_diamond_problem)

Surely this classes are simple, and we are only overwritting ``__init__`` method... if anything, we can always go back?

Related (but not much) #2653

Pinging @ansys/pyansys-core for technical feedback. Also pinging @koubaa @greschd 