### PR TITLE
Changing token in approval reaction

### DIFF
--- a/.github/workflows/approver.yml
+++ b/.github/workflows/approver.yml
@@ -60,7 +60,7 @@ jobs:
       #https://github.com/ansys/pymapdl/pull/2654#issuecomment-1889009514
         uses: dkershner6/reaction-action@v2 # You can also use a specific version, e.g. v2.0.0
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
           commentId: ${{ steps.settings.outputs.commentid }} # Optional if the trigger is a comment. Use another action to find this otherwise.
           reaction: "+1" # Optional
 


### PR DESCRIPTION
Because it was using the default token, it was the github actions bot who was reacting.