### PR TITLE
Disabling session ID check by default

### DIFF
--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -2106,19 +2106,6 @@ class _MapdlCore(Commands):
         >>> mapdl.prep7()
 
         """
-        if self._session_id is not None:
-            self._check_session_id()
-        else:
-            # For some reason the session hasn't been created
-            if self.is_grpc:
-                self._create_session()
-
-        if mute is None:
-            if hasattr(self, "mute"):
-                mute = self.mute
-            else:  # if not gRPC
-                mute = False
-
         # check if multiline
         if "\n" in command or "\r" in command:
             raise ValueError("Use ``input_strings`` for multi-line commands")
@@ -2146,10 +2133,25 @@ class _MapdlCore(Commands):
                 UserWarning,
             )
 
+        # Early exit if on non-interactive.
         if self._store_commands and not avoid_non_interactive:
             # If you are using NBLOCK on input, you should not strip the string
             self._stored_commands.append(command)
             return
+
+        # Actually sending the message
+        if self._session_id is not None:
+            self._check_session_id()
+        else:
+            # For some reason the session hasn't been created
+            if self.is_grpc:
+                self._create_session()
+
+        if mute is None:
+            if hasattr(self, "mute"):
+                mute = self.mute
+            else:  # if not gRPC
+                mute = False
 
         command = command.strip()
 

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -3293,7 +3293,7 @@ class MapdlGrpc(MapdlBase):
 
     def _check_session_id(self):
         """Verify that the local session ID matches the remote MAPDL session ID."""
-        if self._checking_session_id_:
+        if self._checking_session_id_ or not self._strict_session_id_check:
             # To avoid recursion error
             return
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1907,6 +1907,7 @@ def test_force_output(mapdl):
 
 
 def test_session_id(mapdl, running_test):
+    mapdl._strict_session_id_check = True
     assert mapdl._session_id is not None
 
     # already checking version
@@ -1933,6 +1934,7 @@ def test_session_id(mapdl, running_test):
     assert not mapdl._check_session_id()
 
     mapdl._session_id_ = id_
+    mapdl._strict_session_id_check = False
 
 
 def test_check_empty_session_id(mapdl):


### PR DESCRIPTION
This check penalise the performant quite a lot since several gRPC calls are made.

I'm disabling it for the moment.

Ideally we will have to implement something on the server side.

Close #2608