### PR TITLE
Skipping `test_xpl.py::test_save` on v24.2

### DIFF
--- a/tests/test_xpl.py
+++ b/tests/test_xpl.py
@@ -80,6 +80,9 @@ def test_read_asarray(xpl):
 
 
 def test_save(xpl):
+    if xpl._mapdl.version == 24.2:
+        pytest.xfail("There is a bug on v242 which makes saving using XPL to fail.")
+
     xpl.save()
     with pytest.raises(MapdlCommandIgnoredError):
         xpl.list()

--- a/tests/test_xpl.py
+++ b/tests/test_xpl.py
@@ -81,7 +81,9 @@ def test_read_asarray(xpl):
 
 def test_save(xpl):
     if xpl._mapdl.version == 24.2:
-        pytest.xfail("There is a bug on v242 which makes saving using XPL to fail.")
+        pytest.xfail(
+            "There is a bug (977113) on v242 which makes saving using XPL to fail."
+        )
 
     xpl.save()
     with pytest.raises(MapdlCommandIgnoredError):


### PR DESCRIPTION
As the title.

Close #2904