### PR TITLE
Using while in cache cleaner branch side

### DIFF
--- a/.github/workflows/cache_cleaner.yml
+++ b/.github/workflows/cache_cleaner.yml
@@ -26,9 +26,15 @@ jobs:
           ## Setting this to not fail the workflow while deleting cache keys. 
           set +e
           echo "Deleting caches..."
-          for cacheKey in $cacheKeysForPR
+          
+          while [ ! -z "$cacheKeysForPR" ];
           do
-              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm && echo "Deleting cache with key: $cacheKey"
+            for cacheKey in $cacheKeysForPR
+            do
+                gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm && echo "Deleting cache with key: $cacheKey"
+            done
+          
+            cacheKeysForPR=$(gh actions-cache list -R $REPO | cut -f 1 )
           done
           echo "Done"
         env:
@@ -48,9 +54,14 @@ jobs:
             ## Setting this to not fail the workflow while deleting cache keys. 
             set +e
             echo "Deleting caches..."
-            for cacheKey in $cacheKeysForPR
+            while [ ! -z "$cacheKeysForPR" ];
             do
-                gh actions-cache delete $cacheKey -R $REPO --confirm && echo "Deleting cache with key: $cacheKey"
+              for cacheKey in $cacheKeysForPR
+              do
+                  gh actions-cache delete $cacheKey -R $REPO --confirm && echo "Deleting cache with key: $cacheKey"
+              done
+
+              cacheKeysForPR=$(gh actions-cache list -R $REPO | cut -f 1 )
             done
             echo "Done"
         env:


### PR DESCRIPTION
For some reason, when getting the cache keys, there is a limit. 

I had to rerun this workflow 2-3 times for all the keys to be deleted.
Using a while loop should fix it.