### PR TITLE
Ignoring `PYMAPDL_START_INSTANCE` env var on CLI `pymapdl start`

### DIFF
--- a/src/ansys/mapdl/core/cli.py
+++ b/src/ansys/mapdl/core/cli.py
@@ -470,6 +470,10 @@ For more information see :func:`ansys.mapdl.core.launcher.launch_mapdl`.""",
                 + " The following argument is not allowed in CLI: 'license_server_check'.\nIgnoring argument."
             )
 
+        # Ignoring env var if using CLI
+        if "PYMAPDL_START_INSTANCE" in os.environ:
+            os.environ.pop("PYMAPDL_START_INSTANCE")
+
         out = launch_mapdl(
             exec_file=exec_file,
             just_launch=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,7 +54,7 @@ def run_cli():
 @requires("click")
 @requires("local")
 @requires("nostudent")
-@pytest.mark.parametrize("start_instance", [None, True, False] )
+@pytest.mark.parametrize("start_instance", [None, True, False])
 def test_launch_mapdl_cli(monkeypatch, run_cli, start_instance):
     if start_instance is not None:
         monkeypatch.setenv("PYMAPDL_START_INSTANCE", str(start_instance))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,7 +54,13 @@ def run_cli():
 @requires("click")
 @requires("local")
 @requires("nostudent")
-def test_launch_mapdl_cli(run_cli):
+@pytest.mark.parametrize("start_instance", [None, True, False] )
+def test_launch_mapdl_cli(monkeypatch, run_cli, start_instance):
+    if start_instance is not None:
+        monkeypatch.setenv("PYMAPDL_START_INSTANCE", str(start_instance))
+    else:
+        monkeypatch.unset("PYMAPDL_START_INSTANCE")
+
     output = run_cli()
 
     # In local


### PR DESCRIPTION
As the title.

Close #2914 