### PR TITLE
Adding a more comprehensive printing in pytest

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -104,7 +104,7 @@ def has_grpc():
 
 
 def has_dpf():
-    return os.environ.get("DPF_PORT", "")
+    return bool(os.environ.get("DPF_PORT", ""))
 
 
 def is_smp():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@
 from collections import namedtuple
 import os
 from pathlib import Path
+from shutil import get_terminal_size
 from sys import platform
 
 from _pytest.terminal import TerminalReporter  # for terminal customization
@@ -236,6 +237,38 @@ MAPDL_VERSION = None  # this is cached by mapdl fixture and used in the minimal 
 
 if START_INSTANCE and not ON_LOCAL:
     raise MapdlRuntimeError(ERRMSG)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_report_header(config, start_path, startdir):
+    text = []
+    text += ["Testing variables".center(get_terminal_size()[0], "-")]
+    text += [
+        f"Session dependent: ON_CI ({ON_CI}), TESTING_MINIMAL ({TESTING_MINIMAL}), SUPPORT_PLOTTING ({SUPPORT_PLOTTING})"
+    ]
+    text += [
+        f"OS dependent: ON_LINUX ({ON_LINUX}), ON_UBUNTU ({ON_UBUNTU}), ON_WINDOWS ({ON_WINDOWS}), ON_MACOS )({ON_MACOS})"
+    ]
+    text += [
+        f"MAPDL dependent: ON_LOCAL ({ON_LOCAL}), ON_STUDENT ({ON_STUDENT}), HAS_GRPC ({HAS_GRPC}), HAS_DPF ({HAS_DPF}), IS_SMP ({IS_SMP})"
+    ]
+
+    text += ["Environment variables".center(get_terminal_size()[0], "-")]
+    line = ""
+    for env_var in [
+        "PYMAPDL_START_INSTANCE",
+        "PYMAPDL_PORT",
+        "PYMAPDL_DB_PORT",
+        "PYMAPDL_IP",
+        "DPF_PORT",
+        "DPF_START_SERVER",
+    ]:
+        env_var_value = os.environ.get(env_var, None)
+        if env_var_value is not None:
+            line += f"{env_var} ('{env_var_value}'), "
+    text += [line]
+    text += ["Pytest configuration".center(get_terminal_size()[0], "-")]
+    return "\n".join(text)
 
 
 ## Changing report line length


### PR DESCRIPTION
As the title.

It am added some printing related to env vars:
```output
------------------------------------------------------------Testing variables-------------------------------------------------------------
Session dependent: ON_CI (False), TESTING_MINIMAL (False), SUPPORT_PLOTTING (True)
OS dependent: ON_LINUX (False), ON_UBUNTU (False), ON_WINDOWS (False), ON_MACOS )(True)
MAPDL dependent: ON_LOCAL (False), ON_STUDENT (False), HAS_GRPC (True), HAS_DPF (True), IS_SMP (True)
----------------------------------------------------------Environment variables-----------------------------------------------------------
PYMAPDL_START_INSTANCE ('False'), PYMAPDL_PORT ('50092'), PYMAPDL_DB_PORT ('50095'), DPF_PORT ('50056'), DPF_START_SERVER ('false'), 
-----------------------------------------------------------Pytest configuration-----------------------------------------------------------
```

This is how it looks like:
```console
$ pytest
========================================================== test session starts ===========================================================
platform darwin -- Python 3.10.13, pytest-8.0.0, pluggy-1.3.0
------------------------------------------------------------Testing variables-------------------------------------------------------------
Session dependent: ON_CI (False), TESTING_MINIMAL (False), SUPPORT_PLOTTING (True)
OS dependent: ON_LINUX (False), ON_UBUNTU (False), ON_WINDOWS (False), ON_MACOS )(True)
MAPDL dependent: ON_LOCAL (False), ON_STUDENT (False), HAS_GRPC (True), HAS_DPF (True), IS_SMP (True)
----------------------------------------------------------Environment variables-----------------------------------------------------------
PYMAPDL_START_INSTANCE ('False'), PYMAPDL_PORT ('50092'), PYMAPDL_DB_PORT ('50095'), DPF_PORT ('50056'), DPF_START_SERVER ('false'), 
-----------------------------------------------------------Pytest configuration-----------------------------------------------------------
rootdir: /Users/german.ayuso/pymapdl
configfile: pyproject.toml
testpaths: tests
plugins: sphinx-0.6.0, timeout-2.2.0, cov-4.1.0, rerunfailures-13.0, anyio-4.1.0, pytest_pyvista-0.1.9
collected 1695 items          
```
