### PR TITLE
Fix doc builds in Windows

### DIFF
--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1578,6 +1578,7 @@ def launch_mapdl(
             # launch an instance of pymapdl if it does not already exist and
             # we're allowed to start instances
             if GALLERY_INSTANCE[0] is None:
+                GALLERY_INSTANCE[0] = "Loading..."
                 mapdl = launch_mapdl(
                     start_instance=True,
                     cleanup_on_exit=False,
@@ -1588,8 +1589,8 @@ def launch_mapdl(
                 GALLERY_INSTANCE[0] = {"ip": mapdl._ip, "port": mapdl._port}
                 return mapdl
 
-                # otherwise, connect to the existing gallery instance if available
-            elif GALLERY_INSTANCE[0] is not None:
+            # otherwise, connect to the existing gallery instance if available, but it needs to be fully loaded.
+            elif GALLERY_INSTANCE[0] != "Loading...":
                 mapdl = MapdlGrpc(
                     ip=GALLERY_INSTANCE[0]["ip"],
                     port=GALLERY_INSTANCE[0]["port"],

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1578,6 +1578,7 @@ def launch_mapdl(
             # launch an instance of pymapdl if it does not already exist and
             # we're allowed to start instances
             if GALLERY_INSTANCE[0] is None:
+                LOG.debug("Loading first MAPDL instance for gallery building.")
                 GALLERY_INSTANCE[0] = "Loading..."
                 mapdl = launch_mapdl(
                     start_instance=True,
@@ -1591,6 +1592,9 @@ def launch_mapdl(
 
             # otherwise, connect to the existing gallery instance if available, but it needs to be fully loaded.
             elif GALLERY_INSTANCE[0] != "Loading...":
+                LOG.debug(
+                    "Connecting to an existing MAPDL instance for gallery building."
+                )
                 mapdl = MapdlGrpc(
                     ip=GALLERY_INSTANCE[0]["ip"],
                     port=GALLERY_INSTANCE[0]["port"],
@@ -1603,6 +1607,9 @@ def launch_mapdl(
                 if clear_on_connect:
                     mapdl.clear()
                 return mapdl
+
+            else:
+                LOG.debug("Bypassing Gallery building flag for the first time.")
 
     else:
         LOG.debug("Connecting to an existing instance of MAPDL at %s:%s", ip, port)

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1611,9 +1611,6 @@ def launch_mapdl(
             print(f"There is an existing MAPDL instance at: {ip}:{port}")
             return
 
-        if pymapdl.BUILDING_GALLERY:  # pragma: no cover
-            LOG.debug("Building gallery.")
-
         if _debug_no_launch:
             return pack_parameters(
                 port,


### PR DESCRIPTION
As the title.

The issue was an infinite loop while launching MAPDL.

Once I added:
```py
from ansys.mapdl.core import LOG

LOG.setLevel("DEBUG")
LOG.log_to_file("mylog.log")
```
to the first example, I was able to get:

```text
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using default port 50052
DEBUG - pymapdl_global -  launcher - launch_mapdl - Building gallery.
DEBUG - pymapdl_global -  launcher - get_start_instance - PYMAPDL_START_INSTANCE is unset. Using default value True.  
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using 'start_instance' equal to True.
DEBUG - pymapdl_global -  launcher - launch_mapdl - No IP address was supplied. Using the default IP address: 127.0.0.1
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using default port 50052
DEBUG - pymapdl_global -  launcher - launch_mapdl - Building gallery.
DEBUG - pymapdl_global -  launcher - get_start_instance - PYMAPDL_START_INSTANCE is unset. Using default value True.  
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using 'start_instance' equal to True.
DEBUG - pymapdl_global -  launcher - launch_mapdl - No IP address was supplied. Using the default IP address: 127.0.0.1
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using default port 50052
DEBUG - pymapdl_global -  launcher - launch_mapdl - Building gallery.
DEBUG - pymapdl_global -  launcher - get_start_instance - PYMAPDL_START_INSTANCE is unset. Using default value True.  
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using 'start_instance' equal to True.
DEBUG - pymapdl_global -  launcher - launch_mapdl - No IP address was supplied. Using the default IP address: 127.0.0.1
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using default port 50052
DEBUG - pymapdl_global -  launcher - launch_mapdl - Building gallery.
DEBUG - pymapdl_global -  launcher - get_start_instance - PYMAPDL_START_INSTANCE is unset. Using default value True.  
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using 'start_instance' equal to True.
DEBUG - pymapdl_global -  launcher - launch_mapdl - No IP address was supplied. Using the default IP address: 127.0.0.1
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using default port 50052
DEBUG - pymapdl_global -  launcher - launch_mapdl - Building gallery.
DEBUG - pymapdl_global -  launcher - get_start_instance - PYMAPDL_START_INSTANCE is unset. Using default value True.  
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using 'start_instance' equal to True.
DEBUG - pymapdl_global -  launcher - launch_mapdl - No IP address was supplied. Using the default IP address: 127.0.0.1
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using default port 50052
DEBUG - pymapdl_global -  launcher - launch_mapdl - Building gallery.
DEBUG - pymapdl_global -  launcher - get_start_instance - PYMAPDL_START_INSTANCE is unset. Using default value True.  
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using 'start_instance' equal to True.
DEBUG - pymapdl_global -  launcher - launch_mapdl - No IP address was supplied. Using the default IP address: 127.0.0.1
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using default port 50052
DEBUG - pymapdl_global -  launcher - launch_mapdl - Building gallery.
DEBUG - pymapdl_global -  launcher - get_start_instance - PYMAPDL_START_INSTANCE is unset. Using default value True.  
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using 'start_instance' equal to True.
DEBUG - pymapdl_global -  launcher - launch_mapdl - No IP address was supplied. Using the default IP address: 127.0.0.1
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using default port 50052
DEBUG - pymapdl_global -  launcher - launch_mapdl - Building gallery.
DEBUG - pymapdl_global -  launcher - get_start_instance - PYMAPDL_START_INSTANCE is unset. Using default value True.  
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using 'start_instance' equal to True.
DEBUG - pymapdl_global -  launcher - launch_mapdl - No IP address was supplied. Using the default IP address: 127.0.0.1
DEBUG - pymapdl_global -  launcher - launch_mapdl - Using default port 50052
DEBUG - pymapdl_global -  launcher - launch_mapdl - Building gallery.
```

I had to introduce an stop flag ``"loading..."``, so it is forced to 

Close #2921