### PR TITLE
Improving precision in array retrieval

### DIFF
--- a/src/ansys/mapdl/core/parameters.py
+++ b/src/ansys/mapdl/core/parameters.py
@@ -532,7 +532,7 @@ class Parameters:
         """
         escaped = False
         for each_format_number in [20, 30, 40, 64, 100]:
-            format_str = f"(1F{each_format_number}.12)"
+            format_str = f"(1E{each_format_number}.12)"
             with self._mapdl.non_interactive:
                 # use C ordering
                 self._mapdl.mwrite(parm_name.upper(), label="kji")


### PR DESCRIPTION
As the title.

Simple change but it seems effective.

Instead of printing the array using floating numbers (``F``) we use exponential (``E``).

#### Before
```console
((.venv_py312) ) ➜  pymapdl git:(feat/more-precision-retrieving-arrays) ✗ python tmp/main.py
[ 0.000e+00  0.000e+00 -4.580e-10 -8.780e-10 -2.180e-10 -2.680e-10
 -3.790e-10 -5.410e-10 -4.700e-10 -8.150e-10  4.580e-10 -8.780e-10
  0.000e+00 -1.473e-09  0.000e+00  0.000e+00  4.700e-10 -8.150e-10
  3.790e-10 -5.410e-10  2.180e-10 -2.680e-10  0.000e+00  0.000e+00
  0.000e+00 -1.910e-10  0.000e+00 -4.900e-10  0.000e+00 -8.640e-10]
-4.58e-10
```
#### After change
```console
((.venv_py312) ) ➜  pymapdl git:(feat/more-precision-retrieving-arrays) ✗ python tmp/main.py
[ 0.00000000e+00  0.00000000e+00 -4.58300835e-10 -8.78066913e-10
 -2.18264131e-10 -2.68102076e-10 -3.78991840e-10 -5.41040242e-10
 -4.70445287e-10 -8.15032225e-10  4.58300835e-10 -8.78066913e-10
  8.95900195e-26 -1.47316722e-09  0.00000000e+00  0.00000000e+00
  4.70445287e-10 -8.15032225e-10  3.78991840e-10 -5.41040242e-10
  2.18264131e-10 -2.68102076e-10  0.00000000e+00  0.00000000e+00
  4.44206888e-26 -1.90657946e-10  1.43633916e-25 -4.90177355e-10
  1.15997145e-25 -8.64297293e-10]
-4.58300835113e-10
```


#### Model used for testing
Using the example given in #2939 


Close #2939