### PR TITLE
feat: add a `MAPDL version` section in for bug issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -71,7 +71,7 @@ body:
        - 'MacOS'
        - 'Linux'
     validations:
-      required: false
+      required: true
 
   - type: dropdown
     id: python-version
@@ -85,7 +85,15 @@ body:
        - '3.11'
        - '3.12'
     validations:
-      required: false
+      required: true
+
+  - type: input
+    id: mapdl-version
+    attributes:
+      label: 💾 Which MAPDL version are you using?
+      placeholder: ex. 24.1
+    validations:
+      required: true
 
   - type: textarea
     id: pymapdl-report

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -91,7 +91,7 @@ body:
     id: mapdl-version
     attributes:
       label: 💾 Which MAPDL version are you using?
-      placeholder: ex. 24.1
+      placeholder: ex. 24.1 or 2024R1
     validations:
       required: true
 


### PR DESCRIPTION
Knowing the MAPDL version used to obtain the bug can usually help.
For now, it can be accessible with the `PyMAPDL report` section but I think it would be more visible this way. Also, one can have multiple MAPDL versions installed.