### PR TITLE
Adding documentation about remote mapdl pool

### DIFF
--- a/doc/source/user_guide/pool.rst
+++ b/doc/source/user_guide/pool.rst
@@ -30,6 +30,16 @@ at the current directory within their own isolated directories:
     >>> pool = MapdlPool(10, nproc=1, run_location=my_path)
     Creating Pool: 100%|########| 10/10 [00:01<00:00,  1.43it/s]
 
+Additionally, you can group already running MAPDL instances by connecting to
+them by specifying their ports when creating the pool.
+
+.. code:: pycon
+
+    >>> from ansys.mapdl.core import MapdlPool
+    >>> pool = MapdlPool(port=[50082, 50083, 50084, 50085, 50086])
+    'MAPDL Pool with 5 active instances'
+    >>> pool.exit(block=True)
+
 You can access each individual MAPDL instance with this code:
 
 .. code:: pycon

--- a/doc/source/user_guide/pool.rst
+++ b/doc/source/user_guide/pool.rst
@@ -31,7 +31,7 @@ at the current directory within their own isolated directories:
     Creating Pool: 100%|########| 10/10 [00:01<00:00,  1.43it/s]
 
 Additionally, you can group already running MAPDL instances into an
-:class:`MapdlPool <ansys.mapdl.core.pool.MapdlPool>` by specifying
+:class:`MapdlPool <ansys.mapdl.core.pool.MapdlPool>` instance by specifying
 their ports when creating the pool.
 
 .. code:: pycon

--- a/doc/source/user_guide/pool.rst
+++ b/doc/source/user_guide/pool.rst
@@ -30,8 +30,9 @@ at the current directory within their own isolated directories:
     >>> pool = MapdlPool(10, nproc=1, run_location=my_path)
     Creating Pool: 100%|########| 10/10 [00:01<00:00,  1.43it/s]
 
-Additionally, you can group already running MAPDL instances by connecting to
-them by specifying their ports when creating the pool.
+Additionally, you can group already running MAPDL instances into an
+:class:`MapdlPool <ansys.mapdl.core.pool.MapdlPool>` by specifying
+their ports when creating the pool.
 
 .. code:: pycon
 

--- a/src/ansys/mapdl/core/pool.py
+++ b/src/ansys/mapdl/core/pool.py
@@ -161,7 +161,7 @@ class MapdlPool:
 
     def __init__(
         self,
-        n_instances: int,
+        n_instances: int = None,
         wait: bool = True,
         run_location: Optional[str] = None,
         port: Union[int, List[int]] = MAPDL_DEFAULT_PORT,
@@ -240,6 +240,7 @@ class MapdlPool:
                 ports = available_ports(n_instances, port)
             else:
                 ports = port
+                n_instances = len(ports)
 
             if self._root_dir is not None:
                 if not os.path.isdir(self._root_dir):
@@ -249,6 +250,7 @@ class MapdlPool:
                 ports = [port + i for i in range(n_instances)]
             else:
                 ports = port
+                n_instances = len(ports)
 
         if len(ports) != n_instances:
             raise ValueError(


### PR DESCRIPTION
As the title.

Now if we are providing a list of ports, the number of instances argument (``n_instances``) is optional, not needed.