### PR TITLE
Revert "Skipping `test_xpl.py::test_save` on v24.2 (#2905)"

### DIFF
--- a/tests/test_xpl.py
+++ b/tests/test_xpl.py
@@ -80,11 +80,6 @@ def test_read_asarray(xpl):
 
 
 def test_save(xpl):
-    if xpl._mapdl.version == 24.2:
-        pytest.xfail(
-            "There is a bug (977113) on v242 which makes saving using XPL to fail."
-        )
-
     xpl.save()
     with pytest.raises(MapdlCommandIgnoredError):
         xpl.list()


### PR DESCRIPTION
This reverts commit ea42836ed7c3d3141f43dc78b114da17bf7a033e.

The bug should have been fixed by now.