### PR TITLE
feat: allowing multiple IPs for remote connection on `MapdlPool`

### DIFF
--- a/doc/changelog.d/3166.miscellaneous.md
+++ b/doc/changelog.d/3166.miscellaneous.md
@@ -1,0 +1,1 @@
+feat: allowing multiple IPs for remote connection on `MapdlPool`

--- a/src/ansys/mapdl/core/pool.py
+++ b/src/ansys/mapdl/core/pool.py
@@ -273,18 +273,18 @@ class MapdlPool:
 
         if n_instances is None:
             if ip is None or (isinstance(ip, list) and len(ip) == 0):
-                if (
-                    port is None
-                    or isinstance(port, int)
-                    or (isinstance(port, list) and len(port) < 1)
-                ):
+                if port is None or (isinstance(port, list) and len(port) < 1):
                     raise ValueError(
                         "The number of instances could not be inferred "
                         "from arguments 'n_instances', 'ip' nor 'port'."
                     )
 
+                elif isinstance(port, int):
+                    n_instances = 1
+                    ports = [port]
+                    ips = [LOCALHOST]
+
                 elif isinstance(port, list):
-                    # This we could get
                     n_instances = len(port)
                     ports = port
                     ips = [LOCALHOST]
@@ -333,7 +333,7 @@ class MapdlPool:
         else:
 
             if not isinstance(n_instances, int):
-                raise TypeError("Only integers are allowed for 'n_instances' argument")
+                raise TypeError("Only integers are allowed for 'n_instances' argument.")
 
             if n_instances < 1:
                 raise ValueError("Must request at least 1 instance to create a pool.")

--- a/src/ansys/mapdl/core/pool.py
+++ b/src/ansys/mapdl/core/pool.py
@@ -83,11 +83,10 @@ class MapdlPool:
 
     Parameters
     ----------
-    n_instance : int
-        Number of instances to create.
-
-    restart_failed : bool, optional
-        Restarts failed instances.  Defaults to ``True``.
+    n_instances : int, optional
+        Number of instances to create. This argument can be optional if the
+        number of instances can be inferred from the ``ip`` and/or ``port``
+        arguments. See these arguments documentation for more information.
 
     wait : bool, optional
         Wait for pool to be initialized.  Otherwise, pool will start
@@ -97,15 +96,35 @@ class MapdlPool:
         Base directory to create additional directories for each MAPDL
         instance.  Defaults to a temporary working directory.
 
-    port : int, optional
-        Starting port for the MAPDL instances.  Defaults to 50052.
+    ip : str, list[str], optional
+        IP address(es) to connect to where the MAPDL instances are running. You
+        can use one IP, if you have multiple instances running on it, but in
+        that case you must specify all the ports using the argument `port`.
+        If using a list of IPs, the number of ports in 'port' argument should
+        match the number of IPs.
+
+    port : int, list[int], optional
+        The ports where the MAPDL instances are started on or can be connected to.
+        If you are connecting to a single remote instance (only one IP in ``ip``
+        argument), you must specify a number of ports equal to the number of
+        instances you want to connect to.
+        If you are connecting to multiple instances (multiple IPs in ``ip``
+        argument), the amount of ports, should match the number of IPs.
+
+        If only one port is specified and you are starting the MAPDL instances
+        locally (``start_instance`` is ``True``), this port is the port for the
+        first instance. The rest of the instances ports are unitarian increments of
+        port, as long as these ports are free from other processes usage.
+        If you are not starting the MAPDL instances local, PyMAPDL does not check
+        whether these ports are busy or not.
+        Defaults to 50052.
 
     progress_bar : bool, optional
         Show a progress bar when starting the pool.  Defaults to
         ``True``.  Will not be shown when ``wait=False``.
 
     restart_failed : bool, optional
-        Restarts any failed instances in the pool.
+        Restarts any failed instances in the pool. Defaults to ``True``.
 
     remove_temp_files : bool, optional
         This launcher creates a new MAPDL working directory for each instance
@@ -122,10 +141,19 @@ class MapdlPool:
         the index of each instance in the pool.
         By default, the instances directories are named as "Instances_{i}".
 
+    override: bool, optional
+        Attempts to delete the lock file at the run_location.
+        Useful when a prior MAPDL session has exited prematurely and
+        the lock file has not been deleted.
+
     start_instance : bool, optional
         Set it to ``False`` to make PyMAPDL to connect to remote instances instead
         of launching them. In that case, you need to supply the MAPDL instances
         ports as a list of ``int`` s.
+
+    exec_file: str, optional
+        The location of the MAPDL executable.  Will use the cached
+        location when left at the default ``None``.
 
     **kwargs : dict, optional
         Additional keyword arguments. For a complete listing, see the
@@ -160,6 +188,11 @@ class MapdlPool:
     >>> exec_file = '/ansys_inc/v211/ansys/bin/ansys211'
     >>> pool = MapdlPool(10, exec_file=exec_file)
     Creating Pool: 100%|########| 10/10 [00:01<00:00,  1.43it/s]
+
+    Create a pool of instances in multiple instances and with different ports:
+
+    >>> pool = MapdlPool(ip=["123.0.0.1", "123.0.0.2", "123.0.0.3", "123.0.0.4"], port=[50052, 50053, 50055, 50060])
+    Creating Pool: 100%|########| 4/4 [00:01<00:00,  1.23it/s]
 
     """
 
@@ -209,20 +242,23 @@ class MapdlPool:
 
         ip = None if ip == "" else ip  # Making sure the variable is not empty
 
-        if ip is None:
-            ips = [LOCALHOST]
-
-        else:
-            if not isinstance(ip, (tuple, list)):
-                ips = [ip]
-            else:
-                ips = ip
-
-            # Converting ip or hostname to ip
-            ips = [socket.gethostbyname(each) for each in ips]
-            _ = [check_valid_ip(each) for each in ips]  # double check
-
-        n_instances = len(ips)
+        if n_instances is None:
+            if (
+                ip is None
+                or isinstance(ip, str)
+                or (isinstance(ip, list) and len(ip) < 1)
+            ):
+                if (
+                    port is None
+                    or isinstance(port, str)
+                    or (isinstance(port, list) and len(port) < 1)
+                ):
+                    raise ValueError(
+                        "The number of instances could not be inferred "
+                        "from arguments 'n_instances', 'ip' nor 'port'."
+                    )
+                n_instances = len(port)
+            n_instances = len(ip)
 
         # Getting "start_instance" using "True" as default.
         if (ip is not None) and (start_instance is None):
@@ -234,6 +270,138 @@ class MapdlPool:
 
         self._start_instance = start_instance
         LOG.debug(f"'start_instance' equals to '{start_instance}'")
+
+        if n_instances is None:
+            if ip is None or (isinstance(ip, list) and len(ip) == 0):
+                if (
+                    port is None
+                    or isinstance(port, int)
+                    or (isinstance(port, list) and len(port) < 1)
+                ):
+                    raise ValueError(
+                        "The number of instances could not be inferred "
+                        "from arguments 'n_instances', 'ip' nor 'port'."
+                    )
+
+                elif isinstance(port, list):
+                    # This we could get
+                    n_instances = len(port)
+                    ports = port
+                    ips = [LOCALHOST]
+                else:
+                    raise TypeError(
+                        "Argument 'port' does not support this type of argument."
+                    )
+
+            elif isinstance(ip, str):
+                # only one IP
+                if isinstance(port, list):
+                    if len(port) > 0:
+                        n_instances = len(port)
+                        ports = port
+                        ips = [ip for each in range(n_instances)]
+                    else:
+                        raise ValueError(
+                            "The number of ports should be higher than"
+                            " zero if using only one IP address."
+                        )
+
+            elif isinstance(ip, list):
+                n_instances = len(ip)
+                ips = ip
+
+                if start_instance:
+                    raise ValueError(
+                        "If using 'start_instance', 'ip' cannot be"
+                        "a list of IPs since PyMAPDL cannot start instances remotely."
+                    )
+
+                if port is None or isinstance(port, int):
+                    ports = [port or MAPDL_DEFAULT_PORT for i in range(n_instances)]
+
+                elif isinstance(port, list):
+                    if len(ports) != len(ips):
+                        raise ValueError(
+                            f"The number of ports ({len(ports)}) should be the same as the number of IPs ({len(ips)})."
+                        )
+                    ports = port
+
+                else:
+                    raise TypeError(
+                        "Argument 'ip' does not support this type of argument."
+                    )
+        else:
+
+            if not isinstance(n_instances, int):
+                raise TypeError("Only integers are allowed for 'n_instances' argument")
+
+            if n_instances < 1:
+                raise ValueError("Must request at least 1 instance to create a pool.")
+
+            if ip is None:
+                ips = [LOCALHOST for i in range(n_instances)]
+
+                if port is None or isinstance(port, int):
+                    if start_instance:
+                        ports = available_ports(n_instances, port or MAPDL_DEFAULT_PORT)
+                    else:
+                        port = port or MAPDL_DEFAULT_PORT
+                        ports = [port + i for i in range(n_instances)]
+
+                elif isinstance(port, list) and len(port) != n_instances:
+                    raise ValueError(
+                        "If using 'n_instances' and 'port' without multiple 'ip', "
+                        "you should provide as many ports as number of instances requested."
+                    )
+                elif isinstance(port, list):
+                    ports = port
+                else:
+                    raise TypeError(
+                        "Argument 'port' does not support this type of argument."
+                    )
+
+            elif isinstance(ip, str):
+                ip = [ip for i in range(n_instances)]
+                if (
+                    port is None
+                    or isinstance(port, int)
+                    or (isinstance(port, list) and len(port) != n_instances)
+                ):
+                    raise ValueError(
+                        "If using 'n_instances' and only one 'ip', "
+                        "you should provide as many ports as number of instances requested."
+                    )
+                else:
+                    ports = port
+
+            elif isinstance(ip, list):
+                if len(ip) != n_instances:
+                    raise ValueError(
+                        f"The number of IPs ({len(ip)}) should be the same as the number of instances ({n_instances})."
+                    )
+
+                ips = ip
+                if port is None or isinstance(port, int):
+                    ports = [port or MAPDL_DEFAULT_PORT for i in range(n_instances)]
+
+                elif isinstance(port, list):
+                    if len(port) != n_instances:
+                        raise ValueError(
+                            "If using 'n_instances', and multiple ips and ports, "
+                            "you should provide as many ports as number of instances requested."
+                        )
+                    ports = port
+                else:
+                    raise TypeError(
+                        "Argument 'port' does not support this type of argument."
+                    )
+
+            else:
+                raise TypeError("Argument 'ip' does not support this type of argument.")
+
+        # Converting ip or hostname to ip
+        ips = [socket.gethostbyname(each) for each in ips]
+        _ = [check_valid_ip(each) for each in ips]  # double check
 
         if not names:
             names = "Instance"
@@ -277,47 +445,17 @@ class MapdlPool:
         self._exec_file = exec_file
 
         # grab available ports
-        if start_instance:
-            if isinstance(port, int) or len(port) == 1:
-                ports = available_ports(n_instances, port)
-            else:
-                ports = port
-                n_instances = len(ports)
-
-            if self._root_dir is not None:
-                if not os.path.isdir(self._root_dir):
-                    os.makedirs(self._root_dir)
-        else:
-            if isinstance(port, int) or (isinstance(port, list) and len(port) == 1):
-                if len(ips) > 1:
-                    ports = [port for i in range(n_instances)]
-                else:  # in local using port + i
-                    ports = [port + i for i in range(n_instances)]
-            else:
-                ports = port
-                n_instances = len(ports)
-
-        if len(ports) != n_instances:
-            raise ValueError(
-                "The number of instances should be the same as the number of ports."
-            )
-
-        if ips == LOCALHOST:
-            ips = [LOCALHOST for each in ports]
-
-        if len(ports) != len(ips):
-            raise ValueError(
-                "The number of ips should be the same as the number of ports."
-            )
+        if (
+            start_instance
+            and self._root_dir is not None
+            and not os.path.isdir(self._root_dir)
+        ):
+            os.makedirs(self._root_dir)
 
         LOG.debug(f"Using ports: {ports}")
 
         self._instances = []
         self._active = True  # used by pool monitor
-
-        n_instances = int(n_instances)
-        if n_instances < 1:
-            raise ValueError("Must request at least 1 instance to create a pool.")
 
         pbar = None
         if wait and progress_bar:
@@ -347,15 +485,15 @@ class MapdlPool:
         threads = [
             self._spawn_mapdl(
                 i,
-                ip=ips[i],
-                port=ports[i],
+                ip=ip,
+                port=port,
                 pbar=pbar,
                 name=self._names(i),
                 thread_name=self._names(i),
                 start_instance=start_instance,
                 exec_file=exec_file,
             )
-            for i in range(n_instances)
+            for i, (ip, port) in enumerate(zip(ips, ports))
         ]
         if wait:
             [thread.join() for thread in threads]

--- a/src/ansys/mapdl/core/pool.py
+++ b/src/ansys/mapdl/core/pool.py
@@ -289,7 +289,7 @@ class MapdlPool:
                     os.makedirs(self._root_dir)
         else:
             if isinstance(port, int) or (isinstance(port, list) and len(port) == 1):
-                if len(ip) > 1:
+                if len(ips) > 1:
                     ports = [port for i in range(n_instances)]
                 else:  # in local using port + i
                     ports = [port + i for i in range(n_instances)]

--- a/src/ansys/mapdl/core/pool.py
+++ b/src/ansys/mapdl/core/pool.py
@@ -210,7 +210,7 @@ class MapdlPool:
         ip = None if ip == "" else ip  # Making sure the variable is not empty
 
         if ip is None:
-            ips = LOCALHOST
+            ips = [LOCALHOST]
 
         else:
             if not isinstance(ip, (tuple, list)):
@@ -222,12 +222,7 @@ class MapdlPool:
             ips = [socket.gethostbyname(each) for each in ips]
             _ = [check_valid_ip(each) for each in ips]  # double check
 
-        if n_instances and (ips and len(ips) != 1):
-            raise Exception(
-                "If using 'ip' argument, it is not needed to use 'n_instances'."
-            )
-        else:
-            n_instances = len(ips)
+        n_instances = len(ips)
 
         # Getting "start_instance" using "True" as default.
         if (ip is not None) and (start_instance is None):

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -22,6 +22,7 @@
 
 import os
 from pathlib import Path
+import socket
 import time
 
 import numpy as np
@@ -395,3 +396,23 @@ def test_next_with_returns_index(pool):
     for each_instance in pool:
         assert not each_instance.locked
         assert not each_instance._busy
+
+
+def test_multiple_ips():
+    ips = [
+        "123.45.67.01",
+        "123.45.67.02",
+        "123.45.67.03",
+        "123.45.67.04",
+        "123.45.67.05",
+    ]
+
+    conf = MapdlPool(ip=ips, _debug_no_launch=True)._debug_no_launch
+
+    ips = [socket.gethostbyname(each) for each in ips]
+
+    assert conf["ips"] == ips
+    assert conf["ports"] == [50052 for i in range(len(ips))]
+    assert conf["start_instance"] is False
+    assert conf["exec_file"] is None
+    assert conf["n_instances"] == len(ips)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -40,7 +40,8 @@ else:
 
 from ansys.mapdl.core import Mapdl, MapdlPool, examples
 from ansys.mapdl.core.errors import VersionError
-from conftest import QUICK_LAUNCH_SWITCHES, requires
+from ansys.mapdl.core.launcher import LOCALHOST, MAPDL_DEFAULT_PORT
+from conftest import QUICK_LAUNCH_SWITCHES, NullContext, requires
 
 # skip entire module unless HAS_GRPC
 pytestmark = requires("grpc")
@@ -416,3 +417,351 @@ def test_multiple_ips():
     assert conf["start_instance"] is False
     assert conf["exec_file"] is None
     assert conf["n_instances"] == len(ips)
+
+
+@pytest.mark.parametrize(
+    "n_instances,ip,port,exp_n_instances,exp_ip,exp_port,context",
+    [
+        ## n_instances not set
+        pytest.param(
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            pytest.raises(
+                ValueError, match="The number of instances could not be inferred "
+            ),
+        ),
+        pytest.param(
+            None,
+            [],
+            None,
+            None,
+            None,
+            None,
+            pytest.raises(
+                ValueError, match="The number of instances could not be inferred "
+            ),
+        ),
+        pytest.param(
+            None,
+            [],
+            [],
+            None,
+            None,
+            None,
+            pytest.raises(
+                ValueError, match="The number of instances could not be inferred "
+            ),
+        ),
+        pytest.param(None, [], 50052, 1, [LOCALHOST], [50052], NullContext()),
+        pytest.param(
+            None,
+            None,
+            [50052, 50053],
+            2,
+            [LOCALHOST, LOCALHOST],
+            [50052, 50053],
+            NullContext(),
+        ),
+        pytest.param(
+            None,
+            None,
+            set(),
+            None,
+            None,
+            None,
+            pytest.raises(TypeError, match="Argument 'port' does not support"),
+        ),
+        pytest.param(
+            None,
+            "123.0.0.1",
+            [50052, 50053, 50055],
+            3,
+            ["123.0.0.1", "123.0.0.1", "123.0.0.1"],
+            [50052, 50053, 50055],
+            NullContext(),
+        ),
+        pytest.param(
+            None,
+            "123.0.0.1",
+            [],
+            None,
+            None,
+            None,
+            pytest.raises(
+                ValueError, match="The number of ports should be higher than"
+            ),
+        ),
+        pytest.param(
+            None,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3"],
+            None,
+            3,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3"],
+            [50052, 50052, 50052],
+            NullContext(),
+        ),
+        pytest.param(
+            None,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3"],
+            50053,
+            3,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3"],
+            [50053, 50053, 50053],
+            NullContext(),
+        ),
+        pytest.param(
+            None,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3"],
+            [50052, 50053],
+            None,
+            None,
+            None,
+            pytest.raises(ValueError, match="should be the same as the number of IPs"),
+        ),
+        pytest.param(
+            None,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3"],
+            [50052, 50053, 50053],
+            3,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3"],
+            [50052, 50053, 50053],
+            NullContext(),
+        ),
+        pytest.param(
+            None,
+            set(),
+            None,
+            None,
+            None,
+            None,
+            pytest.raises(TypeError, match="Argument 'ip' does not support"),
+        ),
+        ## n_instances set
+        # ip is none
+        pytest.param(
+            {},
+            None,
+            None,
+            None,
+            None,
+            None,
+            pytest.raises(
+                TypeError, match="Only integers are allowed for 'n_instances'"
+            ),
+        ),
+        pytest.param(
+            0,
+            None,
+            None,
+            None,
+            None,
+            None,
+            pytest.raises(
+                ValueError, match="Must request at least 1 instance to create"
+            ),
+        ),
+        pytest.param(
+            2,
+            None,
+            None,
+            2,
+            [LOCALHOST, LOCALHOST],
+            [MAPDL_DEFAULT_PORT, MAPDL_DEFAULT_PORT + 1],
+            NullContext(),
+        ),
+        pytest.param(
+            3,
+            None,
+            None,
+            3,
+            [LOCALHOST, LOCALHOST, LOCALHOST],
+            [MAPDL_DEFAULT_PORT, MAPDL_DEFAULT_PORT + 1, MAPDL_DEFAULT_PORT + 2],
+            NullContext(),
+        ),
+        pytest.param(
+            3,
+            None,
+            50053,
+            3,
+            [LOCALHOST, LOCALHOST, LOCALHOST],
+            [50053, 50053 + 1, 50053 + 2],
+            NullContext(),
+        ),
+        pytest.param(
+            3,
+            None,
+            [50052, 50053],
+            None,
+            None,
+            None,
+            pytest.raises(
+                ValueError,
+                match="If using 'n_instances' and 'port' without multiple 'ip'",
+            ),
+        ),
+        pytest.param(
+            3,
+            None,
+            [50052, 50053, 50054],
+            3,
+            [LOCALHOST, LOCALHOST, LOCALHOST],
+            [50052, 50053, 50054],
+            NullContext(),
+        ),
+        pytest.param(
+            3,
+            None,
+            set(),
+            None,
+            None,
+            None,
+            pytest.raises(
+                TypeError,
+                match="Argument 'port' does not support this type of argument",
+            ),
+        ),
+        # ip is string
+        pytest.param(
+            3,
+            "123.0.0.1",
+            None,
+            None,
+            None,
+            None,
+            pytest.raises(ValueError, match="If using 'n_instances' and only one 'ip'"),
+        ),
+        pytest.param(
+            3,
+            "123.0.0.1",
+            50053,
+            None,
+            None,
+            None,
+            pytest.raises(ValueError, match="If using 'n_instances' and only one 'ip'"),
+        ),
+        pytest.param(
+            3,
+            "123.0.0.1",
+            [50053, 50052],
+            None,
+            None,
+            None,
+            pytest.raises(ValueError, match="If using 'n_instances' and only one 'ip'"),
+        ),
+        pytest.param(
+            3,
+            "123.0.0.1",
+            [50053, 50052, 50054],
+            3,
+            ["123.0.0.1", "123.0.0.1", "123.0.0.1"],
+            [50053, 50052, 50054],
+            NullContext(),
+        ),
+        # ip is list
+        pytest.param(
+            3,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3", "123.0.0.4"],
+            None,
+            None,
+            None,
+            None,
+            pytest.raises(
+                ValueError, match="should be the same as the number of instances"
+            ),
+        ),
+        pytest.param(
+            4,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3", "123.0.0.4"],
+            None,
+            4,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3", "123.0.0.4"],
+            [
+                MAPDL_DEFAULT_PORT,
+                MAPDL_DEFAULT_PORT,
+                MAPDL_DEFAULT_PORT,
+                MAPDL_DEFAULT_PORT,
+            ],
+            NullContext(),
+        ),
+        pytest.param(
+            4,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3", "123.0.0.4"],
+            50053,
+            4,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3", "123.0.0.4"],
+            [50053, 50053, 50053, 50053],
+            NullContext(),
+        ),
+        pytest.param(
+            4,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3", "123.0.0.4"],
+            [50053, 50054],
+            None,
+            None,
+            None,
+            pytest.raises(
+                ValueError,
+                match="you should provide as many ports as number of instances",
+            ),
+        ),
+        pytest.param(
+            4,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3", "123.0.0.4"],
+            [50055] * 4,
+            4,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3", "123.0.0.4"],
+            [50055] * 4,
+            NullContext(),
+        ),
+        pytest.param(
+            4,
+            ["123.0.0.1", "123.0.0.2", "123.0.0.3", "123.0.0.4"],
+            set(),
+            None,
+            None,
+            None,
+            pytest.raises(
+                TypeError, match="Argument 'port' does not support this type of"
+            ),
+        ),
+        # ip type is not allowed
+        pytest.param(
+            4,
+            set(),
+            None,
+            None,
+            None,
+            None,
+            pytest.raises(
+                TypeError, match="Argument 'ip' does not support this type of"
+            ),
+        ),
+    ],
+)
+def test_ip_port_n_instance(
+    monkeypatch, n_instances, ip, port, exp_n_instances, exp_ip, exp_port, context
+):
+    monkeypatch.delenv("PYMAPDL_START_INSTANCE", raising=False)
+    monkeypatch.delenv("PYMAPDL_IP", raising=False)
+    monkeypatch.setenv(
+        "PYMAPDL_MAPDL_EXEC", "/ansys_inc/v222/ansys/bin/ansys222"
+    )  # to avoid trying to find it.
+
+    with context:
+        conf = MapdlPool(
+            n_instances=n_instances, ip=ip, port=port, _debug_no_launch=True
+        )._debug_no_launch
+
+        if exp_ip:
+            exp_ip = [socket.gethostbyname(each) for each in exp_ip]
+
+        assert conf["n_instances"] == exp_n_instances
+        assert len(conf["ips"]) == exp_n_instances
+        assert len(conf["ports"]) == exp_n_instances
+        assert conf["ips"] == exp_ip
+        assert conf["ports"] == exp_port
+        assert conf["exec_file"] == "/ansys_inc/v222/ansys/bin/ansys222"


### PR DESCRIPTION
As the title.

It should allow to:

```py
ips = [
    "123.45.67.01",
    "123.45.67.02",
    "123.45.67.03",
    "123.45.67.04",
    "123.45.67.05",
]

pool = MapdlPool(ip=ips)
```