### PR TITLE
ci: using trusted publisher release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
           vale-version: "3.4.1"
 
   smoke-tests:
-    name: Build and smoke test (${{ matrix.os }} | Python ${{ matrix.python-version }}) (Release=${{ matrix.should-release }})
+    name: "Build and smoke test (${{ matrix.os }} | Python ${{ matrix.python-version }}) (Release=${{ matrix.should-release }})"
     runs-on: ${{ matrix.os }}
     if: github.ref != 'refs/heads/main'
     timeout-minutes: 20
@@ -252,7 +252,7 @@ jobs:
           path: doc/_build/latex/pymapdl*.pdf
           retention-days: 7
 
-      - name: 'Upload minimal requirements file'
+      - name: "Upload minimal requirements file"
         # To include it in the release
         uses: actions/upload-artifact@v4
         with:
@@ -631,7 +631,7 @@ jobs:
           name: ${{ matrix.mapdl-image }}-local.xml
           flags: ubuntu,local,${{ matrix.mapdl-image }}
 
-      - name: 'Upload coverage artifacts'
+      - name: "Upload coverage artifacts"
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.mapdl-image }}-local.xml
@@ -737,7 +737,7 @@ jobs:
           name: ${{ matrix.mapdl-image }}-minimal.xml
           flags: ubuntu,local,${{ matrix.mapdl-image }},minimal
 
-      - name: 'Upload coverage artifacts'
+      - name: "Upload coverage artifacts"
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.mapdl-image }}-minimal.xml
@@ -762,7 +762,7 @@ jobs:
       #   with:
       #     python-version: 3.9
 
-      - name: "Checking python_"
+      - name: "Checking Python"
         shell: powershell
         run: |
           python -m pip install --upgrade pip
@@ -809,55 +809,26 @@ jobs:
           name: windows-v22.2.0-local.xml
           flags: windows,local,v22.2.0
 
-      - name: Upload coverage artifacts
+      - name: "Upload coverage artifacts"
         uses: actions/upload-artifact@v4
         with:
           name: windows-v22.2.0-local.xml
           path: ./windows_local.xml
 
   package:
-    name: Package library
+    name: "Package library"
     needs: [build-test, build-test-ubuntu, build-test-ubuntu-minimal, docs-build]
     runs-on: ubuntu-latest
     steps:
-      - name: Build library source and wheel artifacts
+      - name: "Build library source and wheel artifacts"
         uses: ansys/actions/build-library@v6
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
 
-  # release-bis:
-  #   name: "Release"
-  #   if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-  #   needs: [docs-build, build-test, build-test-ubuntu, build-test-ubuntu-minimal]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v5
-  #       with:
-  #         python-version: 3.9
-
-  #     - uses: actions/download-artifact@v4
-      
-  #     - name: Copying files and overwrite same name files
-  #       # (to avoid upload issue)
-  #       run: |
-  #         mkdir artifacts
-
-  #     - name: Display structure of downloaded files
-  #       run: ls -Rla
-
-  #     - name: "Release to GitHub"
-  #       uses: softprops/action-gh-release@v2
-  #       with:
-  #         files: |
-  #           ./**/pymapdl-Documentation-*.pdf
-  #           ./**/ansys-mapdl-core*wheelhouse*.zip
-
-
   release:
-    name: Release project
+    name: "Release project"
     if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
     needs: [package]
     runs-on: ubuntu-latest
@@ -867,18 +838,20 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - name: Release to the public PyPI repository
+      - name: "Release to the public PyPI repository"
         uses: ansys/actions/release-pypi-public@v6
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           use-trusted-publisher: true
 
-      - name: Release to GitHub
+      - name: "Release to GitHub"
         uses: ansys/actions/release-github@v6
         with:
           library-name: ${{ env.PACKAGE_NAME }}
           additional-artifacts: "minimum_requirements.txt"
 
+      - name: "Display structure of downloaded files"
+        run: ls -Rla
 
   upload-docs-release:
     name: "Upload release documentation"
@@ -886,7 +859,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release]
     steps:
-      - name: Deploy the stable documentation
+      - name: "Deploy the stable documentation"
         # TODO: testing SEO improvements. This branch avoids creating a
         # sitemap.xml pages in opposite to v5.
         uses: ansys/actions/doc-deploy-stable@feat/seo-improvements
@@ -926,12 +899,12 @@ jobs:
 
 
   upload-dev-docs:
-    name: Upload dev documentation
+    name: "Upload dev documentation"
     if: github.ref == 'refs/heads/main' && !contains(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     needs: [docs-build]
     steps:
-      - name: Deploy the latest documentation
+      - name: "Deploy the latest documentation"
         # TODO: testing SEO improvements. This branch reuses the "index.html" from the stable version
         uses: ansys/actions/doc-deploy-dev@feat/seo-improvements
         with:
@@ -954,12 +927,12 @@ jobs:
 
 
   notify:
-    name: Notify failed build
+    name: "Notify failed build"
     needs: [smoke-tests, docs-build, build-test, build-test-ubuntu, build-test-ubuntu-minimal]
     if: failure() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     steps:
-      - name: Open issue
+      - name: "Open issue"
         uses: jayqi/failed-build-issue-action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -988,13 +961,13 @@ jobs:
           pycallpython=$(julia -e 'using Pkg;Pkg.add("PyCall");using PyCall;println(PyCall.python)')
           echo "pythonpath=$(echo $pycallpython)" >> $GITHUB_OUTPUT
 
-      - name: Installing pymapdl
+      - name: "Installing PyMAPDL"
         env:
           PYTHON_PATH: ${{ steps.get_python.outputs.pythonpath }}
         run: |
           "$PYTHON_PATH" -m pip install -e .
 
-      - name: "Starting julia"
+      - name: "Starting Julia"
         shell: julia {0}
         run: |
           using Pkg; Pkg.add("PyCall");using PyCall;pymapdl = pyimport("ansys.mapdl.core");print(pymapdl.__version__)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,7 @@ jobs:
     name: "Remote: Build & test MAPDL ${{ matrix.mapdl-version }} (Extended testing ${{ matrix.extended_testing }})"
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: [smoke-tests]
     timeout-minutes: 35
     strategy:
       fail-fast: false
@@ -502,6 +503,7 @@ jobs:
     name: "Local: Build & test on Ubuntu MAPDL ${{ matrix.mapdl-image }} (Extended testing ${{ matrix.extended_testing }})"
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: [smoke-tests]
     timeout-minutes: 55
     outputs:
       pushed: ${{ steps.attatch-to-pr.outputs.pushed }}
@@ -640,6 +642,7 @@ jobs:
     name: "Local: Build & test minimal setup on Ubuntu MAPDL ${{ matrix.mapdl-image }} (Extended testing ${{ matrix.extended_testing }})"
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: [smoke-tests]
     timeout-minutes: 55
     strategy:
       fail-fast: false
@@ -812,49 +815,95 @@ jobs:
           name: windows-v22.2.0-local.xml
           path: ./windows_local.xml
 
-
-  release:
-    name: "Release"
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-    needs: [smoke-tests, docs-build, build-test, build-test-ubuntu, build-test-ubuntu-minimal]
+  package:
+    name: Package library
+    needs: [build-test, build-test-ubuntu, build-test-ubuntu-minimal, docs-build]
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Build library source and wheel artifacts
+        uses: ansys/actions/build-library@v6
         with:
-          python-version: 3.9
+          library-name: ${{ env.PACKAGE_NAME }}
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
-      - uses: actions/download-artifact@v4
+
+  # release-bis:
+  #   name: "Release"
+  #   if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+  #   needs: [docs-build, build-test, build-test-ubuntu, build-test-ubuntu-minimal]
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Set up Python
+  #       uses: actions/setup-python@v5
+  #       with:
+  #         python-version: 3.9
+
+  #     - uses: actions/download-artifact@v4
       
-      - name: Copying files and overwrite same name files
-        # (to avoid upload issue)
-        run: |
-          mkdir artifacts
-          find . -iname 'ansys_mapdl_core-*.tar.gz' -exec cp \{\} ./artifacts/ \;
-          find . -iname 'ansys_mapdl_core-*-py3-none-any.whl' -exec cp \{\} ./artifacts/ \;
-          find . -iname 'minimum_requirements.txt' -exec cp \{\} ./artifacts/ \;
+  #     - name: Copying files and overwrite same name files
+  #       # (to avoid upload issue)
+  #       run: |
+  #         mkdir artifacts
 
-      - name: Display structure of downloaded files
-        run: ls -Rla
+  #     - name: Display structure of downloaded files
+  #       run: ls -Rla
 
-      - name: "Release to GitHub"
-        uses: softprops/action-gh-release@v2
+  #     - name: "Release to GitHub"
+  #       uses: softprops/action-gh-release@v2
+  #       with:
+  #         files: |
+  #           ./**/pymapdl-Documentation-*.pdf
+  #           ./**/ansys-mapdl-core*wheelhouse*.zip
+
+
+  release-dry-run:
+    # TO BE REMOVED: This is a temporary step to test the release process
+    name: Release project
+    needs: [package]
+    runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Release to the public PyPI repository
+        uses: ansys/actions/release-pypi-public@v6
         with:
-          files: |
-            ./**/artifacts/ansys_mapdl_core-*-py3-none-any.whl
-            ./**/artifacts/ansys_mapdl_core-*.tar.gz
-            ./**/artifacts/minimum_requirements.txt
-            ./**/pymapdl-Documentation-*.pdf
-            ./**/ansys-mapdl-core*wheelhouse*.zip
+          library-name: ${{ env.PACKAGE_NAME }}
+          use-trusted-publisher: true
+          dry-run: true
+  
+      - name: Release to GitHub
+        uses: ansys/actions/release-github@v6
+        with:
+          library-name: ${{ env.PACKAGE_NAME }}
+          additional-artifacts: "minimum_requirements.txt"
+          dry-run: true
 
-      - name: Upload to Public PyPi
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          pip install twine
-          twine upload --skip-existing ./**/*.whl
-          twine upload --skip-existing ./**/*.tar.gz
+
+  release:
+    name: Release project
+    if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
+    needs: [package]
+    runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - name: Release to the public PyPI repository
+        uses: ansys/actions/release-pypi-public@v6
+        with:
+          library-name: ${{ env.PACKAGE_NAME }}
+          use-trusted-publisher: true
+
+      - name: Release to GitHub
+        uses: ansys/actions/release-github@v6
+        with:
+          library-name: ${{ env.PACKAGE_NAME }}
+          additional-artifacts: "minimum_requirements.txt"
 
 
   upload-docs-release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -856,32 +856,6 @@ jobs:
   #           ./**/ansys-mapdl-core*wheelhouse*.zip
 
 
-  release-dry-run:
-    # TO BE REMOVED: This is a temporary step to test the release process
-    name: Release project
-    needs: [package]
-    runs-on: ubuntu-latest
-    # Specifying a GitHub environment is optional, but strongly encouraged
-    environment: release
-    permissions:
-      id-token: write
-      contents: write
-    steps:
-      - name: Release to the public PyPI repository
-        uses: ansys/actions/release-pypi-public@v6
-        with:
-          library-name: ${{ env.PACKAGE_NAME }}
-          use-trusted-publisher: true
-          dry-run: true
-  
-      - name: Release to GitHub
-        uses: ansys/actions/release-github@v6
-        with:
-          library-name: ${{ env.PACKAGE_NAME }}
-          additional-artifacts: "minimum_requirements.txt"
-          dry-run: true
-
-
   release:
     name: Release project
     if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}

--- a/doc/changelog.d/3171.miscellaneous.md
+++ b/doc/changelog.d/3171.miscellaneous.md
@@ -1,0 +1,1 @@
+maint: using trusted publisher release process

--- a/doc/changelog.d/3171.miscellaneous.md
+++ b/doc/changelog.d/3171.miscellaneous.md
@@ -1,1 +1,1 @@
-maint: using trusted publisher release process
+ci: using trusted publisher release process


### PR DESCRIPTION
Following PyAnsys guidelines, this PR is to implement the [ansys/actions/release-pypi-public](https://actions.docs.ansys.com/version/6.1/migrations/release-pypi-trusted-publisher.html#release-pypi-trusted-publisher).