### PR TITLE
feat: add exit to inprocess backend

### DIFF
--- a/doc/changelog.d/3435.miscellaneous.md
+++ b/doc/changelog.d/3435.miscellaneous.md
@@ -1,0 +1,1 @@
+feat: add exit to inprocess backend

--- a/src/ansys/mapdl/core/mapdl_inprocess.py
+++ b/src/ansys/mapdl/core/mapdl_inprocess.py
@@ -38,6 +38,8 @@ class _Backend(Protocol):
         mute: bool,
     ) -> str: ...
 
+    def exit(self) -> None: ...
+
 
 class MapdlInProcess(MapdlBase):
     def __init__(self, in_process_backend: _Backend):
@@ -69,6 +71,9 @@ class MapdlInProcess(MapdlBase):
         return self._in_process_backend.input_file(
             fname, ext, dir_, int(line or 0), int(log or 0), mute
         )
+
+    def exit(self) -> None:
+        self._in_process_backend.exit()
 
     @MapdlBase.name.getter
     def name(self) -> str:


### PR DESCRIPTION
This will be implemented by the backend, after which the `hasattr` check can be removed here.