### PR TITLE
feat: having two global flags. One for visualizer and one for pyvista

### DIFF
--- a/doc/changelog.d/3460.miscellaneous.md
+++ b/doc/changelog.d/3460.miscellaneous.md
@@ -1,0 +1,1 @@
+feat: having two global flags. One for visualizer and one for pyvista

--- a/src/ansys/mapdl/core/__init__.py
+++ b/src/ansys/mapdl/core/__init__.py
@@ -79,14 +79,22 @@ if RUNNING_TESTS:  # pragma: no cover
 _LOCAL_PORTS = []
 
 
-# Per contract with Sphinx-Gallery, this method must be available at top level
 try:
-    import pyvista
+    from ansys.tools.visualization_interface import Plotter
+
+    _HAS_VISUALIZER = True
+except ModuleNotFoundError:  # pragma: no cover
+    LOG.debug("The module 'ansys-tools-visualization_interface' is not installed.")
+    _HAS_VISUALIZER = False
+
+try:
+    import pyvista as pv
 
     _HAS_PYVISTA = True
 except ModuleNotFoundError:  # pragma: no cover
-    LOG.debug("The module 'PyVista' is not installed.")
+    LOG.debug("The module 'pyvista' is not installed.")
     _HAS_PYVISTA = False
+
 
 try:
     import importlib.metadata as importlib_metadata
@@ -124,7 +132,7 @@ from ansys.mapdl.core.pool import MapdlPool
 
 _HAS_ANSYS = _check_has_ansys()
 
-if _HAS_PYVISTA:
+if _HAS_VISUALIZER:
     from ansys.mapdl.core.plotting.theme import _apply_default_theme
 
     _apply_default_theme()

--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -41,7 +41,7 @@ import numpy as np
 
 from ansys.mapdl import core as pymapdl
 from ansys.mapdl.core import LOG as logger
-from ansys.mapdl.core import _HAS_PYVISTA
+from ansys.mapdl.core import _HAS_VISUALIZER
 from ansys.mapdl.core.commands import (
     CMD_BC_LISTING,
     CMD_LISTING,
@@ -255,7 +255,7 @@ class _MapdlCore(Commands):
         self._mute = False
         self._save_selection_obj = None
 
-        if _HAS_PYVISTA:
+        if _HAS_VISUALIZER:
             if use_vtk is not None:  # pragma: no cover
                 self._use_vtk = use_vtk
             else:
@@ -263,7 +263,7 @@ class _MapdlCore(Commands):
         else:  # pragma: no cover
             if use_vtk:
                 raise ModuleNotFoundError(
-                    "Using the keyword argument 'use_vtk' requires having Pyvista installed."
+                    "Using the keyword argument 'use_vtk' requires having 'ansys-tools-visualization_interface' installed."
                 )
             else:
                 self._use_vtk = False
@@ -1142,7 +1142,6 @@ class _MapdlCore(Commands):
     def _mesh(self) -> "Archive":
         """Write entire archive to ASCII and read it in as an
         ``ansys.mapdl.core.Archive``"""
-        # lazy import here to avoid loading pyvista and vtk
         from ansys.mapdl.reader import Archive
 
         if self._archive_cache is None:

--- a/src/ansys/mapdl/core/mapdl_extended.py
+++ b/src/ansys/mapdl/core/mapdl_extended.py
@@ -31,7 +31,7 @@ import numpy as np
 from numpy.typing import DTypeLike, NDArray
 
 from ansys.mapdl.core import LOG as logger
-from ansys.mapdl.core import _HAS_PYVISTA
+from ansys.mapdl.core import _HAS_VISUALIZER
 from ansys.mapdl.core.commands import CommandListingOutput
 from ansys.mapdl.core.errors import (
     CommandDeprecated,
@@ -425,7 +425,7 @@ class _MapdlCommandExtended(_MapdlCore):
             HPT - Plots only those keypoints that are hard points.
 
         vtk : bool, optional
-            Plot the currently selected lines using ``pyvista``.
+            Plot the currently selected lines using ``ansys-tools-visualization_interface``.
 
         show_keypoint_numbering : bool, optional
             Display keypoint numbers when ``vtk=True``.
@@ -439,9 +439,9 @@ class _MapdlCommandExtended(_MapdlCore):
         if vtk is None:
             vtk = self._use_vtk
         elif vtk is True:
-            if not _HAS_PYVISTA:  # pragma: no cover
+            if not _HAS_VISUALIZER:  # pragma: no cover
                 raise ModuleNotFoundError(
-                    "Using the keyword argument 'vtk' requires having Pyvista installed."
+                    "Using the keyword argument 'vtk' requires having 'ansys-tools-visualization_interface' installed."
                 )
         if vtk:
             from ansys.mapdl.core.plotting.visualizer import MapdlPlotter
@@ -500,7 +500,7 @@ class _MapdlCommandExtended(_MapdlCore):
             NINC are ignored and display all selected lines [LSEL].
 
         vtk : bool, optional
-            Plot the currently selected lines using ``pyvista``.
+            Plot the currently selected lines using ``ansys-tools-visualization_interface``.
 
         show_line_numbering : bool, optional
             Display line and keypoint numbers when ``vtk=True``.
@@ -531,9 +531,9 @@ class _MapdlCommandExtended(_MapdlCore):
         if vtk is None:
             vtk = self._use_vtk
         elif vtk is True:
-            if not _HAS_PYVISTA:  # pragma: no cover
+            if not _HAS_VISUALIZER:  # pragma: no cover
                 raise ModuleNotFoundError(
-                    "Using the keyword argument 'vtk' requires having Pyvista installed."
+                    "Using the keyword argument 'vtk' requires having 'ansys-tools-visualization_interface' installed."
                 )
 
         if vtk:
@@ -658,8 +658,8 @@ class _MapdlCommandExtended(_MapdlCore):
             when ``vtk=True``.
 
         vtk : bool, optional
-            Plot the currently selected areas using ``pyvista``.  As
-            this creates a temporary surface mesh, this may have a
+            Plot the currently selected areas using ``ansys-tools-visualization_interface``.
+            As this creates a temporary surface mesh, this may have a
             long execution time for large meshes.
 
         quality : int, optional
@@ -715,9 +715,9 @@ class _MapdlCommandExtended(_MapdlCore):
         if vtk is None:
             vtk = self._use_vtk
         elif vtk is True:
-            if not _HAS_PYVISTA:  # pragma: no cover
+            if not _HAS_VISUALIZER:  # pragma: no cover
                 raise ModuleNotFoundError(
-                    "Using the keyword argument 'vtk' requires having Pyvista installed."
+                    "Using the keyword argument 'vtk' requires having 'ansys-tools-visualization_interface' installed."
                 )
 
         if vtk:
@@ -891,8 +891,8 @@ class _MapdlCommandExtended(_MapdlCore):
             to .075).  Ignored when ``vtk=True``.
 
         vtk : bool, optional
-            Plot the currently selected volumes using ``pyvista``.  As
-            this creates a temporary surface mesh, this may have a
+            Plot the currently selected volumes using ``ansys-tools-visualization_interface``.
+            As this creates a temporary surface mesh, this may have a
             long execution time for large meshes.
 
         quality : int, optional
@@ -917,9 +917,9 @@ class _MapdlCommandExtended(_MapdlCore):
         if vtk is None:
             vtk = self._use_vtk
         elif vtk is True:
-            if not _HAS_PYVISTA:  # pragma: no cover
+            if not _HAS_VISUALIZER:  # pragma: no cover
                 raise ModuleNotFoundError(
-                    "Using the keyword argument 'vtk' requires having Pyvista installed."
+                    "Using the keyword argument 'vtk' requires having 'ansys-tools-visualization_interface' installed."
                 )
 
         if vtk:
@@ -1096,12 +1096,12 @@ class _MapdlCommandExtended(_MapdlCore):
             vtk = self._use_vtk
 
         if vtk is True:
-            if _HAS_PYVISTA:
+            if _HAS_VISUALIZER:
                 # lazy import here to avoid top level import
                 import pyvista as pv
             else:  # pragma: no cover
                 raise ModuleNotFoundError(
-                    "Using the keyword argument 'vtk' requires having Pyvista installed."
+                    "Using the keyword argument 'vtk' requires having 'ansys-tools-visualization_interface' installed."
                 )
 
         if "knum" in kwargs:
@@ -1152,7 +1152,7 @@ class _MapdlCommandExtended(_MapdlCore):
         Parameters
         ----------
         vtk : bool, optional
-            Plot the currently selected elements using ``pyvista``.
+            Plot the currently selected elements using ``ansys-tools-visualization_interface``.
             Defaults to current ``use_vtk`` setting.
 
         show_node_numbering : bool, optional
@@ -1238,9 +1238,9 @@ class _MapdlCommandExtended(_MapdlCore):
         if vtk is None:
             vtk = self._use_vtk
         elif vtk is True:
-            if not _HAS_PYVISTA:  # pragma: no cover
+            if not _HAS_VISUALIZER:  # pragma: no cover
                 raise ModuleNotFoundError(
-                    "Using the keyword argument 'vtk' requires having Pyvista installed."
+                    "Using the keyword argument 'vtk' requires having 'ansys-tools-visualization_interface' installed."
                 )
 
         if vtk:

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -336,10 +336,18 @@ class Report(base_report_class):
             "ansys.api.mapdl.v0",  # ansys-api-mapdl-v0
             "ansys.mapdl.reader",  # ansys-mapdl-reader
             "google.protobuf",  # protobuf library
+            "ansys-math-core",
         ]
 
         # Optional packages
-        optional = ["matplotlib", "pyvista", "pyiges", "tqdm"]
+        optional = [
+            "matplotlib",
+            "pyvista",
+            "pyiges",
+            "tqdm",
+            "ansys-tools-visualization_interface",
+            "pandas",
+        ]
 
         if _HAS_PYANSYS_REPORT:
             #  Combine all packages into one

--- a/src/ansys/mapdl/core/plotting/__init__.py
+++ b/src/ansys/mapdl/core/plotting/__init__.py
@@ -19,7 +19,7 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-from ansys.mapdl.core import _HAS_PYVISTA
+from ansys.mapdl.core import _HAS_VISUALIZER
 from ansys.mapdl.core.plotting.consts import (  # noqa: F401
     ALLOWED_TARGETS,
     BC_D,
@@ -30,6 +30,6 @@ from ansys.mapdl.core.plotting.consts import (  # noqa: F401
     POINT_SIZE,
 )
 
-if _HAS_PYVISTA:
+if _HAS_VISUALIZER:
     from ansys.mapdl.core.plotting.theme import MapdlTheme  # noqa: F401
     from ansys.mapdl.core.plotting.visualizer import MapdlPlotter  # noqa: F401

--- a/src/ansys/mapdl/core/plotting/visualizer.py
+++ b/src/ansys/mapdl/core/plotting/visualizer.py
@@ -29,7 +29,7 @@ from ansys.tools.visualization_interface.backends.pyvista import PyVistaBackendI
 import numpy as np
 from numpy.typing import NDArray
 
-from ansys.mapdl.core import _HAS_PYVISTA
+from ansys.mapdl.core import _HAS_VISUALIZER
 from ansys.mapdl.core.misc import get_bounding_box
 from ansys.mapdl.core.plotting.consts import (
     ALLOWED_TARGETS,
@@ -42,7 +42,7 @@ from ansys.mapdl.core.plotting.consts import (
 )
 from ansys.mapdl.core.plotting.theme import MapdlTheme
 
-if _HAS_PYVISTA:
+if _HAS_VISUALIZER:
     import pyvista as pv
 
     from ansys.mapdl.core.plotting.plotting_defaults import DefaultSymbol

--- a/src/ansys/mapdl/core/post.py
+++ b/src/ansys/mapdl/core/post.py
@@ -25,11 +25,11 @@ import weakref
 
 import numpy as np
 
-from ansys.mapdl.core import _HAS_PYVISTA
+from ansys.mapdl.core import _HAS_VISUALIZER
 from ansys.mapdl.core.errors import MapdlRuntimeError
 from ansys.mapdl.core.misc import requires_package, supress_logging
 
-if _HAS_PYVISTA:
+if _HAS_VISUALIZER:
     from ansys.mapdl.core.plotting.visualizer import MapdlPlotter
 
 COMPONENT_STRESS_TYPE = ["X", "Y", "Z", "XY", "YZ", "XZ"]


### PR DESCRIPTION
## Description
Fix an issue where having pyvista but not the visualizer will break the imports.

Now we have two flags.
- `_HAS_PYVISTA` which is used for non-plotting capabilities, like `mapdl.geometry` and `mapdl.mesh` modules.
- `_HAS_VISUALIZER` for plotting capabilities like `mapdl.nplot` and `mapdl.post` module.

The visualizer requires pyvista, so it is more strict flag than the pyvista only.

## Note
This PR acknowledges that `pyvista` is used in more places than just for plotting. Hence PyMAPDL is not totally decoupled from `pyvista`.
If we want to use all the features, for instance `mapdl.mesh` and `mapdl.geometry`, we need `pyvista`.

## Issue linked
NA

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)