### PR TITLE
fix: environment variables not being passed to MAPDL process

### DIFF
--- a/doc/changelog.d/3461.fixed.md
+++ b/doc/changelog.d/3461.fixed.md
@@ -1,0 +1,1 @@
+fix: environment variables not being passed to MAPDL process

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -602,7 +602,7 @@ def launch_grpc(
     env_vars = update_env_vars(add_env_vars, replace_env_vars)
 
     LOG.info(
-        f"Running a local instance at port {port} the following command: '{command}'"
+        f"Running a local instance in {run_location} at port {port} the following command: '{command}'"
     )
 
     LOG.debug("MAPDL starting in background.")
@@ -681,6 +681,7 @@ def _check_server_is_alive(stdout_queue, run_location, timeout):
     empty_i = 0
     terminal_output = ""
 
+    LOG.debug(f"Checking if MAPDL server is alive")
     while time.time() < (t0 + timeout):
         terminal_output += "\n".join(_get_std_output(std_queue=stdout_queue)).strip()
 
@@ -700,6 +701,7 @@ def _check_server_is_alive(stdout_queue, run_location, timeout):
             break
 
     else:
+        LOG.debug(f"MAPDL gRPC server didn't print any valid output:\n{terminal_output}")
         raise MapdlDidNotStart("MAPDL failed to start the gRPC server")
 
 
@@ -1811,8 +1813,7 @@ def launch_mapdl(
 
             port, actual_run_location, process = launch_grpc(
                 port=port,
-                add_env_vars=add_env_vars,
-                replace_env_vars=replace_env_vars,
+                replace_env_vars=env_vars,
                 **start_parm,
             )
 
@@ -1917,7 +1918,7 @@ def check_mode(mode, version):
     return mode
 
 
-def update_env_vars(add_env_vars, replace_env_vars):
+def update_env_vars(add_env_vars: dict, replace_env_vars: dict) -> dict:
     """
     Update environment variables for the MAPDL process.
 
@@ -1939,6 +1940,8 @@ def update_env_vars(add_env_vars, replace_env_vars):
     """
 
     # Expanding/replacing env variables for the process.
+    envvars = os.environ.copy()
+
     if add_env_vars and replace_env_vars:
         raise ValueError(
             "'add_env_vars' and 'replace_env_vars' are incompatible. Please provide only one."
@@ -1950,9 +1953,8 @@ def update_env_vars(add_env_vars, replace_env_vars):
                 "The variable 'add_env_vars' should be a dict with env vars."
             )
 
-        add_env_vars.update(os.environ)
+        envvars.update(add_env_vars)
         LOG.debug(f"Updating environment variables with: {add_env_vars}")
-        return add_env_vars
 
     elif replace_env_vars:
         if not isinstance(replace_env_vars, dict):
@@ -1960,7 +1962,9 @@ def update_env_vars(add_env_vars, replace_env_vars):
                 "The variable 'replace_env_vars' should be a dict with env vars."
             )
         LOG.debug(f"Replacing environment variables with: {replace_env_vars}")
-        return replace_env_vars
+        envvars = replace_env_vars
+
+    return envvars
 
 
 def _check_license_argument(license_type, additional_switches):

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -701,7 +701,9 @@ def _check_server_is_alive(stdout_queue, run_location, timeout):
             break
 
     else:
-        LOG.debug(f"MAPDL gRPC server didn't print any valid output:\n{terminal_output}")
+        LOG.debug(
+            f"MAPDL gRPC server didn't print any valid output:\n{terminal_output}"
+        )
         raise MapdlDidNotStart("MAPDL failed to start the gRPC server")
 
 

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -1770,6 +1770,9 @@ def launch_mapdl(
                     f"The machine has {machine_cores} cores. PyMAPDL is asking for {nproc} cores."
                 )
 
+    # Setting env vars
+    env_vars = update_env_vars(add_env_vars, replace_env_vars)
+
     start_parm.update(
         {
             "exec_file": exec_file,

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -256,7 +256,8 @@ def test_remove_temp_files_fail(tmpdir, mapdl):
 
 
 def test_env_injection():
-    assert update_env_vars(None, None) is None
+    no_inject = update_env_vars(None, None)
+    assert no_inject == os.environ.copy()  # return os.environ
 
     assert "myenvvar" in update_env_vars({"myenvvar": "True"}, None)
 


### PR DESCRIPTION
## Description
Explicitly using the current environment  (`os.environ.copy`) in the MAPDL process. This should fix some issues reported internally where MAPDL couldn't start because some env vars weren't being passed.

## Issue linked
NA

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)