### PR TITLE
ci: bypass team check if it is dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,6 +376,7 @@ jobs:
 
       - uses: tspascoal/get-user-teams-membership@v3
         id: is_organization_member
+        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           username: ${{ steps.get_user.outputs.user }}
           organization: ansys
@@ -385,7 +386,7 @@ jobs:
       - id: set-matrix
         env:
           extended_testing: ${{ github.event_name == 'schedule' || ( github.event_name == 'workflow_dispatch' && inputs.run_all_tests ) || ( github.event_name == 'push' && contains(github.ref, 'refs/tags') ) }}
-          auth_user: ${{ steps.is_organization_member.outputs.isTeamMember == 'true' }}
+          auth_user: ${{ steps.is_organization_member.outputs.isTeamMember == 'true' || github.actor == 'dependabot[bot]'  }}
         run: .ci/build_matrix.sh
 
   build-test-remote:
@@ -599,6 +600,7 @@ jobs:
 
       - uses: tspascoal/get-user-teams-membership@v3
         id: is_organization_member
+        if: ${{ github.actor != 'dependabot[bot]' }}
         with:
           username: ${{ github.actor }}
           organization: ansys
@@ -614,7 +616,7 @@ jobs:
           RUN_ALL_TEST: ${{ inputs.run_all_tests }}
           ON_PUSH: ${{ github.event_name == 'push' }}
           HAS_TAG: ${{ contains(github.ref, 'refs/tags') }}
-          auth_user: ${{ steps.is_organization_member.outputs.isTeamMember == 'true' }}
+          auth_user: ${{ steps.is_organization_member.outputs.isTeamMember == 'true' || github.actor == 'dependabot[bot]'  }}
         run: .ci/build_matrix.sh
 
   build-test-ubuntu-local:

--- a/doc/changelog.d/3472.maintenance.md
+++ b/doc/changelog.d/3472.maintenance.md
@@ -1,0 +1,1 @@
+ci: bypass team check if it is dependabot


### PR DESCRIPTION
## Description

With the new `ansys/actions` v8 (see #3470) I realised that dependabot cannot trigger the matrices because it is not part of any team, so that part of the action fails.

## Issue linked
Related to #3470

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)