### PR TITLE
feat: adding 'pymapdl_nproc' to non-slurm runs

### DIFF
--- a/doc/changelog.d/3487.miscellaneous.md
+++ b/doc/changelog.d/3487.miscellaneous.md
@@ -1,0 +1,1 @@
+feat: adding 'pymapdl_nproc' to non-slurm runs

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -2330,20 +2330,24 @@ def get_cpus(args: Dict[str, Any]):
 
     # Bypassing number of processors checks because VDI/VNC might have
     # different number of processors than the cluster compute nodes.
+    # Also the CPUs are set in `get_slurm_options`
     if args["ON_SLURM"]:
         return
 
     # Setting number of processors
     machine_cores = psutil.cpu_count(logical=False)
 
+    # Some machines only have 1 core
+    min_cpus = machine_cores if machine_cores < 2 else 2
+
     if not args["nproc"]:
-        # Some machines only have 1 core
-        args["nproc"] = machine_cores if machine_cores < 2 else 2
-    else:
-        if machine_cores < int(args["nproc"]):
-            raise NotEnoughResources(
-                f"The machine has {machine_cores} cores. PyMAPDL is asking for {args['nproc']} cores."
-            )
+        # Check the env var `PYMAPDL_NPROC`
+        args["nproc"] = int(os.environ.get("PYMAPDL_NPROC", min_cpus))
+
+    if machine_cores < int(args["nproc"]):
+        raise NotEnoughResources(
+            f"The machine has {machine_cores} cores. PyMAPDL is asking for {args['nproc']} cores."
+        )
 
 
 def remove_err_files(run_location, jobname):

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -44,6 +44,7 @@ from ansys.mapdl.core.launcher import (
     force_smp_in_student,
     generate_mapdl_launch_command,
     generate_start_parameters,
+    get_cpus,
     get_exec_file,
     get_run_location,
     get_slurm_options,
@@ -1112,3 +1113,35 @@ def test_launch_grpc(tmpdir):
     assert isinstance(kwags["stdin"], type(subprocess.DEVNULL))
     assert isinstance(kwags["stdout"], type(subprocess.PIPE))
     assert isinstance(kwags["stderr"], type(subprocess.PIPE))
+
+
+@patch("psutil.cpu_count", lambda *args, **kwags: 5)
+@pytest.mark.parametrize("arg", [None, 3, 10])
+@pytest.mark.parametrize("env", [None, 3, 10])
+def test_get_cpus(monkeypatch, arg, env):
+    if env:
+        monkeypatch.setenv("PYMAPDL_NPROC", env)
+
+    context = NullContext()
+    cores_machine = psutil.cpu_count(logical=False)  # it is patched
+
+    if (arg and arg > cores_machine) or (arg is None and env and env > cores_machine):
+        context = pytest.raises(NotEnoughResources)
+
+    args = {"nproc": arg, "ON_SLURM": False}
+    with context:
+        get_cpus(args)
+
+    if arg:
+        assert args["nproc"] == arg
+    elif env:
+        assert args["nproc"] == env
+    else:
+        assert args["nproc"] == 2
+
+
+@patch("psutil.cpu_count", lambda *args, **kwags: 1)
+def test_get_cpus_min():
+    args = {"nproc": None, "ON_SLURM": False}
+    get_cpus(args)
+    assert args["nproc"] == 1


### PR DESCRIPTION
## Description
Until now `PYMAPDL_NPROC` was only accepted when running on SLURM. With this PR, we also accept that env var for setting the number of cores in a normal run (no SLURM).

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)