### PR TITLE
fix: raising port busy when connecting

### DIFF
--- a/doc/changelog.d/3507.fixed.md
+++ b/doc/changelog.d/3507.fixed.md
@@ -1,0 +1,1 @@
+fix: raising port busy when connecting

--- a/src/ansys/mapdl/core/launcher.py
+++ b/src/ansys/mapdl/core/launcher.py
@@ -2069,7 +2069,7 @@ def get_port(port: Optional[int] = None, start_instance: Optional[bool] = None) 
             LOG.debug(f"Port in use.  Incrementing port number. port={port}")
 
     else:
-        if port_in_use(port):
+        if start_instance and port_in_use(port):
             proc = get_process_at_port(port)
             if proc:
                 if is_ansys_process(proc):


### PR DESCRIPTION
## Description
The following 

```py
from ansys.mapdl.core import launch_mapdl

mapdl = launch_mapdl(start_instance=False, port=50053)
```

was giving the error ``PortInUse``.

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [ ] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [ ] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [ ] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [ ] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [ ] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [ ] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [ ] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [ ] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)