### PR TITLE
chore: fix codecov.yml content

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,6 +7,7 @@ comment:
   layout: "diff"
   behavior: default
   require_changes: true  # Avoid coverage comment if no files are changed.
+  after_n_builds: 3
 
 coverage:
   range: 70..100
@@ -29,6 +30,4 @@ codecov:
   notify:
     wait_for_ci: yes
     # do not notify until at least 5 builds have been uploaded from the CI pipeline
-    after_n_builds: 3
-  comment:
     after_n_builds: 3

--- a/doc/changelog.d/3542.added.md
+++ b/doc/changelog.d/3542.added.md
@@ -1,0 +1,1 @@
+chore: fix codecov.yml content


### PR DESCRIPTION
## Description
While checking stuff in `PyAEDT` codecov result (use of multiple tags) I wanted to double check what was done in other repos. When checking the latest main's commit codecov I saw a warning, see below

![image](https://github.com/user-attachments/assets/e08b9b3a-76fa-4a6e-ab83-066ffc45e383)

This PR consists in fixing the "bug" that is reported by codecov.
To double check you can use the following command from the root of your repo
`curl -X POST --data-binary @codecov.yml https://codecov.io/validate`
Before the changes there is an error associated to "comment", now it's no longer present :)
