### PR TITLE
maint: remove importlib-metadata requirement

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
     package-ecosystem: "pip" # See documentation for possible values
     insecure-external-code-execution: allow
     schedule:
-      interval: "weekly"      
+      interval: "weekly"
       day: "friday"
       time: "00:00"
     labels:
@@ -34,7 +34,6 @@ updates:
        minimal:
           patterns:
             - "ansys-api-mapdl"
-            - "importlib-metadata"
             - "numpy"
             - "platformdirs"
             - "psutil"

--- a/doc/changelog.d/3546.documentation.md
+++ b/doc/changelog.d/3546.documentation.md
@@ -1,0 +1,1 @@
+[maint] remove importlib-metadata requirement

--- a/doc/source/examples/extended_examples/hpc/requirements.txt
+++ b/doc/source/examples/extended_examples/hpc/requirements.txt
@@ -16,7 +16,6 @@ fonttools==4.49.0
 geomdl==5.3.1
 grpcio==1.62.0
 idna==3.7.0
-importlib-metadata==7.0.1
 kiwisolver==1.4.5
 matplotlib==3.8.3
 numpy==1.26.4

--- a/doc/source/examples/extended_examples/hpc/requirements.txt
+++ b/doc/source/examples/extended_examples/hpc/requirements.txt
@@ -39,4 +39,3 @@ tabulate==0.9.0
 tqdm==4.66.3
 urllib3==2.2.2
 vtk==9.3.0
-zipp==3.19.1

--- a/minimum_requirements.txt
+++ b/minimum_requirements.txt
@@ -1,5 +1,4 @@
 ansys-api-mapdl==0.5.2
-importlib-metadata==8.5.0
 numpy==2.1.2
 platformdirs==4.3.6
 psutil==6.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = [
     "ansys-tools-path>=0.3.1",
     "click>=8.1.3", # for CLI interface
     "grpcio>=1.30.0",  # tested up to grpcio==1.35
-    "importlib-metadata>=4.0",
     "matplotlib>=3.0.0",  # for colormaps for pyvista
     "numpy>=1.14.0,<1.25.0; python_version < '3.9'",
     "numpy>=1.14.0,<3.0.0; python_version >= '3.9'",

--- a/src/ansys/mapdl/core/report.py
+++ b/src/ansys/mapdl/core/report.py
@@ -93,10 +93,7 @@ class Plain_Report:
             self.kwargs["extra_meta"] = ("GPU Details", "None")
 
     def get_version(self, package):
-        try:
-            import importlib.metadata as importlib_metadata
-        except ModuleNotFoundError:  # pragma: no cover
-            import importlib_metadata
+        import importlib.metadata as importlib_metadata
 
         try:
             return importlib_metadata.version(package.replace(".", "-"))


### PR DESCRIPTION
It should not be required anymore in the version range that we support (importlib.metadata is builtin now)