### PR TITLE
fix: avoid verbose grpc interface when solving

### DIFF
--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -2216,6 +2216,8 @@ class _MapdlCore(Commands):
 
         command = command.strip()
 
+        is_comment = command.startswith("!") or command.upper().startswith("/COM")
+
         # always reset the cache
         self._reset_cache()
 
@@ -2261,7 +2263,7 @@ class _MapdlCore(Commands):
             # simply return the contents of the file
             return self.list(*command.split(",")[1:])
 
-        if "=" in command:
+        if "=" in command and not is_comment:
             # We are storing a parameter.
             param_name = command.split("=")[0].strip()
 
@@ -2867,11 +2869,6 @@ class _MapdlCore(Commands):
                 else:
                     # Catching only the first error.
                     error_message = error_message.group(0)
-
-                # Trimming empty lines
-                error_message = "\n".join(
-                    [each for each in error_message.splitlines() if each]
-                )
 
                 # Trimming empty lines
                 error_message = "\n".join(

--- a/src/ansys/mapdl/core/mapdl_extended.py
+++ b/src/ansys/mapdl/core/mapdl_extended.py
@@ -2123,15 +2123,6 @@ class _MapdlCommandExtended(_MapdlCore):
 
         return ComponentListing(super().cmlist(*args, **kwargs))
 
-    @wraps(_MapdlCore.solve)
-    def solve(self, action="", **kwargs):
-        self._ctrl("set_verb", 0)
-        if hasattr(self, "logger") and self.logger is not None:
-            self.logger.debug("Disabling gRPC logging when solving")
-
-        # TODO: Implement a get verbose option on server side
-        return super().solve(action=action, **kwargs)
-
 
 class _MapdlExtended(_MapdlCommandExtended):
     """Extend Mapdl class with new functions"""

--- a/src/ansys/mapdl/core/mapdl_extended.py
+++ b/src/ansys/mapdl/core/mapdl_extended.py
@@ -2123,6 +2123,15 @@ class _MapdlCommandExtended(_MapdlCore):
 
         return ComponentListing(super().cmlist(*args, **kwargs))
 
+    @wraps(_MapdlCore.solve)
+    def solve(self, action="", **kwargs):
+        self._ctrl("set_verb", 0)
+        if hasattr(self, "logger") and self.logger is not None:
+            self.logger.debug("Disabling gRPC logging when solving")
+
+        # TODO: Implement a get verbose option on server side
+        return super().solve(action=action, **kwargs)
+
 
 class _MapdlExtended(_MapdlCommandExtended):
     """Extend Mapdl class with new functions"""

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1614,6 +1614,11 @@ class MapdlGrpc(MapdlBase):
             return
 
         resp = self._stub.Ctrl(request)
+
+        if cmd.lower() == "set_verb" and str(opt1) == "0":
+            warn("Disabling gRPC verbose ('_ctr') by issuing also '/VERIFY' command.")
+            self.run("/verify")
+
         if hasattr(resp, "response"):
             return resp.response
 

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -931,7 +931,8 @@ class MapdlGrpc(MapdlBase):
     def _run_at_connect(self):
         """Run house-keeping commands when initially connecting to MAPDL."""
         # increase the number of variables allowed in POST26 to the maximum
-        self._run("/verify", mute=True)
+        with self.run_as_routine("Begin level"):
+            self._run("/verify", mute=False)
 
         with self.run_as_routine("POST26"):
             self.numvar(200, mute=True)

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -931,6 +931,8 @@ class MapdlGrpc(MapdlBase):
     def _run_at_connect(self):
         """Run house-keeping commands when initially connecting to MAPDL."""
         # increase the number of variables allowed in POST26 to the maximum
+        self._run("/verify", mute=True)
+
         with self.run_as_routine("POST26"):
             self.numvar(200, mute=True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -437,6 +437,8 @@ def run_before_and_after_tests(
 
     yield  # this is where the testing happens
 
+    mapdl.prep7()
+
     # Check resetting state
     assert prev == mapdl.is_local
     assert not mapdl.exited, "MAPDL is exited after the test. It should have not!"

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -2428,11 +2428,6 @@ def test_not_correct_et_element(mapdl, cleared):
         mapdl.keyopt(1, 222)
 
 
-def test_ctrl(mapdl, cleared):
-    mapdl._ctrl("set_verb", 5)  # Setting verbosity on the server
-    mapdl._ctrl("set_verb", 0)  # Returning to non-verbose
-
-
 def test_cleanup_loggers(mapdl, cleared):
     assert mapdl.logger is not None
     assert mapdl.logger.hasHandlers()

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -2436,6 +2436,7 @@ def test_ctrl(mapdl, cleared):
 
         assert "/verify" in mck_run.call_args_list[0].args[0]
 
+    mapdl.finish()
     mapdl.run("/verify")  # mocking might skip running this inside mapdl._ctrl
 
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -2428,6 +2428,17 @@ def test_not_correct_et_element(mapdl, cleared):
         mapdl.keyopt(1, 222)
 
 
+def test_ctrl(mapdl, cleared):
+    with patch("ansys.mapdl.core.mapdl_grpc.MapdlGrpc.run") as mck_run:
+
+        mapdl._ctrl("set_verb", 5)  # Setting verbosity on the server
+        mapdl._ctrl("set_verb", 0)  # Returning to non-verbose
+
+        assert "/verify" in mck_run.call_args_list[0].args[0]
+
+    mapdl.run("/verify")  # mocking might skip running this inside mapdl._ctrl
+
+
 def test_cleanup_loggers(mapdl, cleared):
     assert mapdl.logger is not None
     assert mapdl.logger.hasHandlers()


### PR DESCRIPTION
## Description
This PR solves #3591 issue. This issue covers the instability/bug seen where MAPDL gets stuck while running some commands, very frequently, the `/SOLVE` command.

The reason for this is that some MAPDL printouts was making MAPDL to wait infinitely for the next line.
These specific prints in MAPDL terminal were coming from a debug messenger (``_MsgDbg1``), an object which prints more output (sometimes for debugging purposes) if it is activated.
It seems this debug messenger is activated by default, but deactivated if we issue `/VERIFY`.
Additionally, the debugger can be also activated if we activate the gRPC debug messenger (``mapdl._ctrl("set_verb", 5)``) since these kind of messengers are singleton objects (unique in the whole program).

MAPDL was getting stuck because for reading the ``anstmp`` file, it uses [``std:getline``](https://en.cppreference.com/w/cpp/string/basic_string/getline)  (only!), hence if the line is empty, the ``getline`` waits forever. See https://stackoverflow.com/a/39905660/6650211

Until now, we did not realise because the first test running solve:

https://github.com/ansys/pymapdl/blob/afad43efc8b5ea0bac4f71d9a462e08a1071259a/tests/test_commands.py#L252-L265

was using this fixture:

https://github.com/ansys/pymapdl/blob/afad43efc8b5ea0bac4f71d9a462e08a1071259a/tests/test_commands.py#L147-L153

Which a verification manual example, which uses `/VERIFY`.
The command `/VERIFY` avoid printing these extra debug printouts.

Clearly this is a server side bug which should be fixed in the future versions. But for the moment, I am going to force MAPDL to run `/VERIFY` when we instantiate the object.

## Issue linked
Related to #3591


## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)