### PR TITLE
test: adding tests asserting None are translated to "None".

### DIFF
--- a/doc/changelog.d/3694.added.md
+++ b/doc/changelog.d/3694.added.md
@@ -1,0 +1,1 @@
+test: adding tests asserting None are translated to "None".

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -2609,3 +2609,36 @@ def test_comment_on_debug_mode(mapdl, cleared):
     mockcom.assert_called_once_with("Entering in non_interactive mode")
 
     mapdl.logger.logger.level = loglevel
+
+
+@pytest.mark.parametrize(
+    "cmd,arg",
+    (
+        ("block", None),
+        ("nsel", None),
+        ("modopt", None),
+    ),
+)
+def test_none_as_argument(mapdl, cmd, arg):
+    with patch.object(mapdl, "_run") as mock_run:
+        func = getattr(mapdl, cmd)
+        out = func(arg)
+
+        if "sel" in cmd:
+            assert isinstance(out, np.ndarray)
+            assert len(out) == 0
+
+        cmd = mock_run.call_args.args[0]
+
+        assert isinstance(cmd, str)
+        assert "NONE" in cmd.upper()
+
+
+@pytest.mark.parametrize("func", ["ksel", "lsel", "asel", "vsel"])
+def test_none_on_selecting(mapdl, cleared, func):
+    mapdl.block(0, 1, 0, 1, 0, 1)
+
+    selfunc = getattr(mapdl, func)
+
+    assert len(selfunc("all")) > 0
+    assert len(selfunc(None)) == 0


### PR DESCRIPTION
## Description
Adding tests to make sure the conversion `None` to `"None"` is correct.

## Issue linked
Close #3660

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)