### PR TITLE
feat: improving performance of save_selection

### DIFF
--- a/.ci/start_mapdl.sh
+++ b/.ci/start_mapdl.sh
@@ -52,6 +52,6 @@ docker run \
     -u=0:0 \
     --memory=6656MB \
     --memory-swap=16896MB \
-    "$MAPDL_IMAGE" "$EXEC_PATH" -grpc -dir /jobs -"$DISTRIBUTED_MODE" -np 2 > log.txt &
+    "$MAPDL_IMAGE" "$EXEC_PATH" -grpc -dir /jobs -"$DISTRIBUTED_MODE" -np 2 -db -5000 -m -5000 - > log.txt &
 
 grep -q 'Server listening on' <(timeout 60 tail -f log.txt)

--- a/doc/changelog.d/3693.maintenance.md
+++ b/doc/changelog.d/3693.maintenance.md
@@ -1,0 +1,1 @@
+ci: adding memory limitation to MAPDL command line

--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -1458,7 +1458,9 @@ class _MapdlCore(Commands):
             for each_type, each_name in _TMP_COMP.items():
                 each_name = f"__{each_name}{id_}__"
                 selection[each_type] = each_name
-                mapdl.cm(each_name, each_type)
+                mapdl.cm(
+                    each_name, each_type, mute=True
+                )  # to hide ComponentNoData error
 
             self.selection.append(selection)
 
@@ -1474,17 +1476,17 @@ class _MapdlCore(Commands):
 
             if cmps:
                 for each_name, each_value in cmps.items():
-                    mapdl.cmsel("a", each_name, each_value)
+                    mapdl.cmsel("a", each_name, each_value, mute=True)
 
             for each_type, each_name in selection.items():
-                mapdl.cmsel("a", each_name, each_type)
+                mapdl.cmsel("a", each_name, each_type, mute=True)
 
                 selfun = getattr(
                     mapdl, ENTITIES_TO_SELECTION_MAPPING[each_type.upper()]
                 )
-                selfun("s", vmin=each_name)
+                selfun("s", vmin=each_name, mute=True)
 
-                mapdl.cmdele(each_name)
+                mapdl.cmdele(each_name, mute=True)
 
     class _chain_commands:
         """Store MAPDL commands and send one chained command."""

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -2217,7 +2217,6 @@ def test_save_selection_2(mapdl, cleared, make_block):
     mapdl.nsel(vmin=n1)
     assert n1 in mapdl.mesh.nnum
     mapdl.cm("nodes_cm", "NODE")
-    mapdl.components["nodes_cm"]
     assert "nodes_cm" in mapdl.components
     assert n1 in mapdl.components["nodes_cm"].items
     assert "NODE" == mapdl.components["nodes_cm"].type
@@ -2226,7 +2225,6 @@ def test_save_selection_2(mapdl, cleared, make_block):
     mapdl.esel(vmin=e1)
     assert e1 in mapdl.mesh.enum
     mapdl.cm("elem_cm", "ELEM")
-    mapdl.components["elem_cm"]
     assert "elem_cm" in mapdl.components
     assert e1 in mapdl.components["elem_cm"].items
     assert "ELEM" == mapdl.components["elem_cm"].type
@@ -2235,7 +2233,6 @@ def test_save_selection_2(mapdl, cleared, make_block):
     mapdl.ksel(vmin=kp1)
     assert kp1 in mapdl.geometry.knum
     mapdl.cm("kp_cm", "kp")
-    mapdl.components["kp_cm"]
     assert "kp_cm" in mapdl.components
     assert kp1 in mapdl.components["kp_cm"].items
     assert "KP" == mapdl.components["kp_cm"].type
@@ -2244,7 +2241,6 @@ def test_save_selection_2(mapdl, cleared, make_block):
     mapdl.lsel(vmin=l1)
     assert l1 in mapdl.geometry.lnum
     mapdl.cm("line_cm", "line")
-    mapdl.components["line_cm"]
     assert "line_cm" in mapdl.components
     assert l1 in mapdl.components["line_cm"].items
     assert "LINE" == mapdl.components["line_cm"].type

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -2112,7 +2112,7 @@ def test_components_selection_keep_between_plots(mapdl, cube_solve):
     assert "mycm" in mapdl.components
 
 
-def test_saving_selection_context(mapdl, cube_solve):
+def test_save_selection_1(mapdl, cube_solve):
     mapdl.allsel()
 
     for i in range(1, 4):
@@ -2208,6 +2208,112 @@ def test_saving_selection_context(mapdl, cube_solve):
 
     assert "nod_selection_4".upper() not in mapdl.cmlist()
     assert "nod_selection_4" not in mapdl.components
+
+
+def test_save_selection_2(mapdl, cleared, make_block):
+    from ansys.mapdl.core.mapdl_core import _TMP_COMP
+
+    n1 = 1
+    mapdl.nsel(vmin=n1)
+    assert n1 in mapdl.mesh.nnum
+    mapdl.cm("nodes_cm", "NODE")
+    mapdl.components["nodes_cm"]
+    assert "nodes_cm" in mapdl.components
+    assert n1 in mapdl.components["nodes_cm"].items
+    assert "NODE" == mapdl.components["nodes_cm"].type
+
+    e1 = 1
+    mapdl.esel(vmin=e1)
+    assert e1 in mapdl.mesh.enum
+    mapdl.cm("elem_cm", "ELEM")
+    mapdl.components["elem_cm"]
+    assert "elem_cm" in mapdl.components
+    assert e1 in mapdl.components["elem_cm"].items
+    assert "ELEM" == mapdl.components["elem_cm"].type
+
+    kp1 = 1
+    mapdl.ksel(vmin=kp1)
+    assert kp1 in mapdl.geometry.knum
+    mapdl.cm("kp_cm", "kp")
+    mapdl.components["kp_cm"]
+    assert "kp_cm" in mapdl.components
+    assert kp1 in mapdl.components["kp_cm"].items
+    assert "KP" == mapdl.components["kp_cm"].type
+
+    l1 = 1
+    mapdl.lsel(vmin=l1)
+    assert l1 in mapdl.geometry.lnum
+    mapdl.cm("line_cm", "line")
+    mapdl.components["line_cm"]
+    assert "line_cm" in mapdl.components
+    assert l1 in mapdl.components["line_cm"].items
+    assert "LINE" == mapdl.components["line_cm"].type
+
+    a1 = 1
+    mapdl.asel(vmin=a1)
+    assert a1 in mapdl.geometry.anum
+    mapdl.cm("area_cm", "area")
+    assert "area_cm" in mapdl.components
+    assert a1 in mapdl.components["area_cm"].items
+    assert "AREA" == mapdl.components["area_cm"].type
+
+    # Assert we have properly set the components
+    assert {
+        "AREA_CM": "AREA",
+        "ELEM_CM": "ELEM",
+        "KP_CM": "KP",
+        "LINE_CM": "LINE",
+        "NODES_CM": "NODE",
+    } == mapdl.components._comp
+
+    # additional changes to the selections
+    kpoints = mapdl.ksel("u", vmin=1)
+    lines = mapdl.lsel("a", vmin=[2, 5, 6])
+    areas = mapdl.asel("a", vmin=2)
+    nodes = mapdl.nsel("S", vmin=[4, 5])
+    elem = mapdl.esel("s", vmin=[1, 3])
+
+    # checking all the elements are correct
+    assert np.allclose(kpoints, mapdl.geometry.knum)
+    assert np.allclose(lines, mapdl.geometry.lnum)
+    assert np.allclose(areas, mapdl.geometry.anum)
+    assert np.allclose(nodes, mapdl.mesh.nnum)
+    assert np.allclose(elem, mapdl.mesh.enum)
+
+    ## storing... __enter__
+    comp_selection = mapdl.components._comp
+
+    print("Starting...")
+    with mapdl.save_selection:
+
+        # do something
+        mapdl.allsel()
+        mapdl.cmsel("NONE")
+        mapdl.asel("NONE")
+        mapdl.nsel("s", vmin=[1, 2, 8, 9])
+        mapdl.allsel()
+        mapdl.vsel("none")
+        mapdl.lsel("a", vmin=[9])
+        mapdl.vsel("all")
+        mapdl.ksel("none")
+
+    # checks
+    assert np.allclose(kpoints, mapdl.geometry.knum)
+    assert np.allclose(lines, mapdl.geometry.lnum)
+    assert np.allclose(areas, mapdl.geometry.anum)
+    assert np.allclose(nodes, mapdl.mesh.nnum)
+    assert np.allclose(elem, mapdl.mesh.enum)
+
+    for each_key, each_value in comp_selection.items():
+        assert (
+            each_key in mapdl.components
+        ), f"Component '{each_key}' is not defined/selected"
+        assert (
+            each_value == mapdl.components[each_key].type
+        ), f"Component '{each_key}' type is not correct"
+
+    for each_tmp in _TMP_COMP.values():
+        assert each_tmp not in mapdl.components
 
 
 def test_inquire_invalid(mapdl, cleared):


### PR DESCRIPTION
## Description
As the title. By using components instead of retrieving all entity ids, we speed up the process.

Previous implementation used `XSEL` functions to set the retrieved ids of the entities. While this was OK, it incurs in performance penalization because it has to write a file (sometimes quite big), transfer it and run it using `non_interactive`. Because of the amount of `XSEL,A,...` lines, this might posed a problem with the infamous gRPC instability (#3313).

I think the thorough testing should be sufficient to ensure we do not hit issues like https://github.com/ansys/pymapdl/issues/3372 or https://github.com/ansys/pymapdl/issues/2452
However can @mikerife have a look at the `test_save_selection_2` code and see if I am missing something?

## Benchmark

Testing code is `test_save_selection_2`.
```
# For 1 million elements
tmp_old.py -> Time spent: 1.423482750004041
tmp_old.py -> Time spent: 1.287161833999562
tmp_new.py -> Time spent: 0.10543733399754274
tmp_new.py -> Time spent: 0.11288025000612834
```

## Issue linked
Close #3695

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)