### PR TITLE
fix: Bug located in VSEL using KSWP field

### DIFF
--- a/doc/changelog.d/3753.fixed.md
+++ b/doc/changelog.d/3753.fixed.md
@@ -1,0 +1,1 @@
+fix: Bug located in VSEL using KSWP field

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -470,7 +470,7 @@ def _get_args_xsel(*args: Tuple[str], **kwargs: Dict[str, str]) -> Tuple[str]:
     vmin = kwargs.pop("vmin", args[3] if len(args) > 3 else "")
     vmax = kwargs.pop("vmax", args[4] if len(args) > 4 else "")
     vinc = kwargs.pop("vinc", args[5] if len(args) > 5 else "")
-    kabs = kwargs.pop("kabs", args[6] if len(args) > 6 else "")
+    kabs = kwargs.pop("kabs", kwargs.pop("kswp", args[6] if len(args) > 6 else ""))
     return type_, item, comp, vmin, vmax, vinc, kabs, kwargs
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -938,10 +938,14 @@ def test_asel_iterable(mapdl, make_block):
     )
 
 
-def test_vsel_iterable(mapdl, make_block):
+def test_vsel_iterable_and_kswp(mapdl, make_block):
     mapdl.run("VGEN, 5, 1, , , 100, , , , , ")
     assert np.allclose(
         mapdl.vsel("S", "volu", "", [1, 2, 4], "", ""), np.array([1, 2, 4])
+    )
+    mapdl.vsel("S", "volu", "", [1], "", "", kswp=1)
+    assert np.allclose(mapdl.geometry.vnum, [1]) and np.allclose(
+        mapdl.geometry.anum, [1, 2, 3, 4, 5, 6]
     )
 
 


### PR DESCRIPTION
## Description
**Please provide a brief description of the changes made in this pull request.**
Fix for #3349 

1. ksel, esel, nsel uses kabs (for field 7)
2. lsel, asel, vsel uses kswp (for field 7)

Wrappers on vsel and other related cmds - like `@allow_pickable_entities` use `_get_args_xsel` to get the args passed. This function currently accounts only for `kabs` , added logic for `kswp`. 

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**
#3349 

## Checklist
- [X] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [X] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [X] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [X] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [X] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [X] I have reviewed my changes before submitting this pull request.
- [X] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [X] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [X] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)