### PR TITLE
fix: removig star from command name in changelog

### DIFF
--- a/doc/changelog.d/3758.fixed.md
+++ b/doc/changelog.d/3758.fixed.md
@@ -1,1 +1,1 @@
-fix: Improve error handling in *GET method and enhance output logging
+fix: Improve error handling in GET method and enhance output logging

--- a/doc/changelog.d/3769.fixed.md
+++ b/doc/changelog.d/3769.fixed.md
@@ -1,0 +1,1 @@
+fix: removig star from command name in changelog


### PR DESCRIPTION
## Description
As the title.

## Issue linked
Fix release issue.
