### PR TITLE
hold the bc settings per plotter instance

### DIFF
--- a/doc/changelog.d/3897.miscellaneous.md
+++ b/doc/changelog.d/3897.miscellaneous.md
@@ -1,0 +1,1 @@
+hold the bc settings per plotter instance

--- a/src/ansys/mapdl/core/plotting/visualizer.py
+++ b/src/ansys/mapdl/core/plotting/visualizer.py
@@ -51,16 +51,12 @@ if _HAS_VISUALIZER:
 
 def _first_use():
     # Run first time we use the visualizer
-    global BC_plot_settings
     global _FIRST_USE_RUN
     if _FIRST_USE_RUN is True:
         return
     if _HAS_VISUALIZER:
-        from ansys.mapdl.core.plotting.plotting_defaults import DefaultSymbol
         from ansys.mapdl.core.plotting.theme import _apply_default_theme
-
         _apply_default_theme()
-        BC_plot_settings = DefaultSymbol()
     _FIRST_USE_RUN = True
 
 
@@ -138,6 +134,17 @@ class MapdlPlotter(Plotter):
         self._notebook = None
         self._savefig = None
         self._title = None
+        self._bc_settings = None
+
+    @property
+    def bc_settings(self):
+        if self._bc_settings is None:
+            self._make_bc_settings()
+        return self._bc_settings
+
+    def _make_bc_settings(self):
+        from ansys.mapdl.core.plotting.plotting_defaults import DefaultSymbol
+        self._bc_settings = DefaultSymbol()
 
     def _bc_labels_checker(self, bc_labels):
         """Make sure we have allowed parameters and data types for ``bc_labels``"""
@@ -601,13 +608,13 @@ class MapdlPlotter(Plotter):
                 orient=False,
                 scale="scale",
                 # tolerance=0.05,
-                geom=BC_plot_settings(each_label)["glyph"],
+                geom=self.bc_settings(each_label)["glyph"],
             )
             name_ = f"{each_label}"
             self.scene.add_mesh(
                 glyphs,
                 # name_filter=None,
-                color=BC_plot_settings(each_label)["color"],
+                color=self.bc_settings(each_label)["color"],
                 style="surface",
                 # style='wireframe',
                 # line_width=3,
@@ -658,11 +665,11 @@ class MapdlPlotter(Plotter):
                     # something it can be seen properly in the legend
                     label_ = value[1]
                     if "U" in label_:
-                        value = [BC_plot_settings("UY")["glyph"], label_, value[2]]
+                        value = [self.bc_settings("UY")["glyph"], label_, value[2]]
                     elif "F" in label_:
-                        value = [BC_plot_settings("FX")["glyph"], label_, value[2]]
+                        value = [self.bc_settings("FX")["glyph"], label_, value[2]]
                     else:
-                        value = [BC_plot_settings(label_)["glyph"], label_, value[2]]
+                        value = [self.bc_settings(label_)["glyph"], label_, value[2]]
 
                     if symbol == value[1]:
                         sorted_dict[key] = value

--- a/src/ansys/mapdl/core/plotting/visualizer.py
+++ b/src/ansys/mapdl/core/plotting/visualizer.py
@@ -56,6 +56,7 @@ def _first_use():
         return
     if _HAS_VISUALIZER:
         from ansys.mapdl.core.plotting.theme import _apply_default_theme
+
         _apply_default_theme()
     _FIRST_USE_RUN = True
 
@@ -144,6 +145,7 @@ class MapdlPlotter(Plotter):
 
     def _make_bc_settings(self):
         from ansys.mapdl.core.plotting.plotting_defaults import DefaultSymbol
+
         self._bc_settings = DefaultSymbol()
 
     def _bc_labels_checker(self, bc_labels):


### PR DESCRIPTION
## Summary by Sourcery

Modify the visualizer to hold BC (boundary condition) settings per plotter instance instead of using a global variable

Enhancements:
- Refactor BC plot settings to be instance-specific instead of global
- Add a lazy-loaded bc_settings property to the visualizer class