### PR TITLE
fix: Change the mapdl_inprocess graphics backend

### DIFF
--- a/doc/changelog.d/3915.fixed.md
+++ b/doc/changelog.d/3915.fixed.md
@@ -1,1 +1,1 @@
-fix: Do not throw when using the in-process backend
+fix: Change the mapdl_inprocess graphics backend

--- a/doc/changelog.d/3915.fixed.md
+++ b/doc/changelog.d/3915.fixed.md
@@ -1,0 +1,1 @@
+fix: Do not throw when using the in-process backend

--- a/src/ansys/mapdl/core/mapdl_inprocess.py
+++ b/src/ansys/mapdl/core/mapdl_inprocess.py
@@ -46,7 +46,7 @@ class MapdlInProcess(MapdlBase):
     def __init__(self, in_process_backend: _Backend):
         super().__init__(
             loglevel="WARNING",
-            graphics_backend=GraphicsBackend.MAPDL,
+            graphics_backend=None,
             log_apdl=None,
             print_com=False,
         )

--- a/src/ansys/mapdl/core/mapdl_inprocess.py
+++ b/src/ansys/mapdl/core/mapdl_inprocess.py
@@ -23,7 +23,6 @@
 from typing import Protocol
 
 from ansys.mapdl.core.mapdl import MapdlBase
-from ansys.mapdl.core.plotting import GraphicsBackend
 
 
 class _Backend(Protocol):


### PR DESCRIPTION
Fixes #3916

`mapdl_inprocess` should use `None` for graphics backend. This will have to be revisited with some automated tests when 2025R2 is released.
