### PR TITLE
fix: MapdlRuntimeError message in ``cwd``

### DIFF
--- a/doc/changelog.d/3938.fixed.md
+++ b/doc/changelog.d/3938.fixed.md
@@ -1,0 +1,1 @@
+fix: MapdlRuntimeError message in ``cwd``

--- a/src/ansys/mapdl/core/_commands/session/run_controls.py
+++ b/src/ansys/mapdl/core/_commands/session/run_controls.py
@@ -167,7 +167,7 @@ class RunControls:
         dirpath = str(dirpath)
         if not (dirpath.startswith("'") and dirpath.endswith("'")) and "'" in dirpath:
             raise MapdlRuntimeError(
-                'The CWD command does not accept paths that contain singular quotes "'
+                'The CWD command does not accept paths that contain singular quotes "\'".'
             )
         return self.run(f"/CWD,'{dirpath}'", **kwargs)
 


### PR DESCRIPTION
This follows @germa89's comment on https://github.com/ansys/pymapdl/pull/3895/files/d7e2653d9a2adac4b05bc528d2495f6920c8e752#r2075315154

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)

## Summary by Sourcery

Bug Fixes:
- Update MapdlRuntimeError message to properly escape inner single quotes in CWD paths