### PR TITLE
fix: migrator secret escaping

### DIFF
--- a/.github/workflows/migrator.yml
+++ b/.github/workflows/migrator.yml
@@ -354,7 +354,7 @@ jobs:
         if : ${{ env.CONTINUE == 'true' }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}
+          github-token: "${{ secrets.PYANSYS_CI_BOT_TOKEN }}"
           script: |
             const prNumber = process.env.PR_NUMBER;
             const prHeadBranch = process.env.PR_HEAD_BRANCH;
@@ -393,7 +393,7 @@ jobs:
               debug: true,
               head: prBaseBranch,  // This is the branch we just created which becomes now the head of the PR, and the base (target) branch is the main branch.
               base: 'main',
-              title: `chore: [migrated PR ${prNumber}] ${originalPR.title}`,
+              title: `migrated (PR ${prNumber}): ${originalPR.title}`,
               body: `This PR is a mirror pull request created from [${originalPR.title}](https://github.com/ansys/pymapdl/pull/${originalPR.number}) to allow the code to access PyMAPDL CICD secrets.
 
             Check the [original PR](https://github.com/ansys/pymapdl/pull/${originalPR.number}) made by @${originalPR.user.login} for more details.
@@ -444,7 +444,8 @@ jobs:
             });
 
       - name: Create comment about failed migration
-        if: ${{ failure() }}
+        # Not creating more failure comments if the workflow is retried
+        if: ${{ failure() && github.run_attempt == 1 }}
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}

--- a/doc/changelog.d/4012.fixed.md
+++ b/doc/changelog.d/4012.fixed.md
@@ -1,0 +1,1 @@
+Fix: migrator secret escaping


### PR DESCRIPTION
## Description
Fix migrator secret escaping, PR title and not commenting when re-running

## Issue linked
Related to failure to migrate #4009 however I am not sure this should fix it.

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)

## Summary by Sourcery

Fix secret escaping in the migrator workflow, standardize the migrated PR title format, and limit failure comments to the first run attempt.

CI:
- Quote the CI bot token to ensure proper secret escaping in the migrator workflow.
- Standardize the migrated PR title to use the format "migrated (PR #): <original title>".
- Restrict failure comment creation to only the first workflow run to avoid duplicates on retries.