### PR TITLE
feat: improving inquire

### DIFF
--- a/doc/changelog.d/4030.miscellaneous.md
+++ b/doc/changelog.d/4030.miscellaneous.md
@@ -1,0 +1,1 @@
+Fix: (migrated pr 4027): added missing kwargs to the dmpoption command.

--- a/src/ansys/mapdl/core/_commands/solution/analysis_options.py
+++ b/src/ansys/mapdl/core/_commands/solution/analysis_options.py
@@ -1253,7 +1253,7 @@ class AnalysisOptions:
         command = f"DMPEXT,{smode},{tmode},{dmpname},{freqb},{freqe},{nsteps}"
         return self.run(command, **kwargs)
 
-    def dmpoption(self, filetype="", combine="", **kwargs):
+    def dmpoption(self, filetype="", combine="", rescombfreq="", deleopt="", **kwargs):
         """Specifies distributed memory parallel (Distributed ANSYS) file
 
         APDL Command: DMPOPTION
@@ -1290,6 +1290,22 @@ class AnalysisOptions:
             Yes - Combine solution files (default).
 
             No - Do not combine solution files.
+
+        rescombfreq
+            Frequency used to combine the local results files during a distributed memory parallel solution. This option applies only when FileType = RST and Combine = YES.
+
+            NONE - Do not combine the local results files during solution. The local results files is combined only upon leaving the solution processor (default).
+
+            ALL - Combines the local results files at every time point.
+
+            LAST - Combines the local results files at the last time point of every load step.
+
+        deleopt
+            Option to delete local solution files of the type specified by FileType option after they are combined. This option applies only when Combine = Yes.
+
+            Yes - Delete the local solution files after they are combined.
+
+            No - Do not delete the local solution files after they are combined (default).
 
         Notes
         -----
@@ -1350,7 +1366,7 @@ class AnalysisOptions:
         a subsequent analysis. In this case, use the COMBINE command to combine
         local solution files into a single, global file.
         """
-        command = f"DMPOPTION,{filetype},{combine}"
+        command = f"DMPOPTION,{filetype},{combine}{rescombfreq},{deleopt}"
         return self.run(command, **kwargs)
 
     def dspoption(

--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -2329,7 +2329,7 @@ class _MapdlCore(Commands):
             # We are storing a parameter.
             param_name = command.split("=")[0].strip()
 
-            if "/COM" not in cmd_ and "/TITLE" not in cmd_:
+            if cmd_[:4].upper() not in ["/COM", "/TITLE", "/SYS"]:
                 # Edge case. `\title, 'par=1234' `
                 self._check_parameter_name(param_name)
 

--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -2329,7 +2329,7 @@ class _MapdlCore(Commands):
             # We are storing a parameter.
             param_name = command.split("=")[0].strip()
 
-            if cmd_[:4].upper() not in ["/COM", "/TITLE", "/SYS"]:
+            if cmd_[:4].upper() not in ["/COM", "/TIT", "/SYS"]:
                 # Edge case. `\title, 'par=1234' `
                 self._check_parameter_name(param_name)
 

--- a/src/ansys/mapdl/core/mapdl_extended.py
+++ b/src/ansys/mapdl/core/mapdl_extended.py
@@ -1459,9 +1459,24 @@ class _MapdlCommandExtended(_MapdlCore):
         ]:  # the output is multiline, we just need the last line.
             response = response.splitlines()[-1]
 
-            response = response.split("=")[1].strip()
+        response = response.split("=")[1].strip()
 
-        return response
+        # Check if the function is to check existence
+        # so it makes sense to return a boolean
+        if func.upper() in ["EXIST", "WRITE", "READ", "EXEC"]:
+            if "1.0" in response:
+                return True
+            elif "0.0" in response:
+                return False
+            else:
+                raise MapdlRuntimeError(
+                    f"Unexpected output from 'mapdl.inquire' function:\n{response}"
+                )
+
+        try:
+            return float(response)
+        except ValueError:
+            return response
 
     @wraps(_MapdlCore.parres)
     def parres(self, lab="", fname="", ext="", **kwargs):

--- a/src/ansys/mapdl/core/mapdl_extended.py
+++ b/src/ansys/mapdl/core/mapdl_extended.py
@@ -1449,12 +1449,15 @@ class _MapdlCommandExtended(_MapdlCore):
         if not response:
             if not self._store_commands:
                 raise MapdlRuntimeError("/INQUIRE command didn't return a response.")
-        else:
-            if func.upper() in [
-                "ENV",
-                "TITLE",
-            ]:  # the output is multiline, we just need the last line.
-                response = response.splitlines()[-1]
+            else:
+                # Exit since we are in non-interactive mode
+                return None
+
+        if func.upper() in [
+            "ENV",
+            "TITLE",
+        ]:  # the output is multiline, we just need the last line.
+            response = response.splitlines()[-1]
 
             response = response.split("=")[1].strip()
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1235,23 +1235,17 @@ def test_cwd(mapdl, cleared, tmpdir):
     mapdl.slashdelete("anstmp")
 
 
-@requires("nocicd")
-@requires("local")
 def test_inquire(mapdl, cleared):
     # Testing basic functions (First block: Functions)
     assert "apdl" in mapdl.inquire("", "apdl").lower()
 
     # **Returning the Value of an Environment Variable to a Parameter**
-    env = list(os.environ.keys())[0]
-    if os.name == "nt":
-        env_value = os.getenv(env).split(";")[0]
-    elif os.name == "posix":
-        env_value = os.getenv(env).split(":")[0]
+    if mapdl.platform == "linux":
+        name, value = mapdl.sys(f"printenv").splitlines()[0].split("=")
     else:
-        raise Exception("Not supported OS.")
+        pytest.skip(f"Platform {mapdl.platform} not supported")
 
-    env_ = mapdl.inquire("", "ENV", env, 0)
-    assert env_ == env_value
+    assert value == mapdl.inquire("", "ENV", name, 0)
 
     # **Returning the Value of a Title to a Parameter**
     title = "This is the title"
@@ -1260,8 +1254,17 @@ def test_inquire(mapdl, cleared):
 
     # **Returning Information About a File to a Parameter**
     jobname = mapdl.inquire("", "jobname")
-    assert isinstance(mapdl.inquire("", "exist", jobname + ".lock"), bool)
-    assert isinstance(mapdl.inquire("", "exist", jobname, "lock"), bool)
+    existing_file = mapdl.list_files()[0]
+
+    assert isinstance(mapdl.inquire("", "exist", existing_file), bool)
+    assert isinstance(mapdl.inquire("", "exist", "unexisting_file.myext"), bool)
+
+    assert mapdl.inquire("", "exist", existing_file)
+    assert not mapdl.inquire("", "exist", "unexisting_file.myext")
+
+    with mapdl.non_interactive:
+        # Testing the case where the file does not exist
+        assert mapdl.inquire("", "exist", "unexisting_file.myext") is None
 
 
 def test_ksel(mapdl, cleared):
@@ -2406,8 +2409,7 @@ def test_inquire_invalid(mapdl, cleared):
         mapdl.inquire("dummy", "hi")
 
 
-def test_inquire_default(mapdl, cleared):
-    mapdl.title("heeeelloo")
+def test_inquire_default_no_args(mapdl, cleared):
     assert str(Path(mapdl.directory)) == str(Path(mapdl.inquire()))
 
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1260,8 +1260,8 @@ def test_inquire(mapdl, cleared):
 
     # **Returning Information About a File to a Parameter**
     jobname = mapdl.inquire("", "jobname")
-    assert float(mapdl.inquire("", "exist", jobname + ".lock")) in [0, 1]
-    assert float(mapdl.inquire("", "exist", jobname, "lock")) in [0, 1]
+    assert isinstance(mapdl.inquire("", "exist", jobname + ".lock"), bool)
+    assert isinstance(mapdl.inquire("", "exist", jobname, "lock"), bool)
 
 
 def test_ksel(mapdl, cleared):

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1254,7 +1254,7 @@ def test_inquire(mapdl, cleared):
 
     # **Returning Information About a File to a Parameter**
     jobname = mapdl.inquire("", "jobname")
-    existing_file = mapdl.list_files()[0]
+    existing_file = [each for each in mapdl.list_files() if each.endswith(".log")][0]
 
     assert isinstance(mapdl.inquire("", "exist", existing_file), bool)
     assert isinstance(mapdl.inquire("", "exist", "unexisting_file.myext"), bool)


### PR DESCRIPTION
## Description
As the title.

## Issue linked
Extracted from #1300.

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)

## Summary by Sourcery

Improve the inquire method to provide typed and consistent return values, handle missing responses gracefully, and support boolean queries.

Enhancements:
- Return None when in non-interactive mode and no response is received.
- Extract the last line of multiline responses for ENV and TITLE inquiries.
- Parse and strip the response value for all inquiries.
- Return boolean values for EXIST, WRITE, READ, and EXEC inquiries, with error handling on unexpected output.
- Convert numeric responses to floats and fall back to strings for non-numeric outputs.