### PR TITLE
Fix socket.gethostbyaddr(ip) error when no reverse DNS available.

### DIFF
--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -381,9 +381,7 @@ class MapdlGrpc(MapdlBase):
         else:
             # it is an IP
             self._hostname = (
-                "localhost"
-                if ip in ["127.0.0.1", "127.0.1.1", "localhost"]
-                else ip
+                "localhost" if ip in ["127.0.0.1", "127.0.1.1", "localhost"] else ip
             )
 
         check_valid_ip(ip)

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -383,7 +383,7 @@ class MapdlGrpc(MapdlBase):
             self._hostname = (
                 "localhost"
                 if ip in ["127.0.0.1", "127.0.1.1", "localhost"]
-                else socket.gethostbyaddr(ip)[0]
+                else ip
             )
 
         check_valid_ip(ip)


### PR DESCRIPTION
## Description
For ip addresses without reverse DNS, socket.gethostbyaddr(ip) will fail. We can simply use ip address for hostname display.

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)

## Summary by Sourcery

Bug Fixes:
- Prevent socket.gethostbyaddr errors by using the IP address directly for hostname when reverse DNS lookup would fail