### PR TITLE
test: enhance testing logging

### DIFF
--- a/doc/changelog.d/4097.miscellaneous.md
+++ b/doc/changelog.d/4097.miscellaneous.md
@@ -1,0 +1,1 @@
+Test: enhance testing logging

--- a/tests/common.py
+++ b/tests/common.py
@@ -169,7 +169,7 @@ def debug_testing() -> bool:
         return False
 
 
-def test_dpf_backend() -> bool:
+def testing_dpf_backend() -> bool:
     return os.environ.get("TEST_DPF_BACKEND", "NO").upper().strip() in ["YES", "TRUE"]
 
 
@@ -224,18 +224,8 @@ def get_details_of_elements(mapdl_) -> Dict[int, Node]:
     return elements
 
 
-def log_test(mapdl: Mapdl, end=False) -> None:
+def log_start_test(mapdl: Mapdl, test_name: str) -> None:
     """Print the current test to the MAPDL log file and console output."""
-    test_name = os.environ.get(
-        "PYTEST_CURRENT_TEST", "**test id could not get retrieved.**"
-    )
-
-    if end:
-        mapdl.com("!", mute=True)
-        mapdl.com(f"! End of test: {test_name.split('::')[1]}"[:639], mute=True)
-        mapdl.com("!", mute=True)
-        return
-
     # To see it also in MAPDL terminal output
     if len(test_name) > 75:
         # terminal output is limited to 75 characters
@@ -252,6 +242,12 @@ def log_test(mapdl: Mapdl, end=False) -> None:
 
     else:
         mapdl.com(f"Running test: {test_name}", mute=True)
+
+
+def log_end_test(mapdl: Mapdl, test_name: str) -> None:
+    mapdl.com("!", mute=True)
+    mapdl.com(f"! End of test: {test_name.split('::')[1]}"[:639], mute=True)
+    mapdl.com("!", mute=True)
 
 
 def restart_mapdl(mapdl: Mapdl, test_name: str = "") -> Mapdl:

--- a/tests/common.py
+++ b/tests/common.py
@@ -169,6 +169,10 @@ def debug_testing() -> bool:
         return False
 
 
+def test_dpf_backend() -> bool:
+    return os.environ.get("TEST_DPF_BACKEND", "NO").upper().strip() in ["YES", "TRUE"]
+
+
 def is_float(s: str) -> bool:
     try:
         float(s)
@@ -220,15 +224,17 @@ def get_details_of_elements(mapdl_) -> Dict[int, Node]:
     return elements
 
 
-def log_test_start(mapdl: Mapdl) -> None:
+def log_test(mapdl: Mapdl, end=False) -> None:
     """Print the current test to the MAPDL log file and console output."""
     test_name = os.environ.get(
         "PYTEST_CURRENT_TEST", "**test id could not get retrieved.**"
     )
 
-    mapdl.run("!")
-    mapdl.run(f"! PyMAPDL running test: {test_name}"[:639])
-    mapdl.run("!")
+    if end:
+        mapdl.com("!", mute=True)
+        mapdl.com(f"! End of test: {test_name.split('::')[1]}"[:639], mute=True)
+        mapdl.com("!", mute=True)
+        return
 
     # To see it also in MAPDL terminal output
     if len(test_name) > 75:
@@ -239,13 +245,13 @@ def log_test_start(mapdl: Mapdl) -> None:
         else:
             types_ = ["File path", "Test function"]
 
-        mapdl._run("/com,Running test in:", mute=True)
+        mapdl.com("Running test in:", mute=True)
 
         for type_, name_ in zip(types_, test_name_):
-            mapdl._run(f"/com,    {type_}: {name_}", mute=True)
+            mapdl.com(f"    {type_}: {name_}", mute=True)
 
     else:
-        mapdl._run(f"/com,Running test: {test_name}", mute=True)
+        mapdl.com(f"Running test: {test_name}", mute=True)
 
 
 def restart_mapdl(mapdl: Mapdl, test_name: str = "") -> Mapdl:
@@ -265,9 +271,11 @@ def restart_mapdl(mapdl: Mapdl, test_name: str = "") -> Mapdl:
         if ON_LOCAL:
             # First we try to reconnect
             try:
+                LOG.debug("Reconnecting to MAPDL...")
                 mapdl.reconnect_to_mapdl(timeout=5)
                 assert mapdl.finish()
 
+                LOG.debug("Reconnected to MAPDL successfully.")
                 return mapdl
 
             except MapdlConnectionError as e:
@@ -277,9 +285,11 @@ def restart_mapdl(mapdl: Mapdl, test_name: str = "") -> Mapdl:
 
             # Killing the instance (just in case)
             try:
+
+                LOG.debug("Exiting MAPDL...")
                 mapdl.exit(force=True)
             except Exception as e:
-                pass
+                LOG.warning(f"Failed to exit MAPDL: {str(e)}")
 
             # Relaunching MAPDL
             LOG.debug("Relaunching MAPDL...")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,11 +46,12 @@ from common import (
     is_on_ubuntu,
     is_running_on_student,
     is_smp,
-    log_test,
+    log_end_test,
+    log_start_test,
     make_sure_not_instances_are_left_open,
     restart_mapdl,
     support_plotting,
-    test_dpf_backend,
+    testing_dpf_backend,
     testing_minimal,
 )
 
@@ -61,7 +62,7 @@ from common import (
 #
 DEBUG_TESTING = debug_testing()
 TESTING_MINIMAL = testing_minimal()
-TEST_DPF_BACKEND = test_dpf_backend()
+TEST_DPF_BACKEND = testing_dpf_backend()
 
 ON_LOCAL = is_on_local()
 ON_CI = is_on_ci()
@@ -567,7 +568,7 @@ def run_before_and_after_tests(
 
     # Write test info to log_apdl
     if DEBUG_TESTING:
-        log_test(mapdl)
+        log_start_test(mapdl, test_name)
 
     # check if the local/remote state has changed or not
     prev = mapdl.is_local
@@ -577,7 +578,7 @@ def run_before_and_after_tests(
     yield  # this is where the testing happens
 
     if DEBUG_TESTING:
-        log_test(mapdl, end=True)
+        log_end_test(mapdl, test_name)
 
     mapdl.prep7()
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -39,12 +39,17 @@ import psutil
 import pytest
 
 from conftest import (
+    IS_SMP,
+    ON_CI,
+    ON_LOCAL,
     PATCH_MAPDL,
     PATCH_MAPDL_START,
+    QUICK_LAUNCH_SWITCHES,
     VALID_PORTS,
     NullContext,
     Running_test,
     has_dependency,
+    requires,
 )
 
 if has_dependency("pyvista"):
@@ -68,7 +73,6 @@ from ansys.mapdl.core.launcher import launch_mapdl
 from ansys.mapdl.core.mapdl_grpc import SESSION_ID_NAME
 from ansys.mapdl.core.misc import random_string, stack
 from ansys.mapdl.core.plotting import GraphicsBackend
-from conftest import IS_SMP, ON_CI, ON_LOCAL, QUICK_LAUNCH_SWITCHES, requires
 
 # Path to files needed for examples
 PATH = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Description
As the title. Improve logging while testing.

## Issue linked
NA but related to #1300.

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)

## Summary by Sourcery

Improve testing logging and debugging, introduce controlled DPF backend testing, and adjust test fixtures for enhanced output and error handling.

New Features:
- Add test_dpf_backend function to enable DPF backend testing via TEST_DPF_BACKEND environment variable.

Enhancements:
- Replace log_test_start with unified log_test supporting start and end markers and switched to mapdl.com for consistent messaging.
- Extend Mapdl reconnection and exit routines with additional DEBUG and WARNING log statements.
- Raise explicit exceptions when test error representations lack expected attributes.

Tests:
- Set TEST_DPF_BACKEND flag and adjust run_before_and_after_tests fixture to emit start and end logs conditionally.
- Change mapdl fixture loglevel to DEBUG and configure log_apdl and mapdl_output paths based on DEBUG_TESTING and ON_LOCAL.