### PR TITLE
refactor: using Path method for joining paths.

### DIFF
--- a/doc/changelog.d/4101.miscellaneous.md
+++ b/doc/changelog.d/4101.miscellaneous.md
@@ -1,0 +1,1 @@
+Refactor: using path method for joining paths.

--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -1213,7 +1213,7 @@ class _MapdlCore(Commands):
         """Lockfile path"""
         path = self.directory
         if path is not None:
-            return path / (self.jobname + ".lock")
+            return path / f"{self.jobname}.lock"
 
     @property
     @supress_logging
@@ -2532,7 +2532,7 @@ class _MapdlCore(Commands):
 
     def _screenshot_path(self):
         """Return last filename based on the current jobname"""
-        filenames = glob.glob(self.directory / f"{self.jobname}*.png")
+        filenames = glob.glob(str(self.directory / f"{self.jobname}*.png"))
         filenames.sort()
         return filenames[-1]
 

--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -264,7 +264,7 @@ class _MapdlCore(Commands):
         local: bool = True,
         print_com: bool = False,
         file_type_for_plots: VALID_FILE_TYPE_FOR_PLOT_LITERAL = "PNG",
-        **start_parm,
+        **start_parm: dict[str, Any],
     ):
         """Initialize connection with MAPDL."""
         self._show_matplotlib_figures = True  # for testing
@@ -315,8 +315,12 @@ class _MapdlCore(Commands):
         _sanitize_start_parm(start_parm)
         self._start_parm: Dict[str, Any] = start_parm
         self._jobname: str = start_parm.get("jobname", "file")
-        self._path: Union[str, pathlib.Path] = start_parm.get("run_location", None)
-        self._check_parameter_names = start_parm.get("check_parameter_names", True)
+        self._path: pathlib.PurePath = self._wrap_directory(
+            start_parm.get("run_location")
+        )
+        self._check_parameter_names: bool = start_parm.get(
+            "check_parameter_names", True
+        )
 
         # Setting up loggers
         self._log: logger = logger.add_instance_logger(
@@ -501,7 +505,7 @@ class _MapdlCore(Commands):
     def _wrap_directory(self, path: str) -> pathlib.PurePath:
         if self._platform is None:
             # MAPDL is not initialized yet so returning the path as is.
-            return path
+            return pathlib.PurePath(path)
 
         if self._platform == "windows":
             # Windows path

--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -523,7 +523,7 @@ class _MapdlCore(Commands):
 
     @property
     @supress_logging
-    def directory(self) -> str:
+    def directory(self) -> pathlib.PurePath:
         """
         Current MAPDL directory.
 
@@ -1184,8 +1184,9 @@ class _MapdlCore(Commands):
         rth_basename = "%s0.%s" % (filename, "rth")
         rst_basename = "%s0.%s" % (filename, "rst")
 
-        rth_file = os.path.join(self.directory, rth_basename)
-        rst_file = os.path.join(self.directory, rst_basename)
+        rth_file = self.directory / rth_basename
+        rst_file = self.directory / rst_basename
+
         if os.path.isfile(rth_file) and os.path.isfile(rst_file):
             return last_created([rth_file, rst_file])
         elif os.path.isfile(rth_file):
@@ -1212,7 +1213,7 @@ class _MapdlCore(Commands):
         """Lockfile path"""
         path = self.directory
         if path is not None:
-            return os.path.join(path, self.jobname + ".lock").replace("\\", "/")
+            return path / (self.jobname + ".lock")
 
     @property
     @supress_logging
@@ -1223,8 +1224,8 @@ class _MapdlCore(Commands):
 
         if self._archive_cache is None:
             # write database to an archive file
-            arch_filename = os.path.join(self.directory, "_tmp.cdb")
-            nblock_filename = os.path.join(self.directory, "nblock.cdb")
+            arch_filename = self.directory / "_tmp.cdb"
+            nblock_filename = self.directory / "nblock.cdb"
 
             # must have all nodes elements are using selected
             self.cm("__NODE__", "NODE", mute=True)
@@ -1282,8 +1283,8 @@ class _MapdlCore(Commands):
                 # Case where there is RST extension because it is thermal for example
                 filename = self.jobname
 
-                rth_file = os.path.join(self.directory, f"{filename}.rth")
-                rst_file = os.path.join(self.directory, f"{filename}.rst")
+                rth_file = self.directory / f"{filename}.rth"
+                rst_file = self.directory / f"{filename}.rst"
 
                 if self._prioritize_thermal and os.path.isfile(rth_file):
                     return rth_file
@@ -1295,7 +1296,7 @@ class _MapdlCore(Commands):
                 elif os.path.isfile(rst_file):
                     return rst_file
             else:
-                filename = os.path.join(self.directory, f"{filename}.{ext}")
+                filename = self.directory / f"{filename}.{ext}"
                 if os.path.isfile(filename):
                     return filename
         else:
@@ -1661,7 +1662,7 @@ class _MapdlCore(Commands):
     @run_as("PREP7")
     def _generate_iges(self):
         """Save IGES geometry representation to disk"""
-        filename = os.path.join(self.directory, "_tmp.iges")
+        filename = self.directory / "_tmp.iges"
         self.igesout(filename, att=1, mute=True)
         return filename
 
@@ -1949,7 +1950,7 @@ class _MapdlCore(Commands):
     def _list(self, command):
         """Replaces *LIST command"""
         items = command.split(",")
-        filename = os.path.join(self.directory, ".".join(items[1:]))
+        filename = self.directory / ".".join(items[1:])
         if os.path.isfile(filename):
             self._response = open(filename).read()
             response_ = "\n".join(self._response.splitlines()[:10])
@@ -2531,7 +2532,7 @@ class _MapdlCore(Commands):
 
     def _screenshot_path(self):
         """Return last filename based on the current jobname"""
-        filenames = glob.glob(os.path.join(self.directory, f"{self.jobname}*.png"))
+        filenames = glob.glob(self.directory / f"{self.jobname}*.png")
         filenames.sort()
         return filenames[-1]
 
@@ -3000,7 +3001,7 @@ class _MapdlCore(Commands):
             sys_output = self._download_as_raw("__outputcmd__.txt").decode().strip()
 
         else:
-            file_ = os.path.join(self.directory, "__outputcmd__.txt")
+            file_ = self.directory / "__outputcmd__.txt"
             with open(file_, "r") as f:
                 sys_output = f.read().strip()
 

--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -315,8 +315,8 @@ class _MapdlCore(Commands):
         _sanitize_start_parm(start_parm)
         self._start_parm: Dict[str, Any] = start_parm
         self._jobname: str = start_parm.get("jobname", "file")
-        self._path: pathlib.PurePath = self._wrap_directory(
-            start_parm.get("run_location")
+        self._path: str | pathlib.PurePath | None = (
+            None  # start_parm.get("run_location", None)
         )
         self._check_parameter_names: bool = start_parm.get(
             "check_parameter_names", True

--- a/src/ansys/mapdl/core/mapdl_extended.py
+++ b/src/ansys/mapdl/core/mapdl_extended.py
@@ -382,7 +382,7 @@ class _MapdlCommandExtended(_MapdlCore):
         except MapdlCommandIgnoredError as e:
             raise IncorrectWorkingDirectory(e.args[0])
 
-        self._path = args[0]  # caching
+        self._path = self._wrap_directory(args[0])  # caching
         return output
 
     @wraps(_MapdlCore.list)

--- a/src/ansys/mapdl/core/mapdl_extended.py
+++ b/src/ansys/mapdl/core/mapdl_extended.py
@@ -406,7 +406,7 @@ class _MapdlCommandExtended(_MapdlCore):
 
         path = pathlib.Path(filename)
         if path.parent != ".":
-            path = os.path.join(self.directory, filename)
+            path = self.directory / filename
 
         path = str(path) + ext
         with open(path) as fid:

--- a/src/ansys/mapdl/core/mapdl_extended.py
+++ b/src/ansys/mapdl/core/mapdl_extended.py
@@ -109,7 +109,7 @@ class _MapdlCommandExtended(_MapdlCore):
         file_, ext_, _ = self._decompose_fname(fname)
         return self._file(file_, ext_, **kwargs)
 
-    def _file(self, filename: str, extension: str, **kwargs) -> str:
+    def _file(self, filename: str = "", extension: str = "", **kwargs) -> str:
         """Run the MAPDL ``file`` command with a proper filename."""
         return self.run(f"FILE,{filename},{extension}", **kwargs)
 

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -3187,10 +3187,10 @@ class MapdlGrpc(MapdlBase):
         # are unclear
         fname = self._get_file_name(fname, ext, "cdb")
         fname = self._get_file_path(fname, kwargs.get("progress_bar", False))
-        file_, ext_, _ = self._decompose_fname(fname)
+        file_, ext_, path_ = self._decompose_fname(fname)
 
         if self._local:
-            return self._file(filename=fname, **kwargs)
+            return self._file(filename=path_ / file_, extension=ext_, **kwargs)
         else:
             return self._file(filename=file_, extension=ext_, **kwargs)
 

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -2598,7 +2598,7 @@ class MapdlGrpc(MapdlBase):
         if self.is_local:
             # filtering with glob (accepting *)
             if not os.path.dirname(file):
-                file = self.directory / file
+                file = str(self.directory / file)
             list_files = glob.glob(file + extension, recursive=recursive)
 
         else:

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -352,7 +352,7 @@ class MapdlGrpc(MapdlBase):
         disable_run_at_connect: bool = False,
         channel: Optional[grpc.Channel] = None,
         remote_instance: Optional["PIM_Instance"] = None,
-        **start_parm,
+        **start_parm: dict[str, Any],
     ):
         """Initialize connection to the mapdl server"""
         self._name: Optional[str] = None
@@ -408,7 +408,7 @@ class MapdlGrpc(MapdlBase):
         self._cleanup: bool = cleanup_on_exit
         self.remove_temp_dir_on_exit: bool = remove_temp_dir_on_exit
         self._jobname: str = start_parm.get("jobname", "file")
-        self._path: Optional[str] = start_parm.get("run_location", None)
+        self._path: Optional[str] = self._wrap_directory(start_parm.get("run_location"))
         self._start_instance: Optional[str] = (
             start_parm.get("start_instance") or get_start_instance()
         )

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -408,7 +408,9 @@ class MapdlGrpc(MapdlBase):
         self._cleanup: bool = cleanup_on_exit
         self.remove_temp_dir_on_exit: bool = remove_temp_dir_on_exit
         self._jobname: str = start_parm.get("jobname", "file")
-        self._path: Optional[str] = self._wrap_directory(start_parm.get("run_location"))
+        self._path: Optional[str] = (
+            None  # self._wrap_directory(start_parm.get("run_location"))
+        )
         self._start_instance: Optional[str] = (
             start_parm.get("start_instance") or get_start_instance()
         )

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -2490,7 +2490,6 @@ class MapdlGrpc(MapdlBase):
         recursive: bool = False,
     ) -> List[str]:
         """Download files when we are on a local session."""
-
         if isinstance(files, str):
             if not os.path.isdir(self.directory / files):
                 list_files = self._validate_files(
@@ -2498,6 +2497,9 @@ class MapdlGrpc(MapdlBase):
                 )
             else:
                 list_files = [files]
+
+        elif isinstance(files, pathlib.PurePath):
+            list_files = [str(files)]
 
         elif isinstance(files, (list, tuple)):
             if not all([isinstance(each, str) for each in files]):
@@ -2512,7 +2514,7 @@ class MapdlGrpc(MapdlBase):
 
         else:
             raise ValueError(
-                f"The `file` parameter type ({type(files)}) is not supported."
+                f"The `file` parameter type ({type(files)}) is not supported. "
                 "Only strings, tuple of strings or list of strings are allowed."
             )
 
@@ -3186,11 +3188,11 @@ class MapdlGrpc(MapdlBase):
         fname = self._get_file_name(fname, ext, "cdb")
         fname = self._get_file_path(fname, kwargs.get("progress_bar", False))
         file_, ext_, _ = self._decompose_fname(fname)
-        fname = fname[: -len(ext_) - 1]  # Removing extension. -1 for the dot.
+
         if self._local:
-            return self._file(filename=fname, extension=ext_, **kwargs)
+            return self._file(filename=fname, **kwargs)
         else:
-            return self._file(filename=file_, extension=ext_)
+            return self._file(filename=file_, extension=ext_, **kwargs)
 
     @wraps(MapdlBase.vget)
     def vget(

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -2149,7 +2149,7 @@ class MapdlGrpc(MapdlBase):
 
     def _get_file_name(
         self,
-        fname: str,
+        fname: str | pathlib.PurePath,
         ext: Optional[str] = None,
         default_extension: Optional[str] = None,
     ) -> str:
@@ -2171,6 +2171,8 @@ class MapdlGrpc(MapdlBase):
 
         # the old behaviour is to supplied the name and the extension separately.
         # to make it easier let's going to allow names with extensions
+        if not isinstance(fname, str):
+            fname = str(fname)
 
         # Sanitizing ext
         while ext and ext[0] == ".":

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -32,7 +32,16 @@ import socket
 import string
 import tempfile
 from threading import Thread
-from typing import Callable, Dict, Iterable, List, Tuple, Union
+from typing import (
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    ParamSpec,
+    Tuple,
+    TypeVar,
+    Union,
+)
 from warnings import warn
 
 import numpy as np
@@ -56,6 +65,10 @@ class ROUTINES(Enum):
     AUX3 = 53
     AUX12 = 62
     AUX15 = 65
+
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 def check_valid_routine(routine: ROUTINES) -> bool:
@@ -133,11 +146,11 @@ def check_has_mapdl() -> bool:
         return False
 
 
-def supress_logging(func: Callable) -> Callable:
+def supress_logging(func: Callable[P, R]) -> Callable[P, R]:
     """Decorator to suppress logging for a MAPDL instance"""
 
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         from ansys.mapdl.core.mapdl import MapdlBase
 
         mapdl = args[0]

--- a/src/ansys/mapdl/core/parameters.py
+++ b/src/ansys/mapdl/core/parameters.py
@@ -677,7 +677,7 @@ class Parameters:
             arr = arr.astype(np.double)
 
         if self._mapdl._local:
-            filename = os.path.join(self._mapdl.directory, filename)
+            filename = str(self._mapdl.directory / filename)
         else:
             filename = os.path.join(tempfile.gettempdir(), filename)
         write_array(filename.encode(), arr.ravel("F"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,13 +216,14 @@ if has_dependency("ansys-tools-path"):
 if has_dependency("pyvista"):
     import pyvista
 
+    # Necessary for CI plotting
+    pyvista.OFF_SCREEN = True
+    pyvista.global_theme.allow_empty_mesh = True
+
     from ansys.mapdl.core.plotting.theme import _apply_default_theme
 
     _apply_default_theme()
 
-    # Necessary for CI plotting
-    pyvista.OFF_SCREEN = True
-    pyvista.global_theme.allow_empty_mesh = True
 
 import ansys.mapdl.core as pymapdl
 

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -405,11 +405,11 @@ def test_download_with_extension(
 @requires("local")
 def test_download_recursive(mapdl, cleared):
     if mapdl.is_local:
-        temp_dir = os.path.join(mapdl.directory, "new_folder")
+        temp_dir = mapdl.directory / "new_folder"
         os.makedirs(temp_dir, exist_ok=True)
-        with open(os.path.join(temp_dir, "file0.txt"), "a") as fid:
+        with open(temp_dir / "file0.txt", "a") as fid:
             fid.write("dummy")
-        with open(os.path.join(temp_dir, "file1.txt"), "a") as fid:
+        with open(temp_dir / "file1.txt", "a") as fid:
             fid.write("dummy")
 
         mapdl.download(temp_dir, recursive=True)  # This is referenced to os.getcwd

--- a/tests/test_krylov.py
+++ b/tests/test_krylov.py
@@ -318,7 +318,7 @@ def test_non_valid_inputs_expand(
 def test_check_full_file_exist(mapdl, cleared):
     # deleting previous full file.
     if mapdl.is_local:
-        full_file = os.path.join(mapdl.directory, mapdl.jobname + ".full")
+        full_file = mapdl.directory / (mapdl.jobname + ".full")
         if os.path.exists(full_file):
             os.remove(full_file)
     else:

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1288,16 +1288,22 @@ def test_inquire_jobname(mapdl, cleared):
 def test_inquire_exist(mapdl, cleared, tmpdir):
     try:
         existing_file = tempfile.mkstemp(suffix=".log")[1]
+
+        with open(existing_file, "w") as f:
+            f.write("This is a test file for inquire exist.")
+
         mapdl.upload(existing_file)
 
         basename = os.path.basename(existing_file)
         if mapdl.is_local:
             assert isinstance(mapdl.inquire("", "exist", existing_file), bool)
+            assert mapdl.inquire("", "exist", basename)
         else:
             assert isinstance(mapdl.inquire("", "exist", basename), bool)
+            assert mapdl.inquire("", "exist", basename)
+
         assert isinstance(mapdl.inquire("", "exist", "unexisting_file.myext"), bool)
 
-        assert mapdl.inquire("", "exist", basename)
         assert not mapdl.inquire("", "exist", "unexisting_file.myext")
 
     finally:

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1291,7 +1291,10 @@ def test_inquire_exist(mapdl, cleared, tmpdir):
         mapdl.upload(existing_file)
 
         basename = os.path.basename(existing_file)
-        assert isinstance(mapdl.inquire("", "exist", basename), bool)
+        if mapdl.is_local:
+            assert isinstance(mapdl.inquire("", "exist", existing_file), bool)
+        else:
+            assert isinstance(mapdl.inquire("", "exist", basename), bool)
         assert isinstance(mapdl.inquire("", "exist", "unexisting_file.myext"), bool)
 
         assert mapdl.inquire("", "exist", basename)

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -2746,7 +2746,7 @@ def test_cwd_changing_directory(mapdl, cleared):
 @pytest.mark.parametrize(
     "platform, class_, contextmanager",
     [
-        [None, str, NullContext()],
+        [None, pathlib.PurePath, NullContext()],
         ["windows", pathlib.PureWindowsPath, NullContext()],
         ["linux", pathlib.PurePosixPath, NullContext()],
         [

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1144,17 +1144,17 @@ def test_cdread_in_apdl_directory(mapdl, cleared):
     assert asserting_cdread_cdwrite_tests(mapdl)
 
     clearing_cdread_cdwrite_tests(mapdl)
-    fullpath = os.path.join(mapdl.directory, "model.cdb")
+    fullpath = mapdl.directory / "model.cdb"
     mapdl.cdread("db", fullpath)
     assert asserting_cdread_cdwrite_tests(mapdl)
 
     clearing_cdread_cdwrite_tests(mapdl)
-    fullpath = os.path.join(mapdl.directory, "model")
+    fullpath = mapdl.directory / "model"
     mapdl.cdread("db", fullpath, "cdb")
     assert asserting_cdread_cdwrite_tests(mapdl)
 
     clearing_cdread_cdwrite_tests(mapdl)
-    fullpath = os.path.join(mapdl.directory, "model")
+    fullpath = mapdl.directory / "model"
     mapdl.cdread("db", fullpath)
     assert asserting_cdread_cdwrite_tests(mapdl)
 
@@ -1222,7 +1222,7 @@ def test_cwd(mapdl, cleared, tmpdir):
     if mapdl.is_local:
         tempdir_ = tmpdir
     else:
-        tempdir_ = os.path.join(mapdl.directory, "tmp")
+        tempdir_ = mapdl.directory / "tmp"
         mapdl.sys(f"mkdir tmp")
 
     try:
@@ -1574,7 +1574,7 @@ def test_file_command_local(mapdl, cube_solve, tmpdir):
         mapdl.file("potato")
 
     assert os.path.basename(rst_file) in mapdl.list_files()
-    rst_fpath = os.path.join(mapdl.directory, rst_file)
+    rst_fpath = str(mapdl.directory / rst_file)
 
     # change directory
     old_path = mapdl.directory
@@ -2562,7 +2562,7 @@ def test_lgwrite(mapdl, cleared, filename, ext, remove_grpc_extra, kedit):
     filename_ = f"{filename}.{ext}"
     assert filename_ in mapdl.list_files()
     if mapdl.is_local:
-        assert os.path.exists(os.path.join(mapdl.directory, filename_))
+        assert os.path.exists(mapdl.directory / filename_)
     else:
         assert os.path.exists(filename_)
 

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -1285,13 +1285,23 @@ def test_inquire_jobname(mapdl, cleared):
     assert jobname
 
 
-def test_inquire_exist(mapdl, cleared):
-    existing_file = [each for each in mapdl.list_files() if each.endswith(".log")][0]
-    assert isinstance(mapdl.inquire("", "exist", existing_file), bool)
-    assert isinstance(mapdl.inquire("", "exist", "unexisting_file.myext"), bool)
+def test_inquire_exist(mapdl, cleared, tmpdir):
+    try:
+        existing_file = tempfile.mkstemp(suffix=".log")[1]
+        mapdl.upload(existing_file)
 
-    assert mapdl.inquire("", "exist", existing_file)
-    assert not mapdl.inquire("", "exist", "unexisting_file.myext")
+        basename = os.path.basename(existing_file)
+        assert isinstance(mapdl.inquire("", "exist", basename), bool)
+        assert isinstance(mapdl.inquire("", "exist", "unexisting_file.myext"), bool)
+
+        assert mapdl.inquire("", "exist", basename)
+        assert not mapdl.inquire("", "exist", "unexisting_file.myext")
+
+    finally:
+        # Clean up the temporary file
+        if os.path.exists(existing_file):
+            os.remove(existing_file)
+        mapdl.slashdelete(basename)
 
 
 def test_inquire_non_interactive(mapdl, cleared):
@@ -1562,7 +1572,7 @@ def test_equal_in_comments_and_title(mapdl, cleared):
 
 def test_result_file(mapdl, solved_box):
     assert mapdl.result_file
-    assert isinstance(mapdl.result_file, str)
+    assert isinstance(mapdl.result_file, (str, pathlib.PurePath))
 
 
 @requires("local")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -159,8 +159,7 @@ def test_load_file_local(mapdl, cleared, tmpdir, file_):
     assert os.path.exists(file_path)
 
     if mapdl.is_local:
-        pth = os.path.join(mapdl.directory, file_)
-        assert not os.path.exists(pth)
+        assert not os.path.exists(mapdl.directory / file_)
     else:
         assert file_ not in mapdl.list_files()
 
@@ -170,10 +169,9 @@ def test_load_file_local(mapdl, cleared, tmpdir, file_):
     assert os.path.exists(file_path)
 
     if mapdl.is_local:
-        pth = os.path.join(mapdl.directory, file_)
-        assert os.path.exists(pth)
+        assert os.path.exists(mapdl.directory / file_)
 
-        with open(os.path.join(mapdl.directory, file_), "r") as fid:
+        with open(mapdl.directory / file_, "r") as fid:
             assert "empty" in fid.read()
 
     else:
@@ -195,7 +193,7 @@ def test_load_file_local(mapdl, cleared, tmpdir, file_):
     load_file(mapdl, file_path, priority_mapdl_file=False)
 
     if mapdl.is_local:
-        file_name__ = os.path.join(mapdl.directory, file_)
+        file_name__ = mapdl.directory / file_
         with open(file_name__, "r") as fid:
             assert "not that empty" in fid.read()
         os.remove(file_name__)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1021,7 +1021,7 @@ def test_WithInterativePlotting(mapdl, make_block):
     last_png = list_files[0]
 
     if mapdl.is_local:
-        last_png = os.path.join(mapdl.directory, last_png)
+        last_png = mapdl.directory / last_png
     else:
         mapdl.download(last_png)
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -34,6 +34,10 @@ if not has_dependency("pyvista"):
         allow_module_level=True, reason="Skipping because 'pyvista' is not installed"
     )
 
+import pyvista
+
+pyvista.global_theme.allow_empty_mesh = True
+
 from ansys.mapdl.core.errors import ComponentDoesNotExits, MapdlRuntimeError
 from ansys.mapdl.core.plotting import GraphicsBackend
 from ansys.mapdl.core.plotting.visualizer import MapdlPlotter


### PR DESCRIPTION
## Description
As the title. Refactor to use the `/` for joining paths.

## Issue linked
NA but using #4079

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)

## Summary by Sourcery

Refactor path handling to use pathlib.Path and the `/` operator across the codebase, update the `directory` property type and tests accordingly, and enhance decorator typing.

Enhancements:
- Standardize file path manipulations by replacing os.path.join with pathlib.Path and the `/` operator
- Change the `directory` property to return a pathlib.PurePath instead of a string
- Introduce ParamSpec and TypeVar typing for the `supress_logging` decorator

Tests:
- Update tests to use the new Path-based `directory` usage and adjust assertions accordingly