### PR TITLE
fix: update MAPDL image version and remove DPF server activation step in documentation build workflow

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -71,8 +71,7 @@ jobs:
       ON_DOCUMENTATION: TRUE
       PYANSYS_OFF_SCREEN: True
       BUILD_CHEATSHEET: '${{ inputs.build_cheatsheet }}'
-      MAPDL_IMAGE_VERSION_DOCS_BUILD: v24.2-ubuntu-student
-      DPF_DOCKER_IMAGE: ghcr.io/ansys/mapdl:v25.2-rocky-dpf-standalone
+      MAPDL_IMAGE_VERSION_DOCS_BUILD: v25.2-ubuntu-cicd
       MAPDL_PACKAGE: ghcr.io/ansys/mapdl
       PYMAPDL_START_INSTANCE: FALSE
       PYMAPDL_PORT: 21000  # default won't work on GitHub runners
@@ -101,17 +100,15 @@ jobs:
           MAPDL_VERSION: ${{ env.MAPDL_IMAGE_VERSION_DOCS_BUILD }}
           MAPDL_PACKAGE: ${{ env.MAPDL_PACKAGE }}
           DISTRIBUTED_MODE: "dmp"
+          DPF_PORT: ${{ env.DPF_PORT }}
+          DPF_PORT_INTERNAL: 50055
         shell: bash
         run: |
           export INSTANCE_NAME=MAPDL_0
+          export RUN_DPF_SERVER=true
           .ci/start_mapdl.sh &> mapdl_launch.log & export DOCKER_PID=$!
           echo "Launching MAPDL service at PID: $DOCKER_PID"
           echo "DOCKER_PID=$(echo $DOCKER_PID)" >> $GITHUB_OUTPUT
-
-      - name: "DPF server activation"
-        shell: bash
-        run: |
-          $(docker pull $DPF_DOCKER_IMAGE && docker run -d --name dpfserver --env ANSYS_DPF_ACCEPT_LA=Y --env ANSYSLMD_LICENSE_FILE="1055@${{ secrets.license-server }}" -p ${{ env.DPF_PORT }}:50052 $DPF_DOCKER_IMAGE && echo "DPF Server active on port ${{ env.DPF_PORT }}.") &
 
       - name: "Getting files change filters"
         uses: dorny/paths-filter@v3

--- a/doc/changelog.d/4118.fixed.md
+++ b/doc/changelog.d/4118.fixed.md
@@ -1,0 +1,1 @@
+Fix: update mapdl image version and remove dpf server activation step in documentation build workflow


### PR DESCRIPTION
## Description
Update docker image tag in documentation build workflow.

## Issue linked
NA

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)

## Summary by Sourcery

Update documentation build workflow to use MAPDL v25.2-ubuntu-cicd image and streamline DPF server activation

CI:
- Switch MAPDL_IMAGE_VERSION_DOCS_BUILD to v25.2-ubuntu-cicd
- Remove the DPF_DOCKER_IMAGE variable and the dedicated DPF server activation step
- Introduce RUN_DPF_SERVER flag and DPF_PORT_INTERNAL environment variable in the workflow run step