### PR TITLE
fix: Set _post as a property so it's initialized when needed

### DIFF
--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -375,7 +375,7 @@ class _MapdlCore(Commands):
         if log_apdl:
             self.open_apdl_log(log_apdl, mode="w")
 
-        self._post = PostProcessing(self)
+        self._post_object = None
 
         # Wrapping listing functions for "to_array" methods
         self._wrap_listing_functions()
@@ -391,6 +391,15 @@ class _MapdlCore(Commands):
 
     def _after_run(self, _command: str) -> None:
         pass
+
+    @property
+    def _post(self):
+        """
+        Initializes _post_object and allows _post to be None at __init__
+        """
+        if self._post_object is None:
+            self._post_object = PostProcessing(self)
+        return self._post_object
 
     @property
     def allow_ignore(self):


### PR DESCRIPTION
## Description
We had an issue in mapdl using *PYT command which starts a python interpreter and imports mapdl as mapdlInProcess.
Then calling mapdl.__dict__ led to a segmentation error because it called PostProcessing whithout results. We figured we didn't need to initialise _post unless needed

## Issue linked
#4145

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [ ] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [ ] I have reviewed my changes before submitting this pull request.
- [ ] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [ ] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [ ] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [ ] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)