### PR TITLE
ci: comment out log upload steps in workflow files

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -278,12 +278,12 @@ jobs:
         run: |
           .ci/collect_mapdl_logs_remote.sh
 
-      - name: "Upload logs to GitHub"
-        if: always()
-        uses: actions/upload-artifact@master
-        with:
-          name: logs-build-docs.tgz
-          path: ./logs-build-docs.tgz
+      # - name: "Upload logs to GitHub"
+      #   if: always()
+      #   uses: actions/upload-artifact@master
+      #   with:
+      #     name: logs-build-docs.tgz
+      #     path: ./logs-build-docs.tgz
 
       - name: "Display files structure"
         if: always()

--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -282,12 +282,12 @@ jobs:
         run: |
           .ci/collect_mapdl_logs_locals.sh
 
-      - name: "Upload logs to GitHub"
-        if: always()
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: logs-${{ inputs.file-name }}.tgz
-          path: ./logs-${{ inputs.file-name }}.tgz
+      # - name: "Upload logs to GitHub"
+      #   if: always()
+      #   uses: actions/upload-artifact@v4.6.2
+      #   with:
+      #     name: logs-${{ inputs.file-name }}.tgz
+      #     path: ./logs-${{ inputs.file-name }}.tgz
 
       - name: "Display files structure"
         if: always()

--- a/.github/workflows/test-remote.yml
+++ b/.github/workflows/test-remote.yml
@@ -307,12 +307,12 @@ jobs:
         run: |
           .ci/collect_mapdl_logs_remote.sh
 
-      - name: "Upload logs to GitHub"
-        if: always()
-        uses: actions/upload-artifact@v4.6.2
-        with:
-          name: logs-${{ inputs.file-name }}.tgz
-          path: ./logs-${{ inputs.file-name }}.tgz
+      # - name: "Upload logs to GitHub"
+      #   if: always()
+      #   uses: actions/upload-artifact@v4.6.2
+      #   with:
+      #     name: logs-${{ inputs.file-name }}.tgz
+      #     path: ./logs-${{ inputs.file-name }}.tgz
 
       - name: "Display files structure"
         if: always()

--- a/doc/changelog.d/4239.maintenance.md
+++ b/doc/changelog.d/4239.maintenance.md
@@ -1,0 +1,1 @@
+Comment out log upload steps in workflow files


### PR DESCRIPTION
Comment out the log upload steps in the workflow files to prevent unnecessary uploads during the CI process.