### PR TITLE
feat: rename pymapdl run to pymapdl exec

### DIFF
--- a/doc/changelog.d/4516.added.md
+++ b/doc/changelog.d/4516.added.md
@@ -1,1 +1,1 @@
-Add `pymapdl exec` CLI subcommand (renamed from `pymapdl run` to align with `docker exec`)
+Add \`pymapdl run\` CLI subcommand

--- a/doc/changelog.d/4516.added.md
+++ b/doc/changelog.d/4516.added.md
@@ -1,1 +1,1 @@
-Add \`pymapdl run\` CLI subcommand
+Add `pymapdl exec` CLI subcommand (renamed from `pymapdl run` to align with `docker exec`)

--- a/doc/changelog.d/4521.added.md
+++ b/doc/changelog.d/4521.added.md
@@ -1,0 +1,1 @@
+Rename pymapdl run to pymapdl exec

--- a/doc/source/user_guide/cli.rst
+++ b/doc/source/user_guide/cli.rst
@@ -406,7 +406,7 @@ then stop the instance:
 .. note::
 
    ``pymapdl exec`` writes command output to stdout and errors to stderr,
-   making it suitable for use in shell scripts and pipelines.  The process
+   making it suitable for use in shell scripts and pipelines. The process
    exits with code ``0`` on success and ``1`` on failure.
 
 To convert an existing APDL script to Python instead of executing it, see

--- a/doc/source/user_guide/cli.rst
+++ b/doc/source/user_guide/cli.rst
@@ -6,7 +6,7 @@ PyMAPDL command line interface
 ==============================
 
 For your convenience, PyMAPDL package includes a command line interface
-which allows you to launch, stop, list, and execute commands on local MAPDL instances.
+which allows you to launch, stop, list, and execute commands on MAPDL instances.
 
 
 Launch MAPDL instances
@@ -284,10 +284,10 @@ Execute MAPDL commands
 ======================
 
 Use ``pymapdl exec`` to send APDL commands to a running MAPDL instance and
-print the output to stdout.  The command always connects to an existing
-instance — it never starts a new one.  Use ``pymapdl start`` first if needed.
+print the output to stdout. The command always connects to an existing
+instance, it never starts a new one. Use ``pymapdl start`` first if needed.
 
-There are three mutually exclusive ways to supply commands.  The recommended
+There are three mutually exclusive ways to supply commands. The recommended
 approach is to use the ``-c`` / ``--command`` option, which can be repeated.
 Each ``-c`` value is one APDL command; all commands are sent as a single block:
 
@@ -351,7 +351,7 @@ read from stdin:
 
 
 By default, ``pymapdl exec`` connects without clearing the MAPDL database, so
-successive calls share the same model state.  Use the ``--clear-on-connect``
+successive calls share the same model state. Use the ``--clear-on-connect``
 flag to clear the database before sending commands:
 
 

--- a/doc/source/user_guide/cli.rst
+++ b/doc/source/user_guide/cli.rst
@@ -6,7 +6,7 @@ PyMAPDL command line interface
 ==============================
 
 For your convenience, PyMAPDL package includes a command line interface
-which allows you to launch, stop and list local MAPDL instances.
+which allows you to launch, stop, list, and execute commands on local MAPDL instances.
 
 
 Launch MAPDL instances
@@ -277,6 +277,140 @@ The converter module has its own command line interface to convert
 MAPDL files to PyMAPDL. For more information, see
 :ref:`ref_cli_converter`.
 
+
+.. _ref_cli_exec:
+
+Execute MAPDL commands
+======================
+
+Use ``pymapdl exec`` to send APDL commands to a running MAPDL instance and
+print the output to stdout.  The command always connects to an existing
+instance — it never starts a new one.  Use ``pymapdl start`` first if needed.
+
+There are three mutually exclusive ways to supply commands.  The recommended
+approach is to use the ``-c`` / ``--command`` option, which can be repeated.
+Each ``-c`` value is one APDL command; all commands are sent as a single block:
+
+
+.. tab-set::
+
+    .. tab-item:: Windows
+        :sync: key1
+
+        .. code:: pwsh-session
+
+            (.venv) PS C:\Users\user\pymapdl> pymapdl exec -c /prep7 -c "BLOCK,0,1,0,1,0,1" -c SAVE
+
+    .. tab-item:: Linux
+        :sync: key1
+
+        .. code:: console
+
+            (.venv) user@machine:~$ pymapdl exec -c /prep7 -c "BLOCK,0,1,0,1,0,1" -c SAVE
+
+
+You can also read commands from an APDL script file using ``--file`` / ``-f``:
+
+
+.. tab-set::
+
+    .. tab-item:: Windows
+        :sync: key1
+
+        .. code:: pwsh-session
+
+            (.venv) PS C:\Users\user\pymapdl> pymapdl exec --file my_script.inp
+
+    .. tab-item:: Linux
+        :sync: key1
+
+        .. code:: console
+
+            (.venv) user@machine:~$ pymapdl exec --file my_script.inp
+
+
+To pipe commands from another program, pass ``-`` as a positional argument to
+read from stdin:
+
+
+.. tab-set::
+
+    .. tab-item:: Windows
+        :sync: key1
+
+        .. code:: pwsh-session
+
+            (.venv) PS C:\Users\user\pymapdl> Get-Content my_script.inp | pymapdl exec -
+
+    .. tab-item:: Linux
+        :sync: key1
+
+        .. code:: console
+
+            (.venv) user@machine:~$ cat my_script.inp | pymapdl exec -
+
+
+By default, ``pymapdl exec`` connects without clearing the MAPDL database, so
+successive calls share the same model state.  Use the ``--clear-on-connect``
+flag to clear the database before sending commands:
+
+
+.. tab-set::
+
+    .. tab-item:: Windows
+        :sync: key1
+
+        .. code:: pwsh-session
+
+            (.venv) PS C:\Users\user\pymapdl> pymapdl exec --clear-on-connect -c /prep7
+
+    .. tab-item:: Linux
+        :sync: key1
+
+        .. code:: console
+
+            (.venv) user@machine:~$ pymapdl exec --clear-on-connect -c /prep7
+
+
+A common workflow is to start MAPDL once, send one or more command blocks, and
+then stop the instance:
+
+
+.. tab-set::
+
+    .. tab-item:: Windows
+        :sync: key1
+
+        .. code:: pwsh-session
+
+            (.venv) PS C:\Users\user\pymapdl> pymapdl start
+            Success: Launched an MAPDL instance (PID=23644) at 127.0.0.1:50052
+            (.venv) PS C:\Users\user\pymapdl> pymapdl exec -c /prep7 -c "BLOCK,0,1,0,1,0,1"
+            (.venv) PS C:\Users\user\pymapdl> pymapdl exec -c SAVE
+            (.venv) PS C:\Users\user\pymapdl> pymapdl stop
+            Success: Ansys instances running on port 50052 have been stopped.
+
+    .. tab-item:: Linux
+        :sync: key1
+
+        .. code:: console
+
+            (.venv) user@machine:~$ pymapdl start
+            Success: Launched an MAPDL instance (PID=23644) at 127.0.0.1:50052
+            (.venv) user@machine:~$ pymapdl exec -c /prep7 -c "BLOCK,0,1,0,1,0,1"
+            (.venv) user@machine:~$ pymapdl exec -c SAVE
+            (.venv) user@machine:~$ pymapdl stop
+            Success: Ansys instances running on port 50052 have been stopped.
+
+
+.. note::
+
+   ``pymapdl exec`` writes command output to stdout and errors to stderr,
+   making it suitable for use in shell scripts and pipelines.  The process
+   exits with code ``0`` on success and ``1`` on failure.
+
+To convert an existing APDL script to Python instead of executing it, see
+:ref:`ref_cli_converter`.
 
 
 .. _ref_cli_converter:

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -173,6 +173,9 @@ spotweld
 squeue
 srun
 stationarity
+stderr
+stdin
+stdout
 struc
 subselected
 substep

--- a/src/ansys/mapdl/core/cli/__init__.py
+++ b/src/ansys/mapdl/core/cli/__init__.py
@@ -37,14 +37,14 @@ if _HAS_CLICK:
         pass
 
     from ansys.mapdl.core.cli.convert import convert as convert_cmd
+    from ansys.mapdl.core.cli.exec import exec_cmd
     from ansys.mapdl.core.cli.list_instances import list_instances
-    from ansys.mapdl.core.cli.run import run as run_cmd
     from ansys.mapdl.core.cli.start import start as start_cmd
     from ansys.mapdl.core.cli.stop import stop as stop_cmd
 
     main.add_command(convert_cmd, name="convert")
+    main.add_command(exec_cmd, name="exec")
     main.add_command(list_instances, name="list")
-    main.add_command(run_cmd, name="run")
     main.add_command(start_cmd, name="start")
     main.add_command(stop_cmd, name="stop")
 

--- a/src/ansys/mapdl/core/cli/exec.py
+++ b/src/ansys/mapdl/core/cli/exec.py
@@ -27,18 +27,18 @@ import click
 
 
 @click.command(
-    short_help="Run MAPDL commands on a running instance.",
+    short_help="Execute MAPDL commands on a running instance.",
     help="""Send MAPDL commands to a running MAPDL instance and print the output.
 
 Commands can be supplied in three mutually exclusive ways:
 
 \b
   1. Repeated --command / -c options (recommended for scripting and LLM use):
-       pymapdl run -c /prep7 -c "BLOCK,0,1,0,1,0,1" -c SAVE
+       pymapdl exec -c /prep7 -c "BLOCK,0,1,0,1,0,1" -c SAVE
   2. File — read commands from an APDL script file:
-       pymapdl run --file my_script.inp
+       pymapdl exec --file my_script.inp
   3. Stdin — pass ``-`` as the positional argument and pipe commands in:
-       echo "/prep7" | pymapdl run -
+       echo "/prep7" | pymapdl exec -
 
 The instance is targeted by ``--ip`` and ``--port`` (defaults: 127.0.0.1:50052).
 MAPDL output is written to stdout so it can be consumed by scripts or LLM agents.
@@ -80,7 +80,7 @@ MAPDL output is written to stdout so it can be consumed by scripts or LLM agents
     is_flag=True,
     default=False,
     help="Clear the MAPDL database upon connecting.  Off by default so that "
-    "successive ``pymapdl run`` calls share the same model state.",
+    "successive ``pymapdl exec`` calls share the same model state.",
 )
 @click.option(
     "--timeout",
@@ -89,7 +89,7 @@ MAPDL output is written to stdout so it can be consumed by scripts or LLM agents
     show_default=True,
     help="Seconds to wait when establishing the gRPC connection to the running instance.",
 )
-def run(
+def exec_cmd(
     stdin_marker: Optional[str],
     commands: Tuple[str, ...],
     script_file: Optional[str],
@@ -98,7 +98,7 @@ def run(
     clear_on_connect: bool,
     timeout: int,
 ) -> None:
-    """Run MAPDL commands on an already-running instance.
+    """Execute MAPDL commands on an already-running instance.
 
     Parameters
     ----------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1259,8 +1259,8 @@ class TestCliStartCommand:
 
 
 @requires("click")
-class TestCliRunCommand:
-    """Tests for the ``pymapdl run`` CLI subcommand."""
+class TestCliExecCommand:
+    """Tests for the ``pymapdl exec`` CLI subcommand."""
 
     MOCK_OUTPUT = "MAPDL output line 1\nMAPDL output line 2"
 
@@ -1291,26 +1291,26 @@ class TestCliRunCommand:
     # Happy-path tests                                                     #
     # ------------------------------------------------------------------ #
 
-    def test_run_single_command(self, cli_runner, mock_mapdl):
+    def test_exec_single_command(self, cli_runner, mock_mapdl):
         """A single -c command is sent to MAPDL."""
         with patch(
             "ansys.mapdl.core.launcher.connection.connect_to_existing",
             return_value=mock_mapdl,
         ):
-            result = cli_runner(["run", "-c", "/prep7"])
+            result = cli_runner(["exec", "-c", "/prep7"])
 
         assert result.exit_code == 0
         assert self.MOCK_OUTPUT in result.output
         mock_mapdl.input_strings.assert_called_once_with("/prep7")
 
-    def test_run_multiple_commands(self, cli_runner, mock_mapdl):
+    def test_exec_multiple_commands(self, cli_runner, mock_mapdl):
         """Multiple -c options are joined with newlines and sent as one block."""
         with patch(
             "ansys.mapdl.core.launcher.connection.connect_to_existing",
             return_value=mock_mapdl,
         ):
             result = cli_runner(
-                ["run", "-c", "/prep7", "-c", "BLOCK,0,1,0,1,0,1", "-c", "SAVE"]
+                ["exec", "-c", "/prep7", "-c", "BLOCK,0,1,0,1,0,1", "-c", "SAVE"]
             )
 
         assert result.exit_code == 0
@@ -1318,20 +1318,20 @@ class TestCliRunCommand:
         sent = mock_mapdl.input_strings.call_args[0][0]
         assert sent == "/prep7\nBLOCK,0,1,0,1,0,1\nSAVE"
 
-    def test_run_windows_path_not_mangled(self, cli_runner, mock_mapdl):
+    def test_exec_windows_path_not_mangled(self, cli_runner, mock_mapdl):
         """Windows paths with backslash sequences (e.g. C:\\new\\file) are preserved."""
         cmd = r"/FILNAME,'C:\new\file',1"
         with patch(
             "ansys.mapdl.core.launcher.connection.connect_to_existing",
             return_value=mock_mapdl,
         ):
-            result = cli_runner(["run", "-c", cmd])
+            result = cli_runner(["exec", "-c", cmd])
 
         assert result.exit_code == 0
         sent = mock_mapdl.input_strings.call_args[0][0]
         assert sent == cmd
 
-    def test_run_file_option(self, cli_runner, mock_mapdl, tmp_path):
+    def test_exec_file_option(self, cli_runner, mock_mapdl, tmp_path):
         """Commands are read from a file when ``--file`` is given."""
         script = tmp_path / "script.inp"
         script.write_text("/prep7\nBLOCK,0,1,0,1,0,1\n")
@@ -1340,7 +1340,7 @@ class TestCliRunCommand:
             "ansys.mapdl.core.launcher.connection.connect_to_existing",
             return_value=mock_mapdl,
         ):
-            result = cli_runner(["run", "--file", str(script)])
+            result = cli_runner(["exec", "--file", str(script)])
 
         assert result.exit_code == 0
         mock_mapdl.input_strings.assert_called_once()
@@ -1348,7 +1348,7 @@ class TestCliRunCommand:
         assert "/prep7" in sent
         assert "BLOCK,0,1,0,1,0,1" in sent
 
-    def test_run_stdin(self, mock_mapdl):
+    def test_exec_stdin(self, mock_mapdl):
         """Commands are read from stdin when ``-`` is the positional argument."""
         from click.testing import CliRunner
 
@@ -1359,12 +1359,12 @@ class TestCliRunCommand:
             "ansys.mapdl.core.launcher.connection.connect_to_existing",
             return_value=mock_mapdl,
         ):
-            result = runner.invoke(main, ["run", "-"], input="/prep7\nSAVE\n")
+            result = runner.invoke(main, ["exec", "-"], input="/prep7\nSAVE\n")
 
         assert result.exit_code == 0
         mock_mapdl.input_strings.assert_called_once()
 
-    def test_run_custom_port_and_ip(self, mock_mapdl):
+    def test_exec_custom_port_and_ip(self, mock_mapdl):
         """``--port`` and ``--ip`` are forwarded to ``connect_to_existing``."""
         from click.testing import CliRunner
 
@@ -1378,7 +1378,7 @@ class TestCliRunCommand:
         ) as mock_connect:
             result = runner.invoke(
                 main,
-                ["run", "--ip", "192.168.1.10", "--port", "50055", "-c", "/PREP7"],
+                ["exec", "--ip", "192.168.1.10", "--port", "50055", "-c", "/PREP7"],
             )
 
         assert result.exit_code == 0
@@ -1386,7 +1386,7 @@ class TestCliRunCommand:
         assert config.ip == "192.168.1.10"
         assert config.port == 50055
 
-    def test_run_clear_on_connect_flag(self, mock_mapdl):
+    def test_exec_clear_on_connect_flag(self, mock_mapdl):
         """``--clear-on-connect`` sets the matching LaunchConfig field."""
         from click.testing import CliRunner
 
@@ -1398,13 +1398,13 @@ class TestCliRunCommand:
             "ansys.mapdl.core.launcher.connection.connect_to_existing",
             return_value=mock_mapdl,
         ) as mock_connect:
-            result = runner.invoke(main, ["run", "--clear-on-connect", "-c", "/PREP7"])
+            result = runner.invoke(main, ["exec", "--clear-on-connect", "-c", "/PREP7"])
 
         assert result.exit_code == 0
         config: LaunchConfig = mock_connect.call_args[0][0]
         assert config.clear_on_connect is True
 
-    def test_run_default_no_clear_on_connect(self, mock_mapdl):
+    def test_exec_default_no_clear_on_connect(self, mock_mapdl):
         """By default ``clear_on_connect`` is ``False`` to preserve model state."""
         from click.testing import CliRunner
 
@@ -1416,13 +1416,13 @@ class TestCliRunCommand:
             "ansys.mapdl.core.launcher.connection.connect_to_existing",
             return_value=mock_mapdl,
         ) as mock_connect:
-            result = runner.invoke(main, ["run", "-c", "/PREP7"])
+            result = runner.invoke(main, ["exec", "-c", "/PREP7"])
 
         assert result.exit_code == 0
         config: LaunchConfig = mock_connect.call_args[0][0]
         assert config.clear_on_connect is False
 
-    def test_run_empty_output_no_echo(self, cli_runner):
+    def test_exec_empty_output_no_echo(self, cli_runner):
         """When MAPDL returns no output nothing extra is printed to stdout."""
         mock = MagicMock()
         mock.input_strings.return_value = ""
@@ -1431,7 +1431,7 @@ class TestCliRunCommand:
             "ansys.mapdl.core.launcher.connection.connect_to_existing",
             return_value=mock,
         ):
-            result = cli_runner(["run", "-c", "/PREP7"])
+            result = cli_runner(["exec", "-c", "/PREP7"])
 
         assert result.exit_code == 0
         assert result.output == ""
@@ -1440,20 +1440,20 @@ class TestCliRunCommand:
     # Error-path tests                                                     #
     # ------------------------------------------------------------------ #
 
-    def test_run_no_commands_error(self, cli_runner):
+    def test_exec_no_commands_error(self, cli_runner):
         """Omitting all input sources exits with an error."""
-        result = cli_runner("run")
+        result = cli_runner("exec")
         assert result.exit_code != 0
 
-    def test_run_commands_and_file_mutually_exclusive(self, cli_runner, tmp_path):
+    def test_exec_commands_and_file_mutually_exclusive(self, cli_runner, tmp_path):
         """Providing both -c and ``--file`` is rejected."""
         script = tmp_path / "script.inp"
         script.write_text("/PREP7\n")
 
-        result = cli_runner(["run", "-c", "/PREP7", "--file", str(script)])
+        result = cli_runner(["exec", "-c", "/PREP7", "--file", str(script)])
         assert result.exit_code != 0
 
-    def test_run_commands_and_stdin_mutually_exclusive(self, mock_mapdl):
+    def test_exec_commands_and_stdin_mutually_exclusive(self, mock_mapdl):
         """Providing both -c and stdin ``-`` is rejected."""
         from click.testing import CliRunner
 
@@ -1464,25 +1464,27 @@ class TestCliRunCommand:
             "ansys.mapdl.core.launcher.connection.connect_to_existing",
             return_value=mock_mapdl,
         ):
-            result = runner.invoke(main, ["run", "-c", "/PREP7", "-"], input="/prep7\n")
+            result = runner.invoke(
+                main, ["exec", "-c", "/PREP7", "-"], input="/prep7\n"
+            )
         assert result.exit_code != 0
 
-    def test_run_unknown_positional_error(self, cli_runner):
+    def test_exec_unknown_positional_error(self, cli_runner):
         """An unexpected positional argument that isn't ``-`` is rejected."""
-        result = cli_runner(["run", "some_command"])
+        result = cli_runner(["exec", "some_command"])
         assert result.exit_code != 0
 
-    def test_run_connection_error_exits_nonzero(self, cli_runner):
+    def test_exec_connection_error_exits_nonzero(self, cli_runner):
         """A connection failure exits with code 1 and prints an error."""
         with patch(
             "ansys.mapdl.core.launcher.connection.connect_to_existing",
             side_effect=ConnectionError("refused"),
         ):
-            result = cli_runner(["run", "-c", "/PREP7"])
+            result = cli_runner(["exec", "-c", "/PREP7"])
 
         assert result.exit_code == 1
 
-    def test_run_command_execution_error_exits_nonzero(self, cli_runner):
+    def test_exec_command_execution_error_exits_nonzero(self, cli_runner):
         """An error during command execution exits with code 1."""
         mock = MagicMock()
         mock.input_strings.side_effect = RuntimeError("bad command")
@@ -1491,11 +1493,11 @@ class TestCliRunCommand:
             "ansys.mapdl.core.launcher.connection.connect_to_existing",
             return_value=mock,
         ):
-            result = cli_runner(["run", "-c", "/PREP7"])
+            result = cli_runner(["exec", "-c", "/PREP7"])
 
         assert result.exit_code == 1
 
-    def test_run_start_instance_false(self, mock_mapdl):
+    def test_exec_start_instance_false(self, mock_mapdl):
         """LaunchConfig always has ``start_instance=False`` (never launches a new MAPDL)."""
         from click.testing import CliRunner
 
@@ -1507,7 +1509,7 @@ class TestCliRunCommand:
             "ansys.mapdl.core.launcher.connection.connect_to_existing",
             return_value=mock_mapdl,
         ) as mock_connect:
-            result = runner.invoke(main, ["run", "-c", "/PREP7"])
+            result = runner.invoke(main, ["exec", "-c", "/PREP7"])
 
         assert result.exit_code == 0
         config: LaunchConfig = mock_connect.call_args[0][0]


### PR DESCRIPTION
## Summary

Rename the pymapdl run CLI subcommand to pymapdl exec to better align with docker exec semantics.

## Changes

### Source
- cli/run.py -> cli/exec.py: function renamed run() -> exec_cmd() to avoid shadowing the Python builtin exec
- cli/__init__.py: import updated, command registered as exec

### Tests
- TestCliRunCommand -> TestCliExecCommand
- All 16 test methods renamed test_run_* -> test_exec_*
- All 16 tests pass

### Documentation
- New Execute MAPDL commands section in doc/source/user_guide/cli.rst
- Covers all three input modes (-c, --file, stdin -), --clear-on-connect flag, and a full start -> exec -> stop workflow

### Changelog
- doc/changelog.d/4516.added.md updated to reflect the rename

Related: #4516