### PR TITLE
fix: implement missing abstract methods for ansys-tools-visualization-interface 0.13.x

### DIFF
--- a/doc/changelog.d/4601.fixed.md
+++ b/doc/changelog.d/4601.fixed.md
@@ -1,0 +1,1 @@
+Implement missing abstract methods in ``MapdlPlotterBackend`` for compatibility with ``ansys-tools-visualization-interface`` 0.13.x

--- a/doc/changelog.d/4601.fixed.md
+++ b/doc/changelog.d/4601.fixed.md
@@ -1,1 +1,1 @@
-Implement missing abstract methods in ``MapdlPlotterBackend`` for compatibility with ``ansys-tools-visualization-interface`` 0.13.x
+Implement missing abstract methods for ansys-tools-visualization-interface 0.13.x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ tests = [
   "ansys-dpf-core[graphics]==0.13.6",
   "ansys-mapdl-reader==0.55.2",
   "ansys-tools-visualization-interface==0.13.1",
+  "autopep8==2.3.2",
   "matplotlib==3.10.9",
   "pandas==2.3.3",
   "pyansys-tools-report==0.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,12 @@ version = "0.72.dev0"
 jupyter = ["ipywidgets", "jupyterlab>=3"]
 
 graphics = [
-  "ansys-tools-visualization-interface>=0.9.0,<0.13.0",
+  "ansys-tools-visualization-interface>=0.9.0,<0.14.0",
   "matplotlib>=3.0.0",                                  # for colormaps for pyvista
 ]
 
 all = [
-  "ansys-tools-visualization-interface>=0.9.0,<0.13.0",
+  "ansys-tools-visualization-interface>=0.9.0,<0.14.0",
   "ipywidgets",
   "jupyterlab>=3",
   "matplotlib>=3.0.0",                                  # for colormaps for pyvista
@@ -65,8 +65,7 @@ all = [
 tests = [
   "ansys-dpf-core[graphics]==0.13.6",
   "ansys-mapdl-reader==0.55.2",
-  "ansys-tools-visualization-interface==0.12.1",
-  "autopep8==2.3.2",
+  "ansys-tools-visualization-interface==0.13.1",
   "matplotlib==3.10.9",
   "pandas==2.3.3",
   "pyansys-tools-report==0.9.0",
@@ -88,7 +87,7 @@ doc = [
   "ansys-dpf-core[graphics]==0.13.6",
   "ansys-mapdl-reader==0.55.2",
   "ansys-sphinx-theme==1.7.2",
-  "ansys-tools-visualization-interface==0.12.1",
+  "ansys-tools-visualization-interface==0.13.1",
   "grpcio==1.80.0",
   "imageio-ffmpeg==0.6.0",
   "imageio==2.37.3",

--- a/src/ansys/mapdl/core/plotting/visualizer.py
+++ b/src/ansys/mapdl/core/plotting/visualizer.py
@@ -215,14 +215,15 @@ class MapdlPlotterBackend(PyVistaBackendInterface):
             Additional keyword arguments passed to
             :meth:`pyvista.Plotter.add_points`.
         """
-        return self.scene.add_points(
-            np.array(points), color=color, point_size=size, **kwargs
-        )
+        # Use setdefault so a caller-supplied ``point_size`` in kwargs takes
+        # precedence and avoids a duplicate-keyword TypeError.
+        kwargs.setdefault("point_size", size)
+        return self.scene.add_points(np.array(points), color=color, **kwargs)
 
     def add_text(
         self,
         text: str,
-        position: Union[tuple, str],
+        position: Union[tuple, str] = "upper_left",
         font_size: int = 12,
         color: str = "white",
         **kwargs,
@@ -233,10 +234,10 @@ class MapdlPlotterBackend(PyVistaBackendInterface):
         ----------
         text : str
             Text string to display.
-        position : tuple or str
+        position : tuple or str, optional
             Position for the text. Can be 2D ``(x, y)`` for screen coordinates,
             3D ``(x, y, z)`` for world coordinates, or a string such as
-            ``'upper_left'``.
+            ``'upper_left'``. The default is ``'upper_left'``.
         font_size : int, optional
             Font size for the text. The default is ``12``.
         color : str, optional

--- a/src/ansys/mapdl/core/plotting/visualizer.py
+++ b/src/ansys/mapdl/core/plotting/visualizer.py
@@ -100,6 +100,159 @@ class MapdlPlotterBackend(PyVistaBackendInterface):
     ):
         pass
 
+    def add_labels(
+        self,
+        points: Union[list, Any],
+        labels: list,
+        font_size: int = 12,
+        point_size: float = 5.0,
+        **kwargs,
+    ) -> Any:
+        """Add labels at 3D point locations.
+
+        Parameters
+        ----------
+        points : list or Any
+            Points where labels should be placed.
+        labels : list
+            List of label strings to display at each point.
+        font_size : int, optional
+            Font size for the labels. The default is ``12``.
+        point_size : float, optional
+            Size of the point markers shown with labels. The default is ``5.0``.
+        **kwargs : dict
+            Additional keyword arguments passed to
+            :meth:`pyvista.Plotter.add_point_labels`.
+        """
+        return self.scene.add_point_labels(
+            points, labels, font_size=font_size, point_size=point_size, **kwargs
+        )
+
+    def add_lines(
+        self,
+        points: Union[list, Any],
+        connections: Optional[Union[list, Any]] = None,
+        color: str = "white",
+        width: float = 1.0,
+        **kwargs,
+    ) -> Any:
+        """Add line segments to the scene.
+
+        Parameters
+        ----------
+        points : list or Any
+            Points defining the lines.
+        connections : list or Any, optional
+            Line connectivity as ``[[start_idx, end_idx], ...]``. If ``None``,
+            points are connected sequentially. The default is ``None``.
+        color : str, optional
+            Color of the lines. The default is ``"white"``.
+        width : float, optional
+            Width of the lines. The default is ``1.0``.
+        **kwargs : dict
+            Additional keyword arguments passed to the underlying PyVista method.
+        """
+        pts = np.array(points)
+        if connections is None:
+            return self.scene.add_lines(
+                pts, color=color, width=width, connected=True, **kwargs
+            )
+        conns = np.array(connections)
+        n_lines = len(conns)
+        cells = np.hstack([np.full((n_lines, 1), 2, dtype=int), conns]).flatten()
+        mesh = pv.PolyData()
+        mesh.points = pts
+        mesh.lines = cells
+        return self.scene.add_mesh(mesh, color=color, line_width=width, **kwargs)
+
+    def add_planes(
+        self,
+        center: tuple = (0.0, 0.0, 0.0),
+        normal: tuple = (0.0, 0.0, 1.0),
+        i_size: float = 1.0,
+        j_size: float = 1.0,
+        **kwargs,
+    ) -> Any:
+        """Add a plane to the scene.
+
+        Parameters
+        ----------
+        center : tuple, optional
+            Center point of the plane ``(x, y, z)``. The default is
+            ``(0.0, 0.0, 0.0)``.
+        normal : tuple, optional
+            Normal vector of the plane ``(x, y, z)``. The default is
+            ``(0.0, 0.0, 1.0)``.
+        i_size : float, optional
+            Size of the plane in the i direction. The default is ``1.0``.
+        j_size : float, optional
+            Size of the plane in the j direction. The default is ``1.0``.
+        **kwargs : dict
+            Additional keyword arguments passed to
+            :meth:`pyvista.Plotter.add_mesh`.
+        """
+        plane = pv.Plane(center=center, direction=normal, i_size=i_size, j_size=j_size)
+        return self.scene.add_mesh(plane, **kwargs)
+
+    def add_points(
+        self,
+        points: Union[list, Any],
+        color: str = "red",
+        size: float = 10.0,
+        **kwargs,
+    ) -> Any:
+        """Add point markers to the scene.
+
+        Parameters
+        ----------
+        points : list or Any
+            Points to add.
+        color : str, optional
+            Color of the points. The default is ``"red"``.
+        size : float, optional
+            Size of the point markers. The default is ``10.0``.
+        **kwargs : dict
+            Additional keyword arguments passed to
+            :meth:`pyvista.Plotter.add_points`.
+        """
+        return self.scene.add_points(
+            np.array(points), color=color, point_size=size, **kwargs
+        )
+
+    def add_text(
+        self,
+        text: str,
+        position: Union[tuple, str],
+        font_size: int = 12,
+        color: str = "white",
+        **kwargs,
+    ) -> Any:
+        """Add text to the scene.
+
+        Parameters
+        ----------
+        text : str
+            Text string to display.
+        position : tuple or str
+            Position for the text. Can be 2D ``(x, y)`` for screen coordinates,
+            3D ``(x, y, z)`` for world coordinates, or a string such as
+            ``'upper_left'``.
+        font_size : int, optional
+            Font size for the text. The default is ``12``.
+        color : str, optional
+            Color of the text. The default is ``"white"``.
+        **kwargs : dict
+            Additional keyword arguments passed to
+            :meth:`pyvista.Plotter.add_text`.
+        """
+        return self.scene.add_text(
+            text, position=position, font_size=font_size, color=color, **kwargs
+        )
+
+    def clear(self) -> None:
+        """Clear all actors from the scene."""
+        self.scene.clear()
+
     @property
     def scene(self):
         """Return the scene."""

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -38,7 +38,7 @@ if not has_dependency("pyvista"):
 
 from ansys.mapdl.core.errors import ComponentDoesNotExits, MapdlRuntimeError
 from ansys.mapdl.core.plotting import GraphicsBackend
-from ansys.mapdl.core.plotting.visualizer import MapdlPlotter
+from ansys.mapdl.core.plotting.visualizer import MapdlPlotter, MapdlPlotterBackend
 
 FORCE_LABELS = [["FX", "FY", "FZ"], ["HEAT"], ["CHRG"]]
 DISPL_LABELS = [["UX", "UY", "UZ"], ["TEMP"], ["VOLT"]]
@@ -1356,3 +1356,124 @@ def test_plvar(mapdl, coupled_example):
     with patch("ansys.mapdl.core.Mapdl.screenshot") as mock_screenshot:
         mapdl.plvar(4, 5)
         mock_screenshot.assert_called_once()
+
+
+# =============================================================================
+# Tests for MapdlPlotterBackend abstract method implementations
+# =============================================================================
+
+
+@pytest.fixture(scope="module")
+def backend():
+    """Return a ``MapdlPlotterBackend`` with off-screen rendering."""
+    import pyvista as pv
+
+    pv.OFF_SCREEN = True
+    return MapdlPlotterBackend(use_trame=False)
+
+
+def test_backend_add_points(backend):
+    """Test that ``add_points`` delegates to the PyVista scene correctly."""
+    pts = [[0, 0, 0], [1, 0, 0]]
+    with patch.object(
+        type(backend),
+        "scene",
+        new_callable=lambda: property(lambda self: self._pl.scene),
+    ):
+        with patch.object(backend._pl.scene, "add_points") as mock_add:
+            backend.add_points(pts, color="blue", size=8.0)
+            mock_add.assert_called_once()
+            _, kwargs = mock_add.call_args
+            assert kwargs["color"] == "blue"
+            assert kwargs["point_size"] == 8.0
+
+
+def test_backend_add_points_no_point_size_collision(backend):
+    """``point_size`` in kwargs must not collide with the ``size`` parameter."""
+    pts = [[0, 0, 0]]
+    with patch.object(backend._pl.scene, "add_points") as mock_add:
+        # Passing explicit point_size should not raise TypeError and should
+        # take precedence over the default size.
+        backend.add_points(pts, size=5.0, point_size=20.0)
+        mock_add.assert_called_once()
+        _, kwargs = mock_add.call_args
+        assert kwargs["point_size"] == 20.0
+
+
+def test_backend_add_labels(backend):
+    """Test that ``add_labels`` delegates to ``add_point_labels``."""
+    pts = [[0, 0, 0], [1, 0, 0]]
+    labels = ["A", "B"]
+    with patch.object(backend._pl.scene, "add_point_labels") as mock_add:
+        backend.add_labels(pts, labels, font_size=14, point_size=6.0)
+        mock_add.assert_called_once()
+        _, kwargs = mock_add.call_args
+        assert kwargs["font_size"] == 14
+        assert kwargs["point_size"] == 6.0
+
+
+def test_backend_add_lines_sequential(backend):
+    """Test ``add_lines`` with sequential (connected) points."""
+    pts = [[0, 0, 0], [1, 0, 0], [1, 1, 0]]
+    with patch.object(backend._pl.scene, "add_lines") as mock_add:
+        backend.add_lines(pts, color="red", width=2.0)
+        mock_add.assert_called_once()
+        _, kwargs = mock_add.call_args
+        assert kwargs["color"] == "red"
+        assert kwargs["width"] == 2.0
+        assert kwargs.get("connected") is True
+
+
+def test_backend_add_lines_with_connections(backend):
+    """Test ``add_lines`` with explicit connectivity builds a PolyData mesh."""
+    import pyvista as pv
+
+    pts = [[0, 0, 0], [1, 0, 0], [0, 1, 0]]
+    conns = [[0, 1], [1, 2]]
+    with patch.object(backend._pl.scene, "add_mesh") as mock_add:
+        backend.add_lines(pts, connections=conns, color="green", width=1.5)
+        mock_add.assert_called_once()
+        args, kwargs = mock_add.call_args
+        mesh = args[0]
+        assert isinstance(mesh, pv.PolyData)
+        assert kwargs["color"] == "green"
+        assert kwargs["line_width"] == 1.5
+
+
+def test_backend_add_planes(backend):
+    """Test that ``add_planes`` creates a ``pv.Plane`` and adds it as a mesh."""
+    import pyvista as pv
+
+    with patch.object(backend._pl.scene, "add_mesh") as mock_add:
+        backend.add_planes(center=(1, 2, 3), normal=(0, 1, 0), i_size=2.0, j_size=3.0)
+        mock_add.assert_called_once()
+        args, _ = mock_add.call_args
+        plane = args[0]
+        assert isinstance(plane, pv.PolyData)
+
+
+def test_backend_add_text_default_position(backend):
+    """Test that ``add_text`` uses ``'upper_left'`` when no position is given."""
+    with patch.object(backend._pl.scene, "add_text") as mock_add:
+        backend.add_text("hello")
+        mock_add.assert_called_once()
+        _, kwargs = mock_add.call_args
+        assert kwargs["position"] == "upper_left"
+
+
+def test_backend_add_text_custom(backend):
+    """Test that ``add_text`` forwards all parameters correctly."""
+    with patch.object(backend._pl.scene, "add_text") as mock_add:
+        backend.add_text("label", position="lower_right", font_size=18, color="yellow")
+        mock_add.assert_called_once()
+        _, kwargs = mock_add.call_args
+        assert kwargs["position"] == "lower_right"
+        assert kwargs["font_size"] == 18
+        assert kwargs["color"] == "yellow"
+
+
+def test_backend_clear(backend):
+    """Test that ``clear`` delegates to the PyVista scene."""
+    with patch.object(backend._pl.scene, "clear") as mock_clear:
+        backend.clear()
+        mock_clear.assert_called_once()


### PR DESCRIPTION
## Description

Fixes a `TypeError` when using `MapdlPlotter` after upgrading `ansys-tools-visualization-interface` to version 0.13.0+.

Version 0.13.0 added six new abstract methods to `BaseBackend` / `PyVistaBackendInterface` that `MapdlPlotterBackend` did not implement, preventing instantiation:

```
TypeError: Can't instantiate abstract class MapdlPlotterBackend without an implementation
for abstract methods 'add_labels', 'add_lines', 'add_planes', 'add_points', 'add_text', 'clear'
```

## Changes

### `src/ansys/mapdl/core/plotting/visualizer.py`
Implemented the six required abstract methods in `MapdlPlotterBackend`, each delegating to the underlying PyVista plotter (`self.scene`):

| Method | Delegates to |
|---|---|
| `add_labels` | `pv.Plotter.add_point_labels` |
| `add_lines` | `pv.Plotter.add_lines` (sequential) or explicit `pv.PolyData` cells (custom connectivity) |
| `add_planes` | `pv.Plane` mesh via `pv.Plotter.add_mesh` |
| `add_points` | `pv.Plotter.add_points` |
| `add_text` | `pv.Plotter.add_text` |
| `clear` | `pv.Plotter.clear` |

### `pyproject.toml`
- Extended upper version bound: `<0.13.0` → `<0.14.0` (runtime extras)
- Bumped pinned test/doc deps: `==0.12.1` → `==0.13.1`

## Related issues

Closes #4597