### PR TITLE
docs: add CITATION.cff for software citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,60 @@
+cff-version: 1.2.0
+title: PyMAPDL
+message: >-
+  If you use this software, please cite it using the metadata
+  from this file.
+type: software
+authors:
+  - given-names: German
+    family-names: Ayuso
+    alias: germa89
+    affiliation: Ansys Inc.
+  - given-names: Alex
+    family-names: Kaszynski
+    alias: akaszynski
+  - given-names: Camille
+    family-names: Latapie
+    alias: clatapie
+    affiliation: Ansys Inc.
+  - given-names: James
+    family-names: Derrick
+    alias: jgd10
+  - given-names: Roberto
+    family-names: Pastor Muela
+    alias: RobPasMue
+    affiliation: Ansys Inc.
+  - given-names: Jamil
+    family-names: Hajjar
+    alias: Gryfenfer97
+    affiliation: Ansys Inc.
+  - given-names: Revathy
+    family-names: Venugopal
+    alias: Revathyvenugopal162
+    affiliation: Ansys Inc.
+  - given-names: Jorge
+    family-names: Martínez
+    alias: jorgepiloto
+    affiliation: Ansys Inc.
+  - given-names: Kathy
+    family-names: Pippert
+    alias: PipKat
+    affiliation: Ansys Inc.
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.5726008
+    description: The Zenodo DOI for PyMAPDL
+repository-code: 'https://github.com/ansys/pymapdl'
+url: 'https://mapdl.docs.pyansys.com'
+abstract: >-
+  PyMAPDL is a Python client library for Ansys MAPDL (Mechanical APDL).
+  It enables Pythonic access to MAPDL, supporting remote connections via
+  gRPC, direct access to MAPDL arrays and meshes as Python objects, and
+  a SciPy-like interface to the APDL math solver.
+keywords:
+  - ansys
+  - mapdl
+  - finite-element-analysis
+  - simulation
+  - python
+  - pyansys
+license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -57,7 +57,10 @@ authors:
     family-names: Fernandez
     alias: AlejandroFernandezLuces
     affiliation: Ansys Inc.
-  - alias: FredAns
+  - given-names: Frederic
+    family-names: Thevenon
+    alias: FredAns
+    affiliation: Ansys Inc.
     affiliation: Ansys Inc.
   - given-names: Sébastien
     family-names: Morais

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -65,6 +65,7 @@ authors:
   - given-names: Sébastien
     family-names: Morais
     alias: SMoraisAnsys
+    affiliation: Ansys Inc.
 identifiers:
   - type: doi
     value: 10.5281/zenodo.5726008

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,6 +44,7 @@ authors:
   - given-names: Kevin
     family-names: Koshy
     alias: kmkoshy
+    affiliation: Ansys Inc.
   - given-names: Roman
     family-names: Ilchenko
     alias: RomanIlchenko1308
@@ -51,7 +52,7 @@ authors:
   - given-names: Mohamed
     family-names: Koubaa
     alias: koubaa
-    affiliation: Synopsys
+    affiliation: Ansys Inc.
   - given-names: Alex
     family-names: Fernandez
     alias: AlejandroFernandezLuces

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -19,6 +19,7 @@ authors:
   - given-names: James
     family-names: Derrick
     alias: jgd10
+    affiliation: Ansys Inc.
   - given-names: Roberto
     family-names: Pastor Muela
     alias: RobPasMue
@@ -39,6 +40,27 @@ authors:
     family-names: Pippert
     alias: PipKat
     affiliation: Ansys Inc.
+  - alias: natter1
+  - given-names: Kevin
+    family-names: Koshy
+    alias: kmkoshy
+  - given-names: Roman
+    family-names: Ilchenko
+    alias: RomanIlchenko1308
+    affiliation: Mercedes-Benz
+  - given-names: Mohamed
+    family-names: Koubaa
+    alias: koubaa
+    affiliation: Synopsys
+  - given-names: Alex
+    family-names: Fernandez
+    alias: AlejandroFernandezLuces
+    affiliation: Ansys Inc.
+  - alias: FredAns
+    affiliation: Ansys Inc.
+  - given-names: Sébastien
+    family-names: Morais
+    alias: SMoraisAnsys
 identifiers:
   - type: doi
     value: 10.5281/zenodo.5726008

--- a/doc/changelog.d/4603.documentation.md
+++ b/doc/changelog.d/4603.documentation.md
@@ -1,0 +1,1 @@
+Add CITATION.cff for software citation metadata

--- a/doc/styles/config/vocabularies/ANSYS/accept.txt
+++ b/doc/styles/config/vocabularies/ANSYS/accept.txt
@@ -209,3 +209,4 @@ Windows Subsystem for Linux
 wsl
 WSL
 Zhu
+Synopsys


### PR DESCRIPTION
## Summary

Adds a `CITATION.cff` file at the repository root.

Closes #4602

## Motivation

The repository lacked a `CITATION.cff` file, which caused Zenodo to auto-generate citation metadata from GitHub contributor data on every release. This led to issues such as:
- Duplicate author entries in the Zenodo record (as seen in [record 5726008](https://zenodo.org/records/5726008))
- GitHub usernames instead of real names for some contributors
- No project control over author ordering or inclusion

Raised by @germa89 in #4561.

## Changes

- Add `CITATION.cff` following the [Citation File Format](https://citation-file-format.github.io/) v1.2 standard
- Author list ordered by contribution count (all-time GitHub commits)
- Links to the existing Zenodo DOI (`10.5281/zenodo.5726008`)

## Effects

- GitHub will display a **"Cite this repository"** widget on the repo home page
- Zenodo will use this file to populate metadata on future releases
- Maintainers can update author list/ordering by editing this file