### PR TITLE
fix: automatic port assignment

### DIFF
--- a/doc/changelog.d/4622.fixed.md
+++ b/doc/changelog.d/4622.fixed.md
@@ -1,0 +1,1 @@
+Automatic port assignment

--- a/doc/changelog.d/4628.maintenance.md
+++ b/doc/changelog.d/4628.maintenance.md
@@ -1,0 +1,1 @@
+Bump version from 0.72.dev0 to 0.74.dev0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ maintainers = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
 name = "ansys-mapdl-core"
 readme = "README.md"
 requires-python = ">=3.10,<3.15" # Update also 'MINIMUM_PYTHON_VERSION' in src/ansys/mapdl/core/__init__.py
-version = "0.72.dev0"
+version = "0.74.dev0"
 
 [project.optional-dependencies]
 jupyter = ["ipywidgets", "jupyterlab>=3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ maintainers = [{ name = "ANSYS, Inc.", email = "pyansys.core@ansys.com" }]
 name = "ansys-mapdl-core"
 readme = "README.md"
 requires-python = ">=3.10,<3.15" # Update also 'MINIMUM_PYTHON_VERSION' in src/ansys/mapdl/core/__init__.py
-version = "0.74.dev0"
+version = "0.72.dev0"
 
 [project.optional-dependencies]
 jupyter = ["ipywidgets", "jupyterlab>=3"]

--- a/src/ansys/mapdl/core/launcher/config.py
+++ b/src/ansys/mapdl/core/launcher/config.py
@@ -27,8 +27,14 @@ This module contains pure functions that resolve configuration from:
 2. Environment variables
 3. System defaults
 
-All functions are pure (same input → same output) and raise
+Most helper functions are pure (same input -> same output) and raise
 ConfigurationError for invalid states.
+
+Note
+----
+``resolve_launch_config`` may perform runtime port availability probing when
+starting a local instance without an explicitly requested port. In that case,
+the resolved port can depend on host runtime state.
 """
 
 import os
@@ -93,6 +99,13 @@ def resolve_launch_config(
     1. Explicit argument (if not None)
     2. Environment variable (if set)
     3. Default value
+
+    Note
+    ----
+    When launching a new local instance and no port is explicitly requested
+    (via ``port`` argument or ``PYMAPDL_PORT`` presence), this function can probe
+    port availability and auto-select the next free port if the default is busy.
+    Therefore, the final resolved ``port`` may depend on runtime host state.
 
     This function combines user-provided arguments, environment variable
     overrides, and system defaults to produce a complete ``LaunchConfig``

--- a/src/ansys/mapdl/core/launcher/config.py
+++ b/src/ansys/mapdl/core/launcher/config.py
@@ -383,6 +383,25 @@ def resolve_launch_config(
     # Resolve core parameters
     resolved_run_location = resolve_run_location(run_location)
     resolved_port = resolve_port(port)
+
+    # When starting a new instance and the user did not explicitly request a
+    # specific port (neither via the argument nor PYMAPDL_PORT env var),
+    # automatically find the next available port if the default is already
+    # occupied.
+    _port_explicitly_set = port is not None or os.getenv("PYMAPDL_PORT") is not None
+    if resolved_start_instance and not _port_explicitly_set:
+        try:
+            from .network import check_port_status, find_available_port
+
+            _status = check_port_status(resolved_port)
+            if not _status.available:
+                resolved_port = find_available_port(start_port=resolved_port)
+                LOG.debug(
+                    f"Default port was in use; automatically selected port {resolved_port}."
+                )
+        except Exception as e:
+            LOG.debug(f"Could not auto-select available port: {e}")
+
     resolved_ip = resolve_ip(ip, resolved_start_instance, launch_on_hpc=launch_on_hpc)
     resolved_mode = resolve_mode(mode, resolved_version)
     resolved_nproc = resolve_nproc(nproc)

--- a/src/ansys/mapdl/core/launcher/config.py
+++ b/src/ansys/mapdl/core/launcher/config.py
@@ -388,7 +388,7 @@ def resolve_launch_config(
     # specific port (neither via the argument nor PYMAPDL_PORT env var),
     # automatically find the next available port if the default is already
     # occupied.
-    _port_explicitly_set = port is not None or os.getenv("PYMAPDL_PORT") is not None
+    _port_explicitly_set = port is not None or bool(os.getenv("PYMAPDL_PORT"))
     if resolved_start_instance and not _port_explicitly_set:
         try:
             from .network import check_port_status, find_available_port

--- a/tests/test_launcher/test_config.py
+++ b/tests/test_launcher/test_config.py
@@ -388,7 +388,9 @@ class TestAutoPortSelection:
             config = resolve_launch_config(port=None, start_instance=True)
 
             assert config.port == 50052
-            mock_debug.assert_any_call("Could not auto-select available port: error cause")
+            mock_debug.assert_any_call(
+                "Could not auto-select available port: error cause"
+            )
 
 
 class TestConfigNproc:

--- a/tests/test_launcher/test_config.py
+++ b/tests/test_launcher/test_config.py
@@ -300,9 +300,7 @@ class TestAutoPortSelection:
                 "ansys.mapdl.core.launcher.config.resolve_exec_file",
                 return_value="/fake/mapdl",
             ),
-            patch(
-                "ansys.mapdl.core.launcher.config.resolve_version", return_value=252
-            ),
+            patch("ansys.mapdl.core.launcher.config.resolve_version", return_value=252),
             patch(
                 "ansys.mapdl.core.launcher.network.check_port_status",
                 side_effect=[busy_status, busy_status, free_status],
@@ -332,9 +330,7 @@ class TestAutoPortSelection:
                 "ansys.mapdl.core.launcher.config.resolve_exec_file",
                 return_value="/fake/mapdl",
             ),
-            patch(
-                "ansys.mapdl.core.launcher.config.resolve_version", return_value=252
-            ),
+            patch("ansys.mapdl.core.launcher.config.resolve_version", return_value=252),
             patch(
                 "ansys.mapdl.core.launcher.network.check_port_status",
                 return_value=busy_status,
@@ -364,9 +360,7 @@ class TestAutoPortSelection:
                 "ansys.mapdl.core.launcher.config.resolve_exec_file",
                 return_value="/fake/mapdl",
             ),
-            patch(
-                "ansys.mapdl.core.launcher.config.resolve_version", return_value=252
-            ),
+            patch("ansys.mapdl.core.launcher.config.resolve_version", return_value=252),
             patch(
                 "ansys.mapdl.core.launcher.network.check_port_status",
                 return_value=busy_status,

--- a/tests/test_launcher/test_config.py
+++ b/tests/test_launcher/test_config.py
@@ -317,10 +317,6 @@ class TestAutoPortSelection:
 
     def test_does_not_auto_select_when_port_is_explicit(self):
         """When a port is explicitly provided, it is used as-is (no auto-selection)."""
-        from ansys.mapdl.core.launcher.models import PortStatus
-
-        busy_status = PortStatus(available=False, used_by_mapdl=True, port=50100)
-
         with (
             patch(
                 "ansys.mapdl.core.launcher.config.resolve_start_instance",
@@ -333,22 +329,19 @@ class TestAutoPortSelection:
             patch("ansys.mapdl.core.launcher.config.resolve_version", return_value=252),
             patch(
                 "ansys.mapdl.core.launcher.network.check_port_status",
-                return_value=busy_status,
-            ),
+            ) as mock_check_port_status,
             patch(
                 "ansys.mapdl.core.launcher.validation.validate_config",
-            ) as mock_check_port_status,
+                return_value=None,
+            ),
         ):
             # Explicit port — should stay at 50100 even though it is "busy"
             config = resolve_launch_config(port=50100, start_instance=True)
             assert config.port == 50100
+            mock_check_port_status.assert_not_called()
 
     def test_does_not_auto_select_when_pymapdl_port_env_set(self):
         """When PYMAPDL_PORT env var is set, auto-selection is not triggered."""
-            mock_check_port_status.assert_not_called()
-        from ansys.mapdl.core.launcher.models import PortStatus
-        busy_status = PortStatus(available=False, used_by_mapdl=True, port=50200)
-
         with (
             patch.dict(os.environ, {"PYMAPDL_PORT": "50200"}),
             patch(
@@ -362,8 +355,7 @@ class TestAutoPortSelection:
             patch("ansys.mapdl.core.launcher.config.resolve_version", return_value=252),
             patch(
                 "ansys.mapdl.core.launcher.network.check_port_status",
-                return_value=busy_status,
-            ),
+            ) as mock_check_port_status,
             patch(
                 "ansys.mapdl.core.launcher.validation.validate_config",
                 return_value=None,
@@ -371,6 +363,7 @@ class TestAutoPortSelection:
         ):
             config = resolve_launch_config(port=None, start_instance=True)
             assert config.port == 50200
+            mock_check_port_status.assert_not_called()
 
 
 class TestConfigNproc:

--- a/tests/test_launcher/test_config.py
+++ b/tests/test_launcher/test_config.py
@@ -292,6 +292,7 @@ class TestAutoPortSelection:
         free_status = PortStatus(available=True, used_by_mapdl=False, port=50053)
 
         with (
+            patch.dict(os.environ, {"PYMAPDL_PORT": ""}),
             patch(
                 "ansys.mapdl.core.launcher.config.resolve_start_instance",
                 return_value=True,

--- a/tests/test_launcher/test_config.py
+++ b/tests/test_launcher/test_config.py
@@ -366,6 +366,30 @@ class TestAutoPortSelection:
             assert config.port == 50200
             mock_check_port_status.assert_not_called()
 
+    def test_keeps_default_port_when_auto_selection_probe_fails(self):
+        """When auto-selection probing fails, keep the resolved default port."""
+        with (
+            patch.dict(os.environ, {"PYMAPDL_PORT": ""}),
+            patch(
+                "ansys.mapdl.core.launcher.config.resolve_start_instance",
+                return_value=True,
+            ),
+            patch(
+                "ansys.mapdl.core.launcher.config.resolve_exec_file",
+                return_value="/fake/mapdl",
+            ),
+            patch("ansys.mapdl.core.launcher.config.resolve_version", return_value=252),
+            patch(
+                "ansys.mapdl.core.launcher.network.check_port_status",
+                side_effect=RuntimeError("error cause"),
+            ),
+            patch("ansys.mapdl.core.launcher.config.LOG.debug") as mock_debug,
+        ):
+            config = resolve_launch_config(port=None, start_instance=True)
+
+            assert config.port == 50052
+            mock_debug.assert_any_call("Could not auto-select available port: error cause")
+
 
 class TestConfigNproc:
     """Tests for nproc resolution."""

--- a/tests/test_launcher/test_config.py
+++ b/tests/test_launcher/test_config.py
@@ -281,6 +281,105 @@ class TestConfigPort:
             assert port is not None and port > 0
 
 
+class TestAutoPortSelection:
+    """Tests for automatic port selection when default port is in use."""
+
+    def test_auto_selects_next_port_when_default_in_use(self):
+        """When no port is given and the default is busy, the next free port is used."""
+        from ansys.mapdl.core.launcher.models import PortStatus
+
+        busy_status = PortStatus(available=False, used_by_mapdl=True, port=50052)
+        free_status = PortStatus(available=True, used_by_mapdl=False, port=50053)
+
+        with (
+            patch(
+                "ansys.mapdl.core.launcher.config.resolve_start_instance",
+                return_value=True,
+            ),
+            patch(
+                "ansys.mapdl.core.launcher.config.resolve_exec_file",
+                return_value="/fake/mapdl",
+            ),
+            patch(
+                "ansys.mapdl.core.launcher.config.resolve_version", return_value=252
+            ),
+            patch(
+                "ansys.mapdl.core.launcher.network.check_port_status",
+                side_effect=[busy_status, busy_status, free_status],
+            ),
+            patch(
+                "ansys.mapdl.core.launcher.validation.validate_config",
+                return_value=None,
+            ),
+        ):
+            config = resolve_launch_config(port=None, start_instance=True)
+            # Port must have been bumped away from the busy 50052
+            assert config.port != 50052
+            assert config.port > 50052
+
+    def test_does_not_auto_select_when_port_is_explicit(self):
+        """When a port is explicitly provided, it is used as-is (no auto-selection)."""
+        from ansys.mapdl.core.launcher.models import PortStatus
+
+        busy_status = PortStatus(available=False, used_by_mapdl=True, port=50100)
+
+        with (
+            patch(
+                "ansys.mapdl.core.launcher.config.resolve_start_instance",
+                return_value=True,
+            ),
+            patch(
+                "ansys.mapdl.core.launcher.config.resolve_exec_file",
+                return_value="/fake/mapdl",
+            ),
+            patch(
+                "ansys.mapdl.core.launcher.config.resolve_version", return_value=252
+            ),
+            patch(
+                "ansys.mapdl.core.launcher.network.check_port_status",
+                return_value=busy_status,
+            ),
+            patch(
+                "ansys.mapdl.core.launcher.validation.validate_config",
+                return_value=None,
+            ),
+        ):
+            # Explicit port — should stay at 50100 even though it is "busy"
+            config = resolve_launch_config(port=50100, start_instance=True)
+            assert config.port == 50100
+
+    def test_does_not_auto_select_when_pymapdl_port_env_set(self):
+        """When PYMAPDL_PORT env var is set, auto-selection is not triggered."""
+        from ansys.mapdl.core.launcher.models import PortStatus
+
+        busy_status = PortStatus(available=False, used_by_mapdl=True, port=50200)
+
+        with (
+            patch.dict(os.environ, {"PYMAPDL_PORT": "50200"}),
+            patch(
+                "ansys.mapdl.core.launcher.config.resolve_start_instance",
+                return_value=True,
+            ),
+            patch(
+                "ansys.mapdl.core.launcher.config.resolve_exec_file",
+                return_value="/fake/mapdl",
+            ),
+            patch(
+                "ansys.mapdl.core.launcher.config.resolve_version", return_value=252
+            ),
+            patch(
+                "ansys.mapdl.core.launcher.network.check_port_status",
+                return_value=busy_status,
+            ),
+            patch(
+                "ansys.mapdl.core.launcher.validation.validate_config",
+                return_value=None,
+            ),
+        ):
+            config = resolve_launch_config(port=None, start_instance=True)
+            assert config.port == 50200
+
+
 class TestConfigNproc:
     """Tests for nproc resolution."""
 

--- a/tests/test_launcher/test_config.py
+++ b/tests/test_launcher/test_config.py
@@ -337,8 +337,7 @@ class TestAutoPortSelection:
             ),
             patch(
                 "ansys.mapdl.core.launcher.validation.validate_config",
-                return_value=None,
-            ),
+            ) as mock_check_port_status,
         ):
             # Explicit port — should stay at 50100 even though it is "busy"
             config = resolve_launch_config(port=50100, start_instance=True)
@@ -346,8 +345,8 @@ class TestAutoPortSelection:
 
     def test_does_not_auto_select_when_pymapdl_port_env_set(self):
         """When PYMAPDL_PORT env var is set, auto-selection is not triggered."""
+            mock_check_port_status.assert_not_called()
         from ansys.mapdl.core.launcher.models import PortStatus
-
         busy_status = PortStatus(available=False, used_by_mapdl=True, port=50200)
 
         with (

--- a/tests/test_launcher/test_network.py
+++ b/tests/test_launcher/test_network.py
@@ -718,9 +718,15 @@ class TestPhase2NetworkIntegration:
                 with patch(
                     "ansys.mapdl.core.launcher.environment.is_wsl", return_value=False
                 ):
-                    config = resolve_launch_config(start_instance=True)
-                    assert config.port == 50052
-                    assert config.ip == "127.0.0.1"
+                    with patch(
+                        "ansys.mapdl.core.launcher.network.check_port_status",
+                        return_value=PortStatus(
+                            port=50052, available=True, used_by_mapdl=False
+                        ),
+                    ):
+                        config = resolve_launch_config(start_instance=True)
+                        assert config.port == 50052
+                        assert config.ip == "127.0.0.1"
 
 
 # ============================================================================


### PR DESCRIPTION
## Description
This restores the pre-0.73 behavior of silently picking a free port rather than raising a hard error when launching MAPDL.