### PR TITLE
fix: doc build

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -179,14 +179,14 @@ jobs:
           echo "PYMAPDL_VERSION=$(python -c 'from ansys.mapdl.core import __version__; print(__version__)')" >> $GITHUB_OUTPUT
           echo "PyMAPDL version is: $(python -c "from ansys.mapdl.core import __version__; print(__version__)")"
 
-      - name: "Cache examples"
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
-        if: ${{ inputs.use_cache_examples && (steps.changes.outputs.documentation != 'true' || env.NOT_ON_RELEASE) }}
-        with:
-          path: doc/source/examples
-          key: Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
-          restore-keys: |
-            Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYMAPDL_VERSION }}
+      # - name: "Cache examples"
+      #   uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
+      #   if: ${{ inputs.use_cache_examples && (steps.changes.outputs.documentation != 'true' || env.NOT_ON_RELEASE) }}
+      #   with:
+      #     path: doc/source/examples
+      #     key: Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
+      #     restore-keys: |
+      #       Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: "Cache docs build directory"
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -27,9 +27,9 @@ on:
 
       use_cache_examples:
         description: |
-          Whether to use the examples cache. Default is "true".
+          Whether to use the examples cache. Default is "false".
         required: false
-        default: true
+        default: false
         type: boolean
 
       use_cache_doc_build:

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -179,14 +179,14 @@ jobs:
           echo "PYMAPDL_VERSION=$(python -c 'from ansys.mapdl.core import __version__; print(__version__)')" >> $GITHUB_OUTPUT
           echo "PyMAPDL version is: $(python -c "from ansys.mapdl.core import __version__; print(__version__)")"
 
-      # - name: "Cache examples"
-      #   uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
-      #   if: ${{ inputs.use_cache_examples && (steps.changes.outputs.documentation != 'true' || env.NOT_ON_RELEASE) }}
-      #   with:
-      #     path: doc/source/examples
-      #     key: Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
-      #     restore-keys: |
-      #       Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYMAPDL_VERSION }}
+      - name: "Cache examples"
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
+        if: ${{ inputs.use_cache_examples && (steps.changes.outputs.documentation != 'true' || env.NOT_ON_RELEASE) }}
+        with:
+          path: doc/source/examples
+          key: Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYMAPDL_VERSION }}-${{ github.sha }}
+          restore-keys: |
+            Examples-v${{ env.RESET_EXAMPLES_CACHE }}-${{ steps.version.outputs.PYMAPDL_VERSION }}
 
       - name: "Cache docs build directory"
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5

--- a/doc/changelog.d/4626.fixed.md
+++ b/doc/changelog.d/4626.fixed.md
@@ -1,0 +1,1 @@
+Doc build

--- a/doc/source/substitutions.rst
+++ b/doc/source/substitutions.rst
@@ -1,4 +1,4 @@
-.. |pyansyscontact| replace:: `PyAnsys Core team <mailto:pyansys.core@ansys.com>`_
+.. |pyansyscontact| replace:: `PyAnsys Core team <pyansys.core@ansys.com>`_
 
 .. |pyansyscontactemail| replace:: pyansys.core@ansys.com
 

--- a/doc/source/substitutions.rst
+++ b/doc/source/substitutions.rst
@@ -1,4 +1,4 @@
-.. |pyansyscontact| replace:: `PyAnsys Core team <pyansys.core@ansys.com>`_
+.. |pyansyscontact| replace:: `PyAnsys Core team <mailto:pyansys.core@ansys.com>`_
 
 .. |pyansyscontactemail| replace:: pyansys.core@ansys.com
 

--- a/examples/00-mapdl-examples/composite_dcb.py
+++ b/examples/00-mapdl-examples/composite_dcb.py
@@ -421,12 +421,15 @@ plotter.add_mesh(
 
 # Add the contact mesh to the scene
 mesh_contact = result_mesh.grid
+damage_scalars_name = "Cohesive Damage"
+mesh_contact.cell_data[damage_scalars_name] = np.zeros(mesh_contact.n_cells)
+mesh_contact.set_active_scalars(damage_scalars_name, preference="cell")
 plotter.add_mesh(
     mesh_contact,
     opacity=0.9,
     scalar_bar_args={"title": "Cohesive Damage"},
     clim=[0, 1],
-    scalars=np.zeros((mesh_contact.n_cells)),
+    scalars=damage_scalars_name,
 )
 for i in range(1, 100):
     # Get displacements
@@ -448,8 +451,7 @@ for i in range(1, 100):
 
     mesh_beam.points = disp_result.data
     mesh_contact.points = disp_cohesive.data
-
-    plotter.update_scalars(cohesive_damage.data, mesh=mesh_contact, render=False)
+    mesh_contact.cell_data[damage_scalars_name][:] = cohesive_damage.data
     plotter.write_frame()
 
 plotter.close()

--- a/src/ansys/mapdl/core/mapdl_geometry.py
+++ b/src/ansys/mapdl/core/mapdl_geometry.py
@@ -870,7 +870,27 @@ class Geometry:
                 entity_num = int(line.d["entity_subs_num"])
                 if entity_num not in entity_nums and entity_num in selected_lnum:
                     entity_nums.append(entity_num)
-                    line = line.to_vtk(resolution=1)
+                    entity = line
+                    try:
+                        line = entity.to_vtk(resolution=1)
+                    except pv.core.errors.DeprecationError as err:
+                        # Compatibility with pyiges releases where CircularArc.to_vtk
+                        # still calls ``transform`` without explicit ``inplace``.
+                        if (
+                            entity.__class__.__name__ != "CircularArc"
+                            or "PolyData.transform" not in str(err)
+                        ):
+                            raise
+
+                        line = pv.CircularArc(
+                            center=[entity.x, entity.y, 0],
+                            pointa=[entity.x1, entity.y1, 0],
+                            pointb=[entity.x2, entity.y2, 0],
+                            resolution=1,
+                        )
+                        line.points += [0, 0, entity.z]
+                        if entity.transform is not None:
+                            line.transform(entity.transform._to_vtk(), inplace=True)
                     line.cell_data["entity_num"] = entity_num
                     lines.append(line)
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -22,6 +22,8 @@
 
 """Test geometry commands"""
 
+from unittest.mock import MagicMock, PropertyMock, patch
+
 import numpy as np
 import pytest
 
@@ -648,3 +650,66 @@ def test_build_legacy_geometry(mapdl, contact_geom_and_mesh):
 
     assert leg_geo.areas(merge=True) == mapdl.geometry.get_areas()
     assert isinstance(leg_geo.areas(merge=True), pv.PolyData)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests for _load_lines CircularArc DeprecationError fallback
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def circular_arc_geom(mapdl, cleared):
+    """Create a simple circular arc in MAPDL and return the line number."""
+    mapdl.prep7(mute=True)
+    k0 = mapdl.k("", 0, 0, 0)  # center
+    k1 = mapdl.k("", 0, 0, 1)  # normal axis direction
+    line_nums = mapdl.circle(k0, 1, k1, arc=90)
+    return line_nums[0]
+
+
+@requires("pyvista")
+@requires("pyiges")
+def test_load_lines_circular_arc_success(mapdl, circular_arc_geom):
+    """Normal path: _load_lines returns a PolyData for a circular arc."""
+    lines = mapdl.geometry._load_lines()
+    assert isinstance(lines, list)
+    assert len(lines) >= 1
+    assert all(isinstance(ln, pv.PolyData) for ln in lines)
+
+
+@requires("pyvista")
+@requires("pyiges")
+def test_load_lines_circular_arc_deprecation_fallback(mapdl, circular_arc_geom):
+    """Fallback path: when CircularArc.to_vtk raises the known DeprecationError,
+    _load_lines constructs the arc via pv.CircularArc instead and still returns
+    a valid PolyData list.
+    """
+    import pyiges.geometry
+
+    err = pv.core.errors.DeprecationError("Use PolyData.transform with inplace=True")
+
+    with patch.object(pyiges.geometry.CircularArc, "to_vtk", side_effect=err):
+        lines = mapdl.geometry._load_lines()
+
+    assert isinstance(lines, list)
+    assert len(lines) >= 1
+    assert all(isinstance(ln, pv.PolyData) for ln in lines)
+
+
+@requires("pyvista")
+@requires("pyiges")
+def test_load_lines_circular_arc_unrelated_deprecation_reraises(
+    mapdl, circular_arc_geom
+):
+    """If CircularArc.to_vtk raises a DeprecationError whose message does not
+    contain 'PolyData.transform', the exception must propagate unchanged.
+    """
+    import pyiges.geometry
+
+    err = pv.core.errors.DeprecationError("Some unrelated deprecation")
+
+    with (
+        patch.object(pyiges.geometry.CircularArc, "to_vtk", side_effect=err),
+        pytest.raises(pv.core.errors.DeprecationError, match="Some unrelated deprecation"),
+    ):
+        mapdl.geometry._load_lines()

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -710,6 +710,8 @@ def test_load_lines_circular_arc_unrelated_deprecation_reraises(
 
     with (
         patch.object(pyiges.geometry.CircularArc, "to_vtk", side_effect=err),
-        pytest.raises(pv.core.errors.DeprecationError, match="Some unrelated deprecation"),
+        pytest.raises(
+            pv.core.errors.DeprecationError, match="Some unrelated deprecation"
+        ),
     ):
         mapdl.geometry._load_lines()

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -22,7 +22,7 @@
 
 """Test geometry commands"""
 
-from unittest.mock import MagicMock, PropertyMock, patch
+from unittest.mock import patch
 
 import numpy as np
 import pytest


### PR DESCRIPTION
## Description
Some examples are silently failing to build due to cache. It has been visible with #4622.

This PR removes the use of the cache for examples when building the documentation.