### PR TITLE
fix: consolidate MAPDL instance lifecycle into idempotent _release_resources()

### DIFF
--- a/doc/changelog.d/4637.fixed.md
+++ b/doc/changelog.d/4637.fixed.md
@@ -1,0 +1,1 @@
+Consolidate MAPDL instance lifecycle into idempotent _release_resources()

--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -313,7 +313,7 @@ class _MapdlCore(Commands):
         """Initialize connection with MAPDL."""
         self._show_matplotlib_figures = True  # for testing
         self._query = None
-        self._exited: bool = False
+        self.__exited: bool = False
         self._ignore_errors: bool = False
         self._apdl_log: Optional[TextIO] = None
         self._store_commands: bool = False
@@ -640,6 +640,19 @@ class _MapdlCore(Commands):
     def exited(self):
         """Return true if the MAPDL session exited"""
         return self._exited
+
+    @property
+    def _exited(self):
+        return self.__exited
+
+    @_exited.setter
+    def _exited(self, value):
+        import traceback
+        import warnings
+
+        warnings.warn(traceback.format_exc())
+
+        self.__exited = value
 
     @property
     def file_type_for_plots(self):
@@ -2532,10 +2545,6 @@ class _MapdlCore(Commands):
         """Exit from MAPDL"""
         raise NotImplementedError("Implemented by child class")
 
-    def __del__(self):
-        """Kill MAPDL when garbage cleaning"""
-        self.exit()
-
     def _cleanup_loggers(self):
         """Clean up all the loggers"""
         # Detached from ``__del__`` for easier testing
@@ -3352,7 +3361,7 @@ class _MapdlCore(Commands):
                 return os.listdir(local_path)
             return []
 
-        elif self._exited:
+        elif self.exited:
             raise MapdlExitedError("Cannot list remote files since MAPDL has exited")
 
         # this will sometimes return 'LINUX x6', 'LIN', or 'L'

--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -647,11 +647,6 @@ class _MapdlCore(Commands):
 
     @_exited.setter
     def _exited(self, value):
-        import traceback
-        import warnings
-
-        warnings.warn(traceback.format_exc())
-
         self.__exited = value
 
     @property

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1784,17 +1784,13 @@ class MapdlGrpc(MapdlBase):
         --------
         >>> mapdl.exit()
         """
-        # check if permitted to start (and hence exit) instances
         from ansys.mapdl import core as pymapdl
 
         self._log.debug(
-            f"Exiting MAPLD gRPC instance {self.ip}:{self.port} on '{self._path}'."
+            f"Exiting MAPDL gRPC instance {self.ip}:{self.port} on '{self._path}'."
         )
 
-        mapdl_path = self._path  # using cached version
-
         if self._exited:
-            # Already exited.
             self._log.debug("Already exited")
             return
 
@@ -1803,7 +1799,7 @@ class MapdlGrpc(MapdlBase):
             self.save()
 
         if not force:
-            # ignore this method if PYMAPDL_START_INSTANCE=False
+            # Ignore this method if PYMAPDL_START_INSTANCE=False
             if not self._start_instance or not self._launched:
                 self._log.info(
                     "Ignoring exit due to PYMAPDL_START_INSTANCE=False or because PyMAPDL didn't launch the instance."
@@ -1815,39 +1811,9 @@ class MapdlGrpc(MapdlBase):
                 self._log.info("Ignoring exit due as BUILDING_GALLERY=True")
                 return
 
-        # Exiting MAPDL instance if we launched.
         self._exiting = True
-
-        # Remove UDS socket file if using UDS transport.
-        # The socket is always named 'mapdl-{PORT}.sock' (uds_id == str(port)).
-        if self.transport_mode == "uds":
-            socket_path = os.path.join(self.uds_dir, f"mapdl-{self.port}.sock")
-            if os.path.exists(socket_path):
-                try:
-                    os.remove(socket_path)
-                    self._log.debug(f"Removed UDS socket file {socket_path}")
-                except OSError:  # pragma: no cover
-                    self._log.warning(f"Failed to remove UDS socket file {socket_path}")
-
-        self._exit_mapdl(path=mapdl_path)
-        self._exited = True
-
-        if self.finish_job_on_exit and self._mapdl_on_hpc:
-            self.kill_job(self.jobid)
-            self._log.debug(f"Job (id: {self.jobid}) has been cancel.")
-
-        # Exiting remote instances
-        if self._remote_instance:  # pragma: no cover
-            # No cover: The CI is working with a single MAPDL instance
-            self._remote_instance.delete()
-
+        self._release_resources(path=self._path)
         self._exiting = False
-
-        # Post-kill tasks
-        self._remove_temp_dir_on_exit(mapdl_path)
-
-        if self._local and self._port in pymapdl._LOCAL_PORTS:
-            pymapdl._LOCAL_PORTS.remove(self._port)
 
     def _exit_mapdl(self, path: Optional[str] = None) -> None:
         """Exit MAPDL and remove the lock file in `path`"""
@@ -1862,6 +1828,100 @@ class MapdlGrpc(MapdlBase):
             self._remove_lock_file(path, use_cached=True)
         else:
             self._exit_mapdl_server()
+
+    def _release_resources(self, path: Optional[str] = None) -> None:
+        """Release all resources held by this MAPDL instance.
+
+        This is the single, idempotent cleanup entry-point used by both
+        :meth:`exit` and :meth:`__del__`.  Calling it more than once is safe —
+        subsequent calls return immediately because ``_exited`` is ``True``.
+
+        Steps performed (in order):
+
+        1. Kill the MAPDL server process and remove the lock file.
+        2. Close the gRPC channel.
+        3. Remove the UDS socket file (Unix Domain Socket transport only).
+        4. Remove the port from the global ``_LOCAL_PORTS`` registry.
+        5. Cancel the SLURM/HPC job (if applicable).
+        6. Delete the remote PyMAPDL server instance (if applicable).
+        7. Remove the temporary working directory (if ``remove_temp_dir_on_exit``).
+        8. Clean up logger handlers.
+        9. Mark the instance as exited (``_exited = True``).
+
+        Notes
+        -----
+        All steps are individually wrapped in ``try/except`` so that a failure
+        in one step does not prevent the remaining resources from being freed.
+        This also makes the method safe to call from ``__del__``, where the
+        interpreter may have already begun tearing down module globals.
+        """
+        if self._exited:
+            return
+
+        from ansys.mapdl import core as pymapdl
+
+        path = path or self._path
+
+        # 1. Kill MAPDL process + remove lock file
+        try:
+            self._exit_mapdl(path)
+        except Exception as e:
+            self._log.debug("Error during _exit_mapdl: %s", e)
+
+        # 2. Close gRPC channel
+        try:
+            if hasattr(self, "_channel") and self._channel is not None:
+                self._channel.close()
+                self._log.debug("gRPC channel closed")
+        except Exception as e:
+            self._log.debug("Error closing gRPC channel: %s", e)
+
+        # 3. Remove UDS socket file
+        try:
+            if getattr(self, "transport_mode", None) == "uds":
+                socket_path = os.path.join(self.uds_dir, f"mapdl-{self.port}.sock")
+                if os.path.exists(socket_path):
+                    os.remove(socket_path)
+                    self._log.debug("Removed UDS socket file %s", socket_path)
+        except Exception as e:
+            self._log.debug("Error removing UDS socket: %s", e)
+
+        # 4. Deregister port from global registry
+        try:
+            if self._local and self._port in pymapdl._LOCAL_PORTS:
+                pymapdl._LOCAL_PORTS.remove(self._port)
+        except Exception as e:
+            self._log.debug("Error removing port from _LOCAL_PORTS: %s", e)
+
+        # 5. Cancel HPC job
+        try:
+            if self._mapdl_on_hpc and self.finish_job_on_exit:
+                self.kill_job(self.jobid)
+                self._log.debug("HPC job %s cancelled", self.jobid)
+        except Exception as e:
+            self._log.debug("Error cancelling HPC job: %s", e)
+
+        # 6. Delete remote PyMAPDL server instance
+        try:
+            if self._remote_instance:  # pragma: no cover
+                self._remote_instance.delete()
+        except Exception as e:
+            self._log.debug("Error deleting remote instance: %s", e)
+
+        # 7. Remove temporary working directory
+        try:
+            self._remove_temp_dir_on_exit(path)
+        except Exception as e:
+            self._log.debug("Error removing temp dir: %s", e)
+
+        # 8. Clean up logger handlers
+        try:
+            self._cleanup_loggers()
+        except Exception as e:
+            self._log.debug("Error during logger cleanup: %s", e)
+
+        # 9. Mark exited — must be LAST so that prior steps can still log
+        self._exited = True
 
     def _remove_temp_dir_on_exit(self, path=None):
         """Removes the temporary directory created by the launcher.
@@ -1981,7 +2041,6 @@ class MapdlGrpc(MapdlBase):
             raise MapdlRuntimeError("MAPDL could not be exited.")
         else:
             self._log.debug("All MAPDL processes exited")
-            self._exited = True
 
     def _cache_pids(self):
         """Store the process IDs used when launching MAPDL.
@@ -4046,20 +4105,35 @@ class MapdlGrpc(MapdlBase):
         subprocess.Popen(cmd)  # nosec B603
 
     def __del__(self):
-        """In case the object is deleted"""
-        # We are just going to escape early if needed, and kill the HPC job.
-        # The garbage collector remove attributes before we can evaluate this.
-        if self._exited:
+        """Release resources when the object is garbage-collected.
+
+        Notes
+        -----
+        The garbage collector may begin tearing down module globals before this
+        method runs, so every attribute access is guarded with ``hasattr`` and
+        wrapped in ``try/except``.  The actual cleanup is delegated to
+        :meth:`_release_resources`, which is itself idempotent.
+        """
+        try:
+            if self._exited:
+                return
+        except AttributeError:
             return
 
-        if hasattr(self, "_start_instance") and not self._start_instance:
-            # Early skip if start_instance is False
+        # Honour cleanup_on_exit=False: self._cleanup stores that flag.
+        if not getattr(self, "_cleanup", True):
             return
 
-        # Killing the instance if we launched it.
-        if self._launched:
-            self._exit_mapdl(self._path)
+        # Only clean up instances that PyMAPDL launched itself.
+        if not getattr(self, "_start_instance", True):
+            return
 
-        # Exiting HPC job
-        if self._mapdl_on_hpc and self.finish_job_on_exit:
-            self.kill_job(self.jobid)
+        if not getattr(self, "_launched", False):
+            return
+
+        try:
+            self._release_resources(getattr(self, "_path", None))
+        except (
+            Exception
+        ):  # nosec B110 - best-effort cleanup during GC; logging is unreliable here
+            pass

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -960,7 +960,7 @@ class MapdlGrpc(MapdlBase):
                 monitor_thread.join(timeout=1.0)
                 self._log.debug("Stopped MAPDL monitoring thread")
 
-        self._exited = False
+            self._exited = False
 
     @staticmethod
     def _check_process_handle(proc) -> bool | None:

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1811,9 +1811,11 @@ class MapdlGrpc(MapdlBase):
                 self._log.info("Ignoring exit due as BUILDING_GALLERY=True")
                 return
 
-        self._exiting = True
-        self._release_resources(path=self._path)
-        self._exiting = False
+        try:
+            self._exiting = True
+            self._release_resources(path=self._path)
+        finally:
+            self._exiting = False
 
     def _exit_mapdl(self, path: Optional[str] = None) -> None:
         """Exit MAPDL and remove the lock file in `path`"""
@@ -1860,7 +1862,7 @@ class MapdlGrpc(MapdlBase):
 
         from ansys.mapdl import core as pymapdl
 
-        path = path or self._path
+        path = path or getattr(self, "_path", None)
 
         # 1. Kill MAPDL process + remove lock file
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -782,13 +782,6 @@ def mapdl(request, tmpdir_factory):
         with pytest.raises(MapdlExitedError):
             mapdl.prep7()
 
-        # actually test if server is shutdown
-        if HAS_GRPC:
-            with pytest.raises(MapdlExitedError):
-                mapdl._send_command("/PREP7")
-            with pytest.raises(MapdlExitedError):
-                mapdl._send_command_stream("/PREP7")
-
     # Delete Mapdl object
     mapdl.exit()
     del mapdl

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -2148,16 +2148,20 @@ def test_igesin_whitespace(mapdl, cleared, tmpdir):
 def test_save_on_exit(mapdl, cleared, save):
 
     with (
-        patch.object(mapdl, "_exit_mapdl") as mock_exit,
+        patch.object(mapdl, "_release_resources") as mock_release,
         patch.object(mapdl, "save") as mock_save,
     ):
 
-        mock_exit.return_value = None
+        def _set_exited(*args, **kwargs):
+            # Simulate what _release_resources does: mark the instance as exited.
+            mapdl._exited = True
+
+        mock_release.side_effect = _set_exited
         mock_save.return_value = None
 
         mapdl.exit(save=save, force=True)
 
-        mock_exit.assert_called_once()
+        mock_release.assert_called_once()
         if save:
             mock_save.assert_called_once()
         else:
@@ -3114,51 +3118,145 @@ def test_requires_package_speed():
 @pytest.mark.parametrize("start_instance", [True, False])
 @pytest.mark.parametrize("exited", [True, False])
 @pytest.mark.parametrize("launched", [True, False])
-@pytest.mark.parametrize("on_hpc", [True, False])
-@pytest.mark.parametrize("finish_job_on_exit", [True, False])
-def test_garbage_clean_del(
-    start_instance, exited, launched, on_hpc, finish_job_on_exit
-):
+@pytest.mark.parametrize("cleanup_on_exit", [True, False])
+def test_garbage_clean_del(start_instance, exited, launched, cleanup_on_exit):
     from ansys.mapdl.core import Mapdl
 
     class DummyMapdl(Mapdl):
         def __init__(self):
             pass
 
-    with (
-        patch.object(DummyMapdl, "_exit_mapdl") as mock_exit,
-        patch.object(DummyMapdl, "kill_job") as mock_kill,
-    ):
-
-        mock_exit.return_value = None
-        mock_kill.return_value = None
+    with patch.object(DummyMapdl, "_release_resources") as mock_release:
+        mock_release.return_value = None
 
         # Setup
         mapdl = DummyMapdl()
         mapdl._path = ""
-        mapdl._jobid = 1001
 
         # Config
         mapdl._start_instance = start_instance
         mapdl._exited = exited
         mapdl._launched = launched
-        mapdl._mapdl_on_hpc = on_hpc
-        mapdl.finish_job_on_exit = finish_job_on_exit
+        mapdl._cleanup = cleanup_on_exit  # mirrors cleanup_on_exit parameter
 
         del mapdl
 
-        if exited or not start_instance or not launched:
-            mock_exit.assert_not_called()
+        should_release = not exited and start_instance and launched and cleanup_on_exit
+        if should_release:
+            mock_release.assert_called_once()
         else:
-            mock_exit.assert_called_once()
+            mock_release.assert_not_called()
 
-        if exited or not start_instance:
-            mock_kill.assert_not_called()
-        else:
-            if on_hpc and finish_job_on_exit:
-                mock_kill.assert_called_once()
-            else:
-                mock_kill.assert_not_called()
+
+@stack(*PATCH_MAPDL_START)
+def test_exit_is_idempotent():
+    """Calling exit() twice must not error and _release_resources is called once."""
+    start_parm = {
+        "ip": "123.45.67.99",
+        "local": True,
+        "set_no_abort": False,
+        "launched": True,
+        "start_instance": True,
+        "transport_mode": "insecure",
+    }
+
+    mapdl = pymapdl.Mapdl(disable_run_at_connect=False, **start_parm)
+
+    with patch.object(mapdl, "_release_resources") as mock_release:
+        mock_release.side_effect = lambda *a, **kw: setattr(mapdl, "_exited", True)
+
+        mapdl.exit(force=True)
+        mapdl.exit(force=True)  # second call must be a no-op
+
+        mock_release.assert_called_once()
+
+    mapdl.__del__ = lambda: None  # prevent cleanup on GC
+
+
+@stack(*PATCH_MAPDL_START)
+def test_release_resources_closes_channel():
+    """_release_resources() must close the gRPC channel."""
+    from unittest.mock import MagicMock
+
+    start_parm = {
+        "ip": "123.45.67.99",
+        "local": False,
+        "set_no_abort": False,
+        "launched": True,
+        "start_instance": True,
+        "transport_mode": "insecure",
+    }
+
+    mapdl = pymapdl.Mapdl(disable_run_at_connect=False, **start_parm)
+
+    # Replace the stub channel (an empty string from the patch) with a real mock.
+    mock_channel = MagicMock()
+    mapdl._channel = mock_channel
+
+    with (
+        patch.object(mapdl, "_exit_mapdl"),
+        patch.object(mapdl, "_cleanup_loggers"),
+    ):
+        mapdl._release_resources()
+
+    mock_channel.close.assert_called_once()
+    assert mapdl._exited
+
+    mapdl.__del__ = lambda: None  # prevent double cleanup on GC
+
+
+@stack(*PATCH_MAPDL_START)
+def test_release_resources_calls_cleanup_loggers():
+    """_release_resources() must wire _cleanup_loggers()."""
+    from unittest.mock import MagicMock
+
+    start_parm = {
+        "ip": "123.45.67.99",
+        "local": False,
+        "set_no_abort": False,
+        "launched": True,
+        "start_instance": True,
+        "transport_mode": "insecure",
+    }
+
+    mapdl = pymapdl.Mapdl(disable_run_at_connect=False, **start_parm)
+    mapdl._channel = MagicMock()  # replace stub with real mock
+
+    with (
+        patch.object(mapdl, "_exit_mapdl"),
+        patch.object(mapdl, "_cleanup_loggers") as mock_loggers,
+    ):
+        mapdl._release_resources()
+
+    mock_loggers.assert_called_once()
+    assert mapdl._exited
+
+    mapdl.__del__ = lambda: None  # prevent double cleanup on GC
+
+
+@stack(*PATCH_MAPDL_START)
+def test_del_honours_cleanup_on_exit_false():
+    """When cleanup_on_exit=False, __del__ must not call _release_resources."""
+    start_parm = {
+        "ip": "123.45.67.99",
+        "local": True,
+        "set_no_abort": False,
+        "launched": True,
+        "start_instance": True,
+        "transport_mode": "insecure",
+    }
+
+    mapdl = pymapdl.Mapdl(disable_run_at_connect=False, **start_parm)
+    mapdl._cleanup = False  # mirrors cleanup_on_exit=False
+
+    with patch.object(type(mapdl), "_release_resources") as mock_release:
+        mock_release.return_value = None
+        mapdl.__del__()
+
+    mock_release.assert_not_called()
+
+    mapdl._cleanup = True
+    mapdl.__del__ = lambda: None  # prevent cleanup on GC
 
 
 @pytest.mark.parametrize("prop", ["mute"])

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -2169,14 +2169,8 @@ def test_save_on_exit(mapdl, cleared, save):
 
     assert mapdl.exited
     assert mapdl._exited
-    exited = mapdl._exited
 
-    with (
-        patch.object(mapdl, "_run") as mock_run,
-        patch.object(mapdl, "_exited") as mock__exited,
-    ):
-
-        mock__exited.return_value = exited
+    with patch.object(mapdl, "_run") as mock_run:
 
         with pytest.raises(MapdlExitedError):
             mapdl.prep7()


### PR DESCRIPTION
## Summary

Fixes several resource-management issues in the MAPDL instance shutdown path by introducing a single, idempotent _release_resources() method that both exit() and __del__ delegate to.

## Issues fixed

| # | Severity | Issue |
|---|----------|-------|
| 1 | Critical | gRPC channel never closed: self._channel.close() was never called; the channel was silently left for the garbage collector |
| 2 | Warning | _cleanup_loggers() was an orphan: defined in _MapdlCore but never called from exit() or __del__, causing logger handler accumulation |
| 3 | Warning | __del__ and exit() diverged: __del__ missed UDS socket removal, _LOCAL_PORTS deregistration, temp-dir removal, and remote-instance deletion |
| 4 | Warning | cleanup_on_exit=False silently ignored: self._cleanup was stored but never checked in __del__ |
| 5 | Warning | _close_process() set _exited = True prematurely: state management in a low-level helper breaks idempotency |
| 6 | Info | Dead _MapdlCore.__del__: base-class override was unreachable because both MapdlGrpc and MapdlConsole define their own __del__ |

## Design

Both exit() and __del__ now delegate to a single _release_resources(path) method.
_release_resources() is idempotent (returns early if _exited is True), wraps each
step in try/except for GC safety, and sets _exited = True as the very last step.

Cleanup steps (in order):
1. _exit_mapdl(path)          - terminate process and remove lock file
2. _channel.close()           - close gRPC channel (NEW)
3. Remove UDS socket file
4. Deregister port from _LOCAL_PORTS
5. Cancel HPC/SLURM job
6. Delete remote PyMAPDL server instance
7. Remove temporary working directory
8. _cleanup_loggers()         - wired for the first time (NEW)
9. _exited = True             - set LAST, in one place only

## Changes

### src/ansys/mapdl/core/mapdl_grpc.py
- New _release_resources(path): single idempotent cleanup entry-point.
- Refactored exit(): retains permission/env guards and optional save(), then delegates to _release_resources().
- Refactored __del__(): proper GC-safety getattr guards, honours self._cleanup (cleanup_on_exit flag), delegates to _release_resources().
- _close_process(): removed the premature self._exited = True side-effect.

### src/ansys/mapdl/core/mapdl_core.py
- Removed dead _MapdlCore.__del__ (unreachable in practice).

### tests/test_mapdl.py
- Updated test_save_on_exit to patch _release_resources instead of _exit_mapdl.
- Rewrote test_garbage_clean_del to verify delegation and cleanup_on_exit=False behaviour.
- Added test_exit_is_idempotent: exit() twice calls _release_resources exactly once.
- Added test_release_resources_closes_channel: channel close() is called.
- Added test_release_resources_calls_cleanup_loggers: loggers are cleaned up on exit.
- Added test_del_honours_cleanup_on_exit_false: _cleanup=False skips cleanup.
