### PR TITLE
docs(api): include Mapdl.exit and session-launcher notes

### DIFF
--- a/doc/changelog.d/4679.documentation.md
+++ b/doc/changelog.d/4679.documentation.md
@@ -1,0 +1,1 @@
+Include Mapdl.exit and session-launcher notes

--- a/doc/source/api/mapdl.rst
+++ b/doc/source/api/mapdl.rst
@@ -116,7 +116,7 @@ Constants
 
 
 Session management and launcher
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 High-level helpers to start or connect to MAPDL instances live in the
 :mod:`ansys.mapdl.core.launcher` module. Use :func:`ansys.mapdl.core.launcher.launch_mapdl`

--- a/doc/source/api/mapdl.rst
+++ b/doc/source/api/mapdl.rst
@@ -113,3 +113,33 @@ Constants
    mapdl_grpc.MapdlGrpc.mute
    mapdl_grpc.MapdlGrpc.port
    mapdl_grpc.MapdlGrpc.upload
+
+
+Session management and launcher
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+High-level helpers to start or connect to MAPDL instances live in the
+:mod:`ansys.mapdl.core.launcher` module. Use :func:`ansys.mapdl.core.launcher.launch_mapdl`
+to start or connect to an instance; for lower-level process control use
+:func:`ansys.mapdl.core.launcher.launch_mapdl_process` or
+:func:`ansys.mapdl.core.launcher.close_all_local_instances`.
+
+.. autosummary::
+   :toctree: _autosummary
+
+   launcher.launch_mapdl
+   launcher.launch_mapdl_process
+   launcher.close_all_local_instances
+
+
+Transport-specific behavior
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Note
+    Some session-management and file-transfer behavior is transport-specific.
+    For example, file upload/download and session persistence are implemented
+    on the :class:`ansys.mapdl.core.mapdl_grpc.MapdlGrpc` subclass (see methods
+    above). Local sessions may automatically make files available for download
+    while remote sessions require explicit :meth:`mapdl_grpc.MapdlGrpc.download`.
+    Also, session-id checks are performed internally to detect mismatches when
+    reconnecting — see :mod:`ansys.mapdl.core.mapdl_grpc` for details.

--- a/doc/source/api/mapdl.rst
+++ b/doc/source/api/mapdl.rst
@@ -21,9 +21,9 @@
    Mapdl.cwd
    Mapdl.default_file_type_for_plots
    Mapdl.directory
+   Mapdl.exit
    Mapdl.exited
    Mapdl.exiting
-   Mapdl.exit
    Mapdl.file_type_for_plots
    Mapdl.finish_job_on_exit
    Mapdl.force_output
@@ -35,11 +35,12 @@
    Mapdl.get_nsol
    Mapdl.get_value
    Mapdl.get_variable
+   Mapdl.graphics_backend
    Mapdl.hostname
    Mapdl.ignore_errors
    Mapdl.info
-   Mapdl.inquire
    Mapdl.input_strings
+   Mapdl.inquire
    Mapdl.is_alive
    Mapdl.is_console
    Mapdl.is_corba
@@ -78,7 +79,6 @@
    Mapdl.screenshot
    Mapdl.set_log_level
    Mapdl.thermal_result
-   Mapdl.graphics_backend
    Mapdl.version
 
 

--- a/doc/source/api/mapdl.rst
+++ b/doc/source/api/mapdl.rst
@@ -141,5 +141,3 @@ Note
     on the :class:`ansys.mapdl.core.mapdl_grpc.MapdlGrpc` subclass (see methods
     above). Local sessions may automatically make files available for download
     while remote sessions require explicit :meth:`mapdl_grpc.MapdlGrpc.download`.
-    Also, session-id checks are performed internally to detect mismatches when
-    reconnecting — see :mod:`ansys.mapdl.core.mapdl_grpc` for details.

--- a/doc/source/api/mapdl.rst
+++ b/doc/source/api/mapdl.rst
@@ -18,10 +18,12 @@
    Mapdl.busy
    Mapdl.chain_commands
    Mapdl.check_parameter_names
+   Mapdl.cwd
    Mapdl.default_file_type_for_plots
    Mapdl.directory
    Mapdl.exited
    Mapdl.exiting
+   Mapdl.exit
    Mapdl.file_type_for_plots
    Mapdl.finish_job_on_exit
    Mapdl.force_output
@@ -36,6 +38,7 @@
    Mapdl.hostname
    Mapdl.ignore_errors
    Mapdl.info
+   Mapdl.inquire
    Mapdl.input_strings
    Mapdl.is_alive
    Mapdl.is_console


### PR DESCRIPTION
Add Mapdl.exit, Mapdl.cwd, and Mapdl.inquire to the Mapdl autosummary and include a session-management/launcher section with transport-specific notes pointing to MapdlGrpc for upload/download and session-id behavior.

This improves discoverability of session lifecycle APIs and clarifies transport-specific differences.

Changes: doc/source/api/mapdl.rst

Close #4677 