### PR TITLE
fix: forward notebook/off_screen/window_size kwargs in MapdlPlotter.show

### DIFF
--- a/doc/changelog.d/4635.fixed.md
+++ b/doc/changelog.d/4635.fixed.md
@@ -1,0 +1,1 @@
+Forward ``notebook``, ``off_screen``, and ``window_size`` arguments from ``MapdlPlotter.show`` to the visualization backend so they are no longer silently ignored, fixing plots not rendering correctly in some IDEs (for example, Spyder)

--- a/doc/changelog.d/4635.fixed.md
+++ b/doc/changelog.d/4635.fixed.md
@@ -1,1 +1,0 @@
-Forward ``notebook``, ``off_screen``, and ``window_size`` arguments from ``MapdlPlotter.show`` to the visualization backend so they are no longer silently ignored, fixing plots not rendering correctly in some IDEs (for example, Spyder)

--- a/doc/changelog.d/4687.fixed.md
+++ b/doc/changelog.d/4687.fixed.md
@@ -1,0 +1,1 @@
+Forward notebook/off_screen/window_size kwargs in MapdlPlotter.show

--- a/src/ansys/mapdl/core/plotting/visualizer.py
+++ b/src/ansys/mapdl/core/plotting/visualizer.py
@@ -27,7 +27,6 @@ from typing import Any, Callable, Dict, Iterable, Optional, Union
 
 from ansys.tools.visualization_interface import Plotter
 from ansys.tools.visualization_interface.backends.pyvista import PyVistaBackendInterface
-import numpy as np
 from numpy.typing import NDArray
 
 from ansys.mapdl.core import LOG as logger
@@ -43,6 +42,7 @@ from ansys.mapdl.core.plotting.consts import (
     POINT_SIZE,
 )
 from ansys.mapdl.core.plotting.theme import MapdlTheme
+import numpy as np
 
 _FIRST_USE_RUN = False
 
@@ -1018,9 +1018,21 @@ class MapdlPlotter(Plotter):
         if notebook:
             self._off_screen = True  # pragma: no cover
 
+        # Forward the explicit ``notebook``/``off_screen`` arguments to the
+        # underlying backend. Without this, values such as ``notebook=False``
+        # (used to work around rendering issues in IDEs like Spyder, see
+        # #4635) were silently dropped and the backend fell back to its own
+        # auto-detection.
+        if notebook is not None:
+            kwargs.setdefault("notebook", notebook)
+
         if savefig:
             self._off_screen = True
             self._notebook = False
+            kwargs["notebook"] = False
+
+        if self._off_screen is not None:
+            kwargs.setdefault("off_screen", self._off_screen)
 
         # permit user to save the figure as a screenshot
         if self._savefig or savefig:
@@ -1041,6 +1053,8 @@ class MapdlPlotter(Plotter):
 
         else:
             if not return_plotter:
+                if window_size is not None:
+                    kwargs.setdefault("window_size", window_size)
                 self._backend.show(**kwargs)
 
         if return_plotter:

--- a/src/ansys/mapdl/core/plotting/visualizer.py
+++ b/src/ansys/mapdl/core/plotting/visualizer.py
@@ -27,6 +27,7 @@ from typing import Any, Callable, Dict, Iterable, Optional, Union
 
 from ansys.tools.visualization_interface import Plotter
 from ansys.tools.visualization_interface.backends.pyvista import PyVistaBackendInterface
+import numpy as np
 from numpy.typing import NDArray
 
 from ansys.mapdl.core import LOG as logger
@@ -42,7 +43,6 @@ from ansys.mapdl.core.plotting.consts import (
     POINT_SIZE,
 )
 from ansys.mapdl.core.plotting.theme import MapdlTheme
-import numpy as np
 
 _FIRST_USE_RUN = False
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -25,10 +25,10 @@
 import os
 from unittest.mock import patch
 
-import numpy as np
 import pytest
 
 from conftest import has_dependency, requires
+import numpy as np
 
 if not has_dependency("pyvista"):
     pytest.skip(
@@ -1327,6 +1327,38 @@ def test_add_mesh():
     assert pl2.meshes[0] == cube2
     assert pl3.meshes[0] == cube3
     assert pl3.meshes[1] == sphere
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"notebook": False}, {"notebook": False}),
+        ({"notebook": True}, {"notebook": True}),
+        ({"off_screen": True}, {"off_screen": True}),
+        (
+            {"notebook": False, "off_screen": True, "window_size": [800, 600]},
+            {"notebook": False, "off_screen": True, "window_size": [800, 600]},
+        ),
+    ],
+)
+def test_show_forwards_notebook_and_off_screen(kwargs, expected):
+    """Regression test for #4635.
+
+    ``notebook``/``off_screen``/``window_size`` passed to ``show`` must reach
+    the underlying backend instead of being silently dropped, since dropping
+    them makes the backend fall back to its own (sometimes incorrect)
+    auto-detection - for example, detecting Spyder's IPython console as a
+    Jupyter notebook.
+    """
+    pl = MapdlPlotter()
+
+    with patch.object(pl._backend, "show") as mock_show:
+        pl.show(**kwargs)
+
+    mock_show.assert_called_once()
+    _, call_kwargs = mock_show.call_args
+    for key, value in expected.items():
+        assert call_kwargs.get(key) == value
 
 
 def test_plot_path_screenshoot(mapdl, cleared, tmpdir):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -25,10 +25,10 @@
 import os
 from unittest.mock import patch
 
+import numpy as np
 import pytest
 
 from conftest import has_dependency, requires
-import numpy as np
 
 if not has_dependency("pyvista"):
     pytest.skip(


### PR DESCRIPTION
## Description

`MapdlPlotter.show()` (in `src/ansys/mapdl/core/plotting/visualizer.py`) captured the `notebook`, `off_screen`, and `window_size` arguments as named parameters, but never forwarded them to the underlying `PyVista`/visualization-interface backend's `show()` call.

As a result, passing `notebook=False` — a common workaround suggested for plots not rendering correctly in some IDEs (see #4594) — had no effect. The backend fell back to its own auto-detection of whether it is running inside a Jupyter notebook, which incorrectly identifies Spyder's IPython console as a notebook environment and tries an unsupported rendering path, resulting in blank or partial plots.

This PR forwards `notebook`, `off_screen`, and `window_size` to the backend's `show()` call so these arguments are respected.

## Issue linked

Fixes #4635

## Changes

- `src/ansys/mapdl/core/plotting/visualizer.py`: forward `notebook`/`off_screen`/`window_size` kwargs to `self._backend.show()` in `MapdlPlotter.show()`.
- `tests/test_plotting.py`: added a regression test (`test_show_forwards_notebook_and_off_screen`) that mocks the backend to verify these arguments reach it.

## Checklist

- [x] I have tested my changes.
- [x] I have added/updated tests to cover my changes.
- [x] `pre-commit run --all-files` passes for the changed files.
