### PR TITLE
fix: Advertise PyMAPDL MCP in documentation

### DIFF
--- a/doc/changelog.d/4699.fixed.md
+++ b/doc/changelog.d/4699.fixed.md
@@ -1,0 +1,1 @@
+Advertise PyMAPDL MCP in documentation

--- a/doc/source/getting_started/project.rst
+++ b/doc/source/getting_started/project.rst
@@ -190,6 +190,18 @@ or `PyMAPDL Discussions <pymapdl_discussions_>`_ for raising issues,
 request new features, or asking questions.
 
 
+PyMAPDL MCP
+-----------
+The `PyMAPDL MCP <pymapdl_mcp_docs_>`_ (Model Context Protocol) is a complementary integration
+that enables AI-powered interactions with MAPDL through AI agents and code editors. This integration
+allows you to leverage large language models to assist with MAPDL scripting and analysis workflows.
+
+For more information on the PyMAPDL MCP, visit:
+
+- `PyMAPDL MCP Documentation <pymapdl_mcp_docs_>`_
+- `PyMAPDL MCP Repository <pymapdl_mcp_repo_>`_
+
+
 Project index
 -------------
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -85,6 +85,13 @@
         If you want to resolve issues you encounter while using PyMAPDL,
         see :ref:`ref_troubleshooting`.
 
+    .. grid-item-card:: :fa:`robot` Try PyMAPDL MCP
+        :link: pymapdl_mcp_docs
+        :link-type: ref
+
+        If you want to use AI agents and code editors with PyMAPDL, see
+        the :ref:`PyMAPDL MCP documentation <pymapdl_mcp_docs>`.
+
     .. grid-item-card:: :fa:`users` Contribute to PyMAPDL
         :link: ref_contributing
         :link-type: ref

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -86,11 +86,10 @@
         see :ref:`ref_troubleshooting`.
 
     .. grid-item-card:: :fa:`robot` Try PyMAPDL MCP
-        :link: pymapdl_mcp_docs
-        :link-type: ref
+        :link: https://mapdl-mcp.docs.pyansys.com/
 
         If you want to use AI agents and code editors with PyMAPDL, see
-        the :ref:`PyMAPDL MCP documentation <pymapdl_mcp_docs>`.
+        the `PyMAPDL MCP documentation <pymapdl_mcp_docs_>`_.
 
     .. grid-item-card:: :fa:`users` Contribute to PyMAPDL
         :link: ref_contributing

--- a/doc/source/links.rst
+++ b/doc/source/links.rst
@@ -88,6 +88,10 @@
 .. _pymapdl_ex_vm: https://examples.mapdl.docs.pyansys.com/verif-manual/index.html
 .. _pymapdl_cheat_sheet: https://mapdl.docs.pyansys.com/stable/_static/_static/cheat_sheet.pdf
 
+.. # PyMAPDL MCP related
+.. _pymapdl_mcp_docs: https://mapdl-mcp.docs.pyansys.com/
+.. _pymapdl_mcp_repo: https://github.com/ansys/pymapdl-mcp
+
 .. # Ansys Structural Guide links:
 .. _ansys_krylov_sweep_harmonic_analysis: https://ansyshelp.ansys.com/account/secured?returnurl=/Views/Secured/corp/%%VERSION%%/en/ans_str/str_Krysweep.html
 


### PR DESCRIPTION
# Advertise PyMAPDL MCP in Documentation

## Issue
Closes #4668

## Changes
This PR adds comprehensive references to the PyMAPDL MCP (Model Context Protocol) throughout the PyMAPDL documentation to make users aware of this complementary integration.

### Specific Changes:

1. **Added MCP links to `doc/source/links.rst`**
   - `_pymapdl_mcp_docs`: https://mapdl-mcp.docs.pyansys.com/
   - `_pymapdl_mcp_repo`: https://github.com/ansys/pymapdl-mcp

2. **Added PyMAPDL MCP section to `doc/source/getting_started/project.rst`**
   - New section explaining the PyMAPDL MCP integration
   - Describes it as a complementary tool enabling AI-powered interactions with MAPDL through AI agents and code editors
   - Includes direct links to the MCP documentation and repository

3. **Added MCP grid card to `doc/source/index.rst`**
   - New "Try PyMAPDL MCP" card in the main landing page grid
   - Directs users to explore AI agent and code editor integration with a robot icon

## Benefits
- Users are now aware of the PyMAPDL MCP from multiple entry points
- The documentation guides users to an alternative interface for AI-assisted MAPDL scripting
- Improves discoverability of the PyMAPDL ecosystem

## Testing
- All pre-commit checks passed
- Documentation syntax verified
- No breaking changes to existing content