### PR TITLE
fix: download files located in subdirectories of the MAPDL working directory

### DIFF
--- a/doc/changelog.d/4700.fixed.md
+++ b/doc/changelog.d/4700.fixed.md
@@ -1,0 +1,1 @@
+Download files located in subdirectories of the MAPDL working directory

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -43,12 +43,11 @@ from warnings import warn
 import weakref
 
 from ansys.tools.common.versioning import version_string_as_tuple
+import grpc
 from grpc._channel import _InactiveRpcError, _MultiThreadedRendezvous
+import numpy as np
 from numpy.typing import NDArray
 import psutil
-
-import grpc
-import numpy as np
 
 MSG_IMPORT = """There was a problem importing the ANSYS MAPDL API module `ansys-api-mapdl`.
 Please make sure you have the latest updated version using:

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -2968,6 +2968,9 @@ class MapdlGrpc(MapdlBase):
         There are some considerations to keep in mind when using this command:
 
         * The glob pattern search does not search recursively in remote instances.
+        * You can download a specific file located in a subdirectory of the
+          MAPDL working directory by giving its relative path, for example
+          ``'subdir/file.rst'``.
         * In a remote instance, it is not possible to list or download files in different
           locations than the MAPDL working directory.
         * If you are in local and provide a file path, downloading files
@@ -3125,9 +3128,13 @@ class MapdlGrpc(MapdlBase):
             )
 
         for each_file in list_files:
+            out_file_name = os.path.join(target_dir, each_file)
+            # 'each_file' might include subdirectories (relative to the
+            # MAPDL working directory), which might not exist yet locally.
+            os.makedirs(os.path.dirname(out_file_name) or ".", exist_ok=True)
             self._download(
                 each_file,
-                out_file_name=os.path.join(target_dir, each_file),
+                out_file_name=out_file_name,
                 chunk_size=chunk_size,
                 progress_bar=progress_bar,
             )
@@ -3147,17 +3154,37 @@ class MapdlGrpc(MapdlBase):
         else:
             extension = ""
 
+        # A glob pattern (with '*', '?' or '[') requires listing the
+        # directory content to filter against.
+        is_glob = bool(re.search(r"[*?\[]", file))
+        # A path with a directory component (for example
+        # ``tmp_dir/file.rst``) points inside a subdirectory of the working
+        # directory.
+        has_subdir = bool(os.path.dirname(file))
+
         if self.is_local:
             # filtering with glob (accepting *)
-            if not os.path.dirname(file):
+            if not os.path.isabs(file):
+                # Relative paths (including ones with subdirectories) are
+                # resolved against the MAPDL working directory.
                 file = str(self.directory / file)
             list_files = glob.glob(file + extension, recursive=recursive)
 
-        else:
+        elif is_glob or not has_subdir:
+            # Either a glob pattern, or a plain filename in the top level of
+            # the working directory: both can be validated against
+            # ``list_files``.
             base_name = os.path.basename(file + extension)
             self_files = self.list_files()
 
             list_files = fnmatch.filter(self_files, base_name)
+
+        else:
+            # Literal file path inside a subdirectory of the working
+            # directory. ``list_files`` only returns the top level of the
+            # working directory, so it cannot be used to validate files in
+            # subdirectories. Trust the explicit path instead.
+            list_files = [file + extension if extension else file]
 
         # filtering by extension
         list_files = [file for file in list_files if file.endswith(extension)]

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -28,7 +28,7 @@ import glob
 import io
 import json
 import os
-from pathlib import Path, PurePath
+from pathlib import Path, PurePath, PurePosixPath
 import re
 import shutil
 
@@ -43,11 +43,12 @@ from warnings import warn
 import weakref
 
 from ansys.tools.common.versioning import version_string_as_tuple
-import grpc
 from grpc._channel import _InactiveRpcError, _MultiThreadedRendezvous
-import numpy as np
 from numpy.typing import NDArray
 import psutil
+
+import grpc
+import numpy as np
 
 MSG_IMPORT = """There was a problem importing the ANSYS MAPDL API module `ansys-api-mapdl`.
 Please make sure you have the latest updated version using:
@@ -3128,18 +3129,45 @@ class MapdlGrpc(MapdlBase):
             )
 
         for each_file in list_files:
-            out_file_name = os.path.join(target_dir, each_file)
+            safe_relative_file = self._validate_remote_relative_path(each_file)
+            out_file_name = os.path.join(target_dir, safe_relative_file)
             # 'each_file' might include subdirectories (relative to the
             # MAPDL working directory), which might not exist yet locally.
             os.makedirs(os.path.dirname(out_file_name) or ".", exist_ok=True)
             self._download(
-                each_file,
+                safe_relative_file,
                 out_file_name=out_file_name,
                 chunk_size=chunk_size,
                 progress_bar=progress_bar,
             )
 
         return list_files
+
+    @staticmethod
+    def _validate_remote_relative_path(path: str) -> str:
+        """Validate a relative remote file path to keep downloads in target_dir."""
+        normalized_path = os.path.normpath(path.replace("\\", "/"))
+        normalized = PurePosixPath(normalized_path)
+
+        if normalized.is_absolute():
+            raise ValueError(
+                f"Path '{path}' is invalid. Absolute paths are not allowed for remote downloads."
+            )
+
+        if ".." in normalized.parts:
+            raise ValueError(
+                f"Path '{path}' is invalid. Parent directory references are not allowed."
+            )
+
+        if normalized.parts and re.match(r"^[a-zA-Z]:$", normalized.parts[0]):
+            raise ValueError(
+                f"Path '{path}' is invalid. Drive-letter paths are not allowed for remote downloads."
+            )
+
+        if str(normalized) in [".", ""]:
+            raise ValueError(f"Path '{path}' is invalid.")
+
+        return str(normalized)
 
     def _validate_files(
         self, file: str, extension: Optional[str] = None, recursive: bool = True
@@ -3183,8 +3211,11 @@ class MapdlGrpc(MapdlBase):
             # Literal file path inside a subdirectory of the working
             # directory. ``list_files`` only returns the top level of the
             # working directory, so it cannot be used to validate files in
-            # subdirectories. Trust the explicit path instead.
-            list_files = [file + extension if extension else file]
+            # subdirectories.
+            file_to_check = self._validate_remote_relative_path(file + extension)
+            list_files = (
+                [file_to_check] if self.inquire("", "EXIST", file_to_check) else []
+            )
 
         # filtering by extension
         list_files = [file for file in list_files if file.endswith(extension)]

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -30,7 +30,6 @@ import sys
 import time
 from unittest.mock import patch
 
-import grpc
 import pytest
 
 from ansys.mapdl.core import examples
@@ -46,6 +45,7 @@ from ansys.mapdl.core.errors import (
 )
 from ansys.mapdl.core.mapdl_grpc import MAX_MESSAGE_LENGTH, MapdlGrpc
 from ansys.mapdl.core.misc import random_string
+import grpc
 
 PATH = os.path.dirname(os.path.abspath(__file__))
 
@@ -350,6 +350,51 @@ def test_screenshot_path_filters_by_jobname(tmp_path):
     assert screenshot_path == str(tmp_path / "tmp.png")
     assert os.path.exists(screenshot_path)
     os.remove(screenshot_path)
+
+
+def test_validate_files_remote_subdirectory():
+    """A literal path inside a subdirectory should be trusted as-is,
+    since ``list_files`` only returns the top level of the working
+    directory (see #4697)."""
+    mapdl = MapdlGrpc.__new__(MapdlGrpc)
+    mapdl._local = False
+    mapdl.list_files = lambda: ["tmp_dir", "other.txt"]
+
+    assert mapdl._validate_files("tmp_dir/file.rst") == ["tmp_dir/file.rst"]
+
+
+def test_validate_files_remote_missing_top_level_file():
+    """A literal top level filename that cannot be found must still raise."""
+    mapdl = MapdlGrpc.__new__(MapdlGrpc)
+    mapdl._local = False
+    mapdl.list_files = lambda: ["other.txt"]
+
+    with pytest.raises(FileNotFoundError):
+        mapdl._validate_files("__notafile__")
+
+
+def test_download_from_remote_subdirectory(tmp_path):
+    """Downloading a file in a subdirectory should recreate the
+    subdirectory structure locally (see #4697)."""
+    mapdl = MapdlGrpc.__new__(MapdlGrpc)
+    mapdl._local = False
+    mapdl.list_files = lambda: ["other.txt"]
+
+    written = {}
+
+    def fake_download(
+        target_name, out_file_name=None, chunk_size=None, progress_bar=None
+    ):
+        written[target_name] = out_file_name
+        with open(out_file_name, "w") as fid:
+            fid.write("data")
+
+    mapdl._download = fake_download
+
+    result = mapdl._download_from_remote("tmp_dir/file.rst", target_dir=str(tmp_path))
+
+    assert result == ["tmp_dir/file.rst"]
+    assert os.path.exists(tmp_path / "tmp_dir" / "file.rst")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -30,6 +30,7 @@ import sys
 import time
 from unittest.mock import patch
 
+import grpc
 import pytest
 
 from ansys.mapdl.core import examples
@@ -45,7 +46,6 @@ from ansys.mapdl.core.errors import (
 )
 from ansys.mapdl.core.mapdl_grpc import MAX_MESSAGE_LENGTH, MapdlGrpc
 from ansys.mapdl.core.misc import random_string
-import grpc
 
 PATH = os.path.dirname(os.path.abspath(__file__))
 

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -30,7 +30,6 @@ import sys
 import time
 from unittest.mock import patch
 
-import grpc
 import pytest
 
 from ansys.mapdl.core import examples
@@ -46,6 +45,7 @@ from ansys.mapdl.core.errors import (
 )
 from ansys.mapdl.core.mapdl_grpc import MAX_MESSAGE_LENGTH, MapdlGrpc
 from ansys.mapdl.core.misc import random_string
+import grpc
 
 PATH = os.path.dirname(os.path.abspath(__file__))
 
@@ -359,8 +359,30 @@ def test_validate_files_remote_subdirectory():
     mapdl = MapdlGrpc.__new__(MapdlGrpc)
     mapdl._local = False
     mapdl.list_files = lambda: ["tmp_dir", "other.txt"]
+    mapdl.inquire = lambda strarray, func, arg1: True
 
     assert mapdl._validate_files("tmp_dir/file.rst") == ["tmp_dir/file.rst"]
+
+
+def test_validate_files_remote_missing_subdirectory_file():
+    """A missing literal subdirectory file must raise as top-level files do."""
+    mapdl = MapdlGrpc.__new__(MapdlGrpc)
+    mapdl._local = False
+    mapdl.list_files = lambda: ["tmp_dir", "other.txt"]
+    mapdl.inquire = lambda strarray, func, arg1: False
+
+    with pytest.raises(FileNotFoundError):
+        mapdl._validate_files("tmp_dir/missing.rst")
+
+
+def test_validate_files_remote_path_traversal_rejected():
+    """Paths that escape the working directory must be rejected."""
+    mapdl = MapdlGrpc.__new__(MapdlGrpc)
+    mapdl._local = False
+    mapdl.inquire = lambda strarray, func, arg1: True
+
+    with pytest.raises(ValueError, match="Parent directory references"):
+        mapdl._validate_files("../escape.rst")
 
 
 def test_validate_files_remote_missing_top_level_file():
@@ -379,6 +401,7 @@ def test_download_from_remote_subdirectory(tmp_path):
     mapdl = MapdlGrpc.__new__(MapdlGrpc)
     mapdl._local = False
     mapdl.list_files = lambda: ["other.txt"]
+    mapdl.inquire = lambda strarray, func, arg1: True
 
     written = {}
 


### PR DESCRIPTION
## Description

Fixes downloading files located in subdirectories of the MAPDL working directory, for example `mapdl.download('tmp_dir/file.rst')`.

## Root cause

For remote sessions, this previously failed because:

- `list_files()` only reports top-level entries in the MAPDL working directory.
- Literal subdirectory paths were validated against that top-level listing, so valid paths like `tmp_dir/file.rst` could not pass validation.
- Downloading into local nested paths did not always ensure parent directories existed.

## Changes

- Allow remote literal subdirectory paths to be validated via `inquire("", "EXIST", ...)` instead of top-level `list_files()` filtering.
- Preserve strict top-level/glob behavior for existing validation paths.
- Create missing local parent directories before writing downloaded files.
- Harden remote path handling by rejecting invalid remote paths (absolute paths, parent traversal, and drive-style roots).
- Add regression tests in `tests/test_grpc.py` for:
  - successful remote subdirectory validation,
  - missing remote subdirectory file raising `FileNotFoundError`,
  - traversal path rejection,
  - remote subdirectory download creating local directories.

Fixes #4697

## Testing

- `PYMAPDL_START_INSTANCE=False uv run pytest tests/test_grpc.py -k "validate_files_remote or download_from_remote_subdirectory"`
