### PR TITLE
fix: add missing -p license_type flag to launch command

### DIFF
--- a/doc/changelog.d/4701.fixed.md
+++ b/doc/changelog.d/4701.fixed.md
@@ -1,0 +1,1 @@
+Add missing -p license_type flag to launch command

--- a/src/ansys/mapdl/core/launcher/process.py
+++ b/src/ansys/mapdl/core/launcher/process.py
@@ -355,6 +355,10 @@ def _generate_launch_command(config: LaunchConfig) -> List[str]:
     if config.ram:
         cmd.extend(["-m", str(config.ram)])
 
+    # License type
+    if config.license_type:
+        cmd.extend(["-p", str(config.license_type)])
+
     # Additional switches
     if config.additional_switches:
         cmd.extend(shlex.split(config.additional_switches))

--- a/tests/test_launcher/test_process.py
+++ b/tests/test_launcher/test_process.py
@@ -114,6 +114,21 @@ class TestGenerateLaunchCommand:
 
         assert "-m" not in cmd
 
+    def test_generate_command_with_license_type(self):
+        """Test command generation with license type."""
+        config = create_launch_config(license_type="meba")
+        cmd = process._generate_launch_command(config)
+
+        assert "-p" in cmd
+        assert cmd[cmd.index("-p") + 1] == "meba"
+
+    def test_generate_command_without_license_type(self):
+        """Test command generation without license type."""
+        config = create_launch_config(license_type=None)
+        cmd = process._generate_launch_command(config)
+
+        assert "-p" not in cmd
+
     def test_generate_command_with_switches(self):
         """Test command generation with additional switches."""
         config = create_launch_config(additional_switches="-dis -acc -w")


### PR DESCRIPTION
Fixes #4632

`launch_mapdl`'s `license_type` parameter was passed through into `LaunchConfig` but `_generate_launch_command` in `process.py` never translated it into the `-p` command-line switch, so the requested license type had no effect. Added the missing `-p` argument and unit tests covering both the case where `license_type` is set and where it's `None`.