### PR TITLE
ci: fix pull-requests write permission for PR docs cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,6 +564,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Needed to push documentation to gh-pages branch
+      pull-requests: write  # Needed to comment on closed PRs when their preview documentation is removed
     needs: [docs-build]
     steps:
       - name: "Deploy the latest documentation"

--- a/doc/changelog.d/4702.maintenance.md
+++ b/doc/changelog.d/4702.maintenance.md
@@ -1,0 +1,1 @@
+Fix pull-requests write permission for PR docs cleanup


### PR DESCRIPTION
## Problem

The dedicated `pr-docs-cleaner.yml` workflow (triggered on `pull_request: closed`) no longer does the actual cleanup: since `ansys/actions/doc-deploy-pr` v10.2, cleanup of PR preview documentation was moved into `ansys/actions/doc-deploy-dev` and now happens automatically as a side effect of every push to `main`.

However, the `upload-dev-docs` job in `ci.yml` (which runs `doc-deploy-dev`) only had `contents: write` permission. The cleanup step in that action tries to comment on each closed PR announcing removal of its docs (via `gh pr comment`), which requires `pull-requests: write`. Without it, the step fails with:

```
GraphQL: Resource not accessible by integration (addComment)
##[error]Process completed with exit code 1.
```

This error happens **before** the `rm -rf pull/<pr>` and push to `gh-pages`, so the job exits 1 and stale PR documentation folders (for example #4587, #4657, #4679, all merged months ago) are never removed. Since `maximum-pr-doc-deployments` is set to `3`, this exhausted the deployment slots, causing new PRs (for example #4699) to get skipped with:

> Pull request documentation preview limit (3) reached: skipping documentation deployment for this pull request.

## Fix

Add `pull-requests: write` to the `upload-dev-docs` job permissions so the cleanup step in `doc-deploy-dev` can comment on closed PRs and complete the removal.

## Verification

Confirmed by inspecting the failed "Upload dev documentation" job logs on `main` runs, where the "Clean up pull/ directory if it exists" step failed at the `gh pr comment` call with a permissions error, aborting before any directory removal.

No changes made to the `gh-pages` branch.