### PR TITLE
ci: refresh CA certificates in the testing image and tidy ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .fuse_hidden*
 *~
 *swp
+.DS_Store
 
 # emacs
 flycheck*
@@ -97,8 +98,8 @@ venv*
 .idea/
 /.vs
 
-# Docker testing secrets - never commit real credentials
-docker/testing/.env
+# Env vars and secrets
+.env
 
 # Extra
 doc/source/errors.txt
@@ -110,5 +111,3 @@ doc/webserver.pid
 # Profiling
 prof
 .github/skills/pymapdl-cli
-docker/run/.env
-docker/testing/.env

--- a/doc/changelog.d/4703.maintenance.md
+++ b/doc/changelog.d/4703.maintenance.md
@@ -1,0 +1,1 @@
+Refresh CA certificates in the testing image and tidy ignores

--- a/docker/testing/Dockerfile
+++ b/docker/testing/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && \
     git \
     openssh-client \
     curl && \
+    update-ca-certificates && \
     # Installing uv
     curl -LsSf https://astral.sh/uv/install.sh | sh \
     && apt-get clean \
@@ -128,9 +129,10 @@ RUN apt-get update && \
     graphviz \
     git \
     openssh-client \
-    curl \
+    curl && \
     # Installing uv
-    && curl -LsSf https://astral.sh/uv/install.sh | sh \
+    update-ca-certificates && \
+    curl -LsSf https://astral.sh/uv/install.sh | sh \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/testing/start.sh
+++ b/docker/testing/start.sh
@@ -109,7 +109,7 @@ uv pip install --python "${VENV_PATH}" -e ".[tests]"
 # shellcheck disable=SC2086
 time xvfb-run -a "${VENV_PATH}/bin/pytest" \
   --basetemp=/tmp/pytest-tmp \
-  -vv \
+  -v \
   ${PYTEST_ARGUMENTS}
 
 PYTEST_EXIT=$?


### PR DESCRIPTION
## Summary

Split out of #4629, where these changes were unrelated to the daemon thread
leak fix that PR is about.

## Changes

### `docker/testing/Dockerfile`

- Runs `update-ca-certificates` in **both** stages. Installing the
  `ca-certificates` package alone does not rebuild the CA bundle, so the
  `curl -LsSf https://astral.sh/uv/install.sh | sh` step can fail TLS
  verification behind a proxy that injects its own root certificate.
- Fixes a line-continuation bug in the second stage. `curl` was chained with a
  bare `\` instead of `&& \`, so `apt-get install` swallowed the following line
  and the `curl` package was effectively an argument to it rather than a
  separate command:

  ```dockerfile
  # before
      openssh-client       curl       # Installing uv
      && curl -LsSf https://astral.sh/uv/install.sh | sh 
  # after
      openssh-client       curl &&       # Installing uv
      update-ca-certificates &&       curl -LsSf https://astral.sh/uv/install.sh | sh   ```

### `docker/testing/start.sh`

Drops pytest from `-vv` to `-v`. The second level only expands assertion diffs
and makes the CI logs considerably harder to scan.

### `.gitignore`

- Replaces the two per-directory entries (`docker/run/.env`,
  `docker/testing/.env`, the latter listed twice) with a single `.env` pattern,
  so any new Docker directory is covered by default. Verified that
  `docker/run/.env` and `docker/testing/.env` are still ignored and that
  `docker/run/example.env` and `docker/testing/example.env` stay tracked.
- Adds `.DS_Store`.

## Checks

`pre-commit` passes on all three files, including `shellcheck` on `start.sh`.