### PR TITLE
fix: avoid segfault from DPF finalizers running during the client API load

### DIFF
--- a/doc/changelog.d/4705.fixed.md
+++ b/doc/changelog.d/4705.fixed.md
@@ -1,0 +1,1 @@
+Avoid segfault from DPF finalizers running during the client API load

--- a/src/ansys/mapdl/core/reader/core.py
+++ b/src/ansys/mapdl/core/reader/core.py
@@ -20,7 +20,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from contextlib import contextmanager
 from functools import wraps
+import gc
 import os
 import pathlib
 import socket
@@ -30,6 +32,7 @@ from typing import (
     Any,
     Callable,
     Iterable,
+    Iterator,
     Literal,
 )
 import weakref
@@ -137,6 +140,37 @@ def update_result(function: Callable[..., Any]) -> Callable[..., Any]:
         return function(self, *args, **kwargs)
 
     return wrapper
+
+
+@contextmanager
+def _gc_disabled() -> Iterator[None]:
+    """Temporarily disable the cyclic garbage collector.
+
+    Loading the DPF client API goes through :mod:`ctypes`, which allocates
+    memory and can therefore trigger a collection pass. If that pass finalizes
+    a DPF object, its ``__del__`` calls into the very C API that is still being
+    loaded, and the process segfaults. Disabling the collector for the duration
+    of the call closes that re-entrancy window.
+
+    Yields
+    ------
+    None
+        Nothing is yielded. The collector state is restored on exit.
+
+    Examples
+    --------
+    >>> with _gc_disabled():
+    ...     dpf.server.start_local_server()
+    """
+    was_enabled = gc.isenabled()
+    if was_enabled:
+        gc.disable()
+
+    try:
+        yield
+    finally:
+        if was_enabled:
+            gc.enable()
 
 
 class DPFResultCore:
@@ -352,26 +386,31 @@ class DPFResultCore:
         external_ip: str | None = None,
         external_port: int | None = None,
     ):
-        if mode == "InProcess":
-            dpf.server.set_server_configuration(
-                dpf.server_factory.AvailableServerConfigs.InProcessServer
+        if mode == "RemoteGrpc" and (external_ip is None or external_port is None):
+            raise ValueError(
+                "external_ip and external_port should be provided for RemoteGrpc communication"
             )
-            srvr = dpf.server.start_local_server()
-        elif mode == "LocalGrpc":
-            dpf.server.set_server_configuration(
-                dpf.server_factory.AvailableServerConfigs.GrpcServer
-            )
-            srvr = dpf.server.start_local_server()
-        elif mode == "RemoteGrpc":
-            dpf.server.set_server_configuration(
-                dpf.server_factory.AvailableServerConfigs.GrpcServer
-            )
-            if external_ip is not None and external_port is not None:
-                srvr = dpf.server.connect_to_server(ip=external_ip, port=external_port)
-            else:
-                raise ValueError(
-                    "external_ip and external_port should be provided for RemoteGrpc communication"
+        elif mode not in ("InProcess", "LocalGrpc", "RemoteGrpc"):
+            raise ValueError(f"Unknown DPF connection mode: {mode}")
+
+        # The garbage collector is disabled while the DPF client API is being
+        # loaded. See the `_gc_disabled` context manager for the rationale.
+        with _gc_disabled():
+            if mode == "InProcess":
+                dpf.server.set_server_configuration(
+                    dpf.server_factory.AvailableServerConfigs.InProcessServer
                 )
+                srvr = dpf.server.start_local_server()
+            elif mode == "LocalGrpc":
+                dpf.server.set_server_configuration(
+                    dpf.server_factory.AvailableServerConfigs.GrpcServer
+                )
+                srvr = dpf.server.start_local_server()
+            else:
+                dpf.server.set_server_configuration(
+                    dpf.server_factory.AvailableServerConfigs.GrpcServer
+                )
+                srvr = dpf.server.connect_to_server(ip=external_ip, port=external_port)
 
         self._server = srvr
 

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -37,11 +37,13 @@ Notes
 
 """
 
+import gc
 from inspect import signature
 import os
 import re
 import shutil
 import tempfile
+from unittest.mock import MagicMock, patch
 from warnings import warn
 
 import numpy as np
@@ -85,6 +87,7 @@ from ansys.mapdl.core.examples import (
 )
 from ansys.mapdl.core.logging import PymapdlCustomAdapter as MAPDLLogger
 from ansys.mapdl.core.misc import create_temp_dir
+from ansys.mapdl.core.reader.core import _gc_disabled
 
 
 def validate(result_values, reader_values=None, post_values=None, rtol=1e-5, atol=1e-8):
@@ -401,9 +404,90 @@ def test_error_initialization_rst_file_not_found():
         DPFResult(rst_file=rst_file)
 
 
+class TestGCDuringDPFAPILoad:
+    """Tests for the garbage collector guard around the DPF client API load.
+
+    See https://github.com/ansys/pymapdl/issues/4704.
+    """
+
+    def test_gc_disabled_restores_state(self):
+        assert gc.isenabled()
+
+        with _gc_disabled():
+            assert not gc.isenabled()
+
+        assert gc.isenabled()
+
+    def test_gc_disabled_restores_state_on_exception(self):
+        assert gc.isenabled()
+
+        with pytest.raises(RuntimeError, match="Loading failed"):
+            with _gc_disabled():
+                assert not gc.isenabled()
+                raise RuntimeError("Loading failed")
+
+        assert gc.isenabled()
+
+    def test_gc_disabled_does_not_enable_gc(self):
+        gc.disable()
+        try:
+            with _gc_disabled():
+                assert not gc.isenabled()
+
+            assert not gc.isenabled()
+        finally:
+            gc.enable()
+
+    @pytest.mark.parametrize(
+        "mode,kwargs",
+        [
+            ("InProcess", {}),
+            ("LocalGrpc", {}),
+            ("RemoteGrpc", {"external_ip": "127.0.0.1", "external_port": 50054}),
+        ],
+    )
+    def test_gc_disabled_while_connecting(self, mode, kwargs):
+        """The collector must be off while DPF loads its client API."""
+        from ansys.mapdl.core.reader import DPFResult
+
+        gc_states = []
+
+        def record_gc_state(*args, **kwargs):
+            gc_states.append(gc.isenabled())
+            return "server"
+
+        result = DPFResult.__new__(DPFResult)
+
+        mock_dpf = MagicMock()
+        mock_dpf.server.start_local_server.side_effect = record_gc_state
+        mock_dpf.server.connect_to_server.side_effect = record_gc_state
+
+        with patch("ansys.mapdl.core.reader.core.dpf", mock_dpf):
+            result._connect_to_dpf_using_mode(mode=mode, **kwargs)
+
+        assert gc_states == [False], "The GC was enabled during the DPF API load."
+        assert result._server == "server"
+        assert gc.isenabled()
+
+    def test_remote_grpc_requires_ip_and_port(self):
+        from ansys.mapdl.core.reader import DPFResult
+
+        result = DPFResult.__new__(DPFResult)
+
+        with pytest.raises(ValueError, match="external_ip and external_port"):
+            result._connect_to_dpf_using_mode(mode="RemoteGrpc")
+
+    def test_unknown_mode(self):
+        from ansys.mapdl.core.reader import DPFResult
+
+        result = DPFResult.__new__(DPFResult)
+
+        with pytest.raises(ValueError, match="Unknown DPF connection mode"):
+            result._connect_to_dpf_using_mode(mode="NotAMode")
+
+
 @pytest.mark.skipif(ON_LOCAL, reason="Skip on local machine")
-def test_dpf_connection():
-    # uses 127.0.0.1 and port 50054 by default
+def test_dpf_connection():  # uses 127.0.0.1 and port 50054 by default
     try:
         grpc_con = dpf_core.connect_to_server(port=DPF_PORT)
         assert grpc_con.live

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -42,6 +42,8 @@ from inspect import signature
 import os
 import re
 import shutil
+import subprocess
+import sys
 import tempfile
 from unittest.mock import MagicMock, patch
 from warnings import warn
@@ -52,6 +54,7 @@ import pytest
 from conftest import HAS_DPF, ON_LOCAL, TEST_DPF_BACKEND, clear, solved_box_func
 
 DPF_PORT = int(os.environ.get("DPF_PORT", 50056))  # Set in ci.yaml
+DPF_IP = os.environ.get("DPF_IP", "127.0.0.1")
 
 if not HAS_DPF:
     pytest.skip(
@@ -404,6 +407,52 @@ def test_error_initialization_rst_file_not_found():
         DPFResult(rst_file=rst_file)
 
 
+GC_DURING_API_LOAD_SCRIPT = '''
+"""Child process for the #4704 regression test.
+
+Connects to a remote DPF server, leaves unreferenced ``DataSources`` objects
+behind in reference cycles so that only the cyclic collector can reclaim them,
+then connects again. The second connection re-runs ``load_client_api()``, which
+is the window in which a collection pass must not run DPF finalizers.
+
+Each attempt starts from a drained collector and creates few enough objects to
+stay below the generation 0 threshold, so no collection happens before the
+load. The allocations of the load itself then cross the threshold and the pass
+fires inside the window. Ten attempts make the crash reliable: without the
+guard this script segfaults every time.
+"""
+
+import gc
+import sys
+
+from ansys.dpf import core as dpf
+
+from ansys.mapdl.core.reader.core import DPFResultCore
+
+ip = sys.argv[1]
+port = int(sys.argv[2])
+
+result = DPFResultCore.__new__(DPFResultCore)
+result._connect_to_dpf_using_mode("RemoteGrpc", ip, port)
+server = result._server
+
+for attempt in range(10):
+    gc.collect()  # start each attempt with no pending garbage
+    for _ in range(40):
+        data_sources = dpf.DataSources(server=server)
+        cycle = {"data_sources": data_sources}
+        cycle["self"] = cycle  # only the cyclic collector can reclaim this
+        del data_sources, cycle
+
+    # Reloads the DPF client API while the objects above await collection.
+    result._connect_to_dpf_using_mode("RemoteGrpc", ip, port)
+    print(f"attempt {attempt} survived", flush=True)
+
+gc.collect()
+print("SURVIVED")
+'''
+
+
 class TestGCDuringDPFAPILoad:
     """Tests for the garbage collector guard around the DPF client API load.
 
@@ -484,6 +533,35 @@ class TestGCDuringDPFAPILoad:
 
         with pytest.raises(ValueError, match="Unknown DPF connection mode"):
             result._connect_to_dpf_using_mode(mode="NotAMode")
+
+    @pytest.mark.skipif(ON_LOCAL, reason="Requires the remote DPF service used in CI")
+    def test_no_segfault_when_gc_runs_during_api_load(self, tmp_path):
+        """Reproduce the crash conditions of #4704 and check the process survives.
+
+        Every new DPF server connection re-runs ``load_client_api()``. If the
+        cyclic collector fires during that load and finalizes a ``DataSources``,
+        its ``__del__`` calls into the half-loaded C API and the interpreter
+        segfaults. Without the guard, this scenario crashes reproducibly.
+
+        The scenario runs in a subprocess because the failure mode is a
+        segmentation fault, which would take the test session down with it.
+        """
+        script = tmp_path / "gc_during_dpf_api_load.py"
+        script.write_text(GC_DURING_API_LOAD_SCRIPT)
+
+        proc = subprocess.run(
+            [sys.executable, str(script), DPF_IP, str(DPF_PORT)],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+
+        assert proc.returncode == 0, (
+            f"The DPF connection crashed with return code {proc.returncode} "
+            f"(-11 or 139 means SIGSEGV).\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+        assert "SURVIVED" in proc.stdout
 
 
 @pytest.mark.skipif(ON_LOCAL, reason="Skip on local machine")


### PR DESCRIPTION
## Description

Closes #4704.

A segmentation fault happens intermittently in the remote DPF CI job (for example, in `tests/test_result.py::test_compatibility_nodal_voltage`) when Python's cyclic garbage collector finalizes an `ansys.dpf.core.data_sources.DataSources` while the main thread is still inside `ctypes` loading the DPF client API.

`DataSources.__del__` ends in a C call routed through a module-level global:

```python
# ansys/dpf/gate/generated/data_processing_capi.py:141
res = capi.dll.DataProcessing_delete_shared_object(data._internal_obj, ...)
```

and `capi.load_api()` replaces that very global, then re-prototypes thousands of symbols one by one:

```python
# ansys/dpf/gate/generated/capi.py
def load_api(path):
    global dll, _api_loading
    _api_loading = True
    dll = ctypes.cdll.LoadLibrary(path)      # global replaced
    if hasattr(dll, "Any_WrappedTypeString"):  # ... thousands of allocations
        dll.Any_WrappedTypeString.argtypes = ...
```

Every allocation in that loop is a chance for the cyclic collector to run. If it reclaims a `DataSources`, the finalizer calls into the half-loaded API and the process dies.

Two things are worth stressing. First, **every** new DPF server connection re-runs `load_client_api()`, so this is not a one-time startup risk. Second, upstream already knows this failure mode: `ansys-dpf-gate` carries a module-level `_api_loading` flag whose comment reads *"Used by `DPFVector.__del__` to avoid re-entrant C API calls during GC cycles that fire mid-initialization, which can cause segfaults under Python 3.11 on Linux."* `DPFVector.__del__` checks it. `DataSources.__del__` does not, and that is our faulting frame.

## Evidence

The hypothesis was verified experimentally rather than assumed, against a real `ghcr.io/ansys/mapdl:v25.2-rocky-dpf-standalone` server with `ansys-dpf-core==0.13.6` on Python 3.12, which is the CI combination. Each cell is five independent processes:

| Unreferenced `DataSources` pending | Automatic GC during the API load | Result |
|---|---|---|
| yes | **on** | **5/5 SIGSEGV** |
| yes | off | 5/5 clean |
| no, drained first | on | 5/5 clean |
| no, drained first | off | 5/5 clean |
| no DPF objects created at all | on | 5/5 clean |

Neither factor crashes on its own. The crash needs both: DPF garbage pending *and* the collector free to run during the load. The faulting stack of the reproduction matches the CI dump of #4704 line for line:

```text
Current thread 0x00007ffffee87740 (most recent call first):
  Garbage-collecting
  File ".../ansys/dpf/gate/generated/data_processing_capi.py", line 141 in data_processing_delete_shared_object
  File ".../ansys/dpf/core/data_sources.py", line 698 in __del__
  File ".../ctypes/__init__.py", line 392 in __getattr__
  File ".../ansys/dpf/gate/generated/capi.py", line 267 in load_api
  File ".../ansys/dpf/gate/load_api.py", line 192 in _try_load_api
  File ".../ansys/dpf/gate/load_api.py", line 239 in load_client_api
  File ".../ansys/dpf/core/server_types.py", line 689 in __init__
  File ".../ansys/dpf/core/server_types.py", line 776 in __init__
  File ".../ansys/dpf/core/server.py", line 364 in connect
  File ".../ansys/dpf/core/server.py", line 382 in connect_to_server
```

## Fix

PyMAPDL cannot change `DataSources.__del__`, but it fully controls when the client API is loaded: inside `DPFResultCore._connect_to_dpf_using_mode()`. Suspending the cyclic collector for that call closes the window, since the collector is the only thing that can run an unrelated finalizer at an arbitrary allocation point in this thread.

In `src/ansys/mapdl/core/reader/core.py`:

- Added the `_gc_disabled()` context manager. It suspends the cyclic collector and restores the previous state on exit, including when an exception propagates. If the caller had already disabled it, it stays disabled, so PyMAPDL never silently re-enables a collector somebody else turned off.
- `_connect_to_dpf_using_mode()` wraps every `dpf.server` start or connect call in it, covering `InProcess`, `LocalGrpc`, and `RemoteGrpc` alike, since any of them can trigger the load.
- Argument validation moved ahead of the connection attempt. `RemoteGrpc` without `external_ip` or `external_port` raises the same `ValueError` as before, and an unknown mode now raises `ValueError` instead of falling through to an `UnboundLocalError` on `srvr`.

Scope is deliberately small: the collector is suspended for the duration of one server connection. Objects that become garbage during the load are collected as usual right afterwards, when the API is fully loaded and the finalizers are safe. Reference-counted deallocation is unaffected, since `gc.disable()` only stops the cyclic collector.

An alternative, calling `gc.collect()` before connecting, also survived 5/5 in the experiment. It was not chosen because it only drains the backlog: anything that becomes garbage *during* the load is still collectable inside the window, so it narrows the race instead of closing it.

## Behavior and compatibility

- No public API change and no signature change.
- The only externally visible difference is the new `ValueError` for an unknown mode, which previously raised `UnboundLocalError` from the same call. `_connect_to_dpf_using_mode()` is private and its mode is typed as a `Literal`.

## Tests

`tests/test_result.py::TestGCDuringDPFAPILoad`, nine tests.

Eight are mocked and need neither MAPDL nor a DPF server: the collector is off inside the context and restored after it, restored when the body raises, an already disabled collector stays disabled, `gc.isenabled()` observed from inside the mocked `start_local_server` and `connect_to_server` is `False` for all three modes, and both validation paths raise.

The ninth, `test_no_segfault_when_gc_runs_during_api_load`, is a real regression test. It drives PyMAPDL's own connection path in a subprocess, since the failure mode is SIGSEGV and would otherwise take the test session with it: connect, leave unreferenced `DataSources` in reference cycles, connect again so the client API reloads while they await collection, repeated ten times. Verified against the real v25.2 DPF server:

- without the guard: **`-11` (SIGSEGV), 5/5**
- with the guard: **exit 0, 5/5**

```sh
HAS_DPF=true TEST_DPF_BACKEND=YES DPF_IP=... DPF_PORT=... \
  pytest tests/test_result.py -k TestGCDuringDPFAPILoad
# 9 passed
```

`pre-commit run --files src/ansys/mapdl/core/reader/core.py tests/test_result.py` passes.

## Follow-up upstream

The complementary fix belongs in `ansys-dpf-core`: `DataSources.__del__` should check the existing `_api_loading` flag the same way `DPFVector.__del__` already does, along with the other `data_processing_delete_shared_object` callers. That would protect every consumer, not only PyMAPDL. An issue with this reproduction is being filed against pydpf-core.

## Related

- Closes #4704
- Related to #4608 (leaked daemon threads, same faulthandler dumps, different root cause) and #4629
