### PR TITLE
fix: track the MAPDL startup reader thread and the stdout redirect file

### DIFF
--- a/doc/changelog.d/4706.fixed.md
+++ b/doc/changelog.d/4706.fixed.md
@@ -1,0 +1,1 @@
+Track the MAPDL startup reader thread and the stdout redirect file

--- a/src/ansys/mapdl/core/launcher/process.py
+++ b/src/ansys/mapdl/core/launcher/process.py
@@ -462,7 +462,12 @@ def _start_subprocess(
         )
     except Exception:
         if stdout_file_handle is not None:
-            stdout_file_handle.close()
+            try:
+                stdout_file_handle.close()
+            except OSError:
+                # Preserve the original Popen failure even if closing the
+                # handle itself raises (e.g. a flush/IO error).
+                pass
         raise
 
     # Keep a reference to the output file so _kill_process can close it

--- a/src/ansys/mapdl/core/launcher/process.py
+++ b/src/ansys/mapdl/core/launcher/process.py
@@ -277,7 +277,8 @@ def wait_for_process_ready(
     LOG.debug("Checking MAPDL process startup")
 
     # Set up stdout monitoring
-    stdout_queue = _monitor_stdout(process.stdout)
+    stdout_queue, stdout_monitor_thread = _monitor_stdout(process.stdout)
+    process._startup_stdout_thread = stdout_monitor_thread  # type: ignore[attr-defined]
 
     # Check process alive
     check_process_is_alive(process, run_location)
@@ -431,8 +432,10 @@ def _start_subprocess(
     stdout_arg: Union[int, IO[bytes]]
     stderr_arg: int
 
+    stdout_file_handle: Optional[IO[bytes]] = None
     if output_file:
-        stdout_arg = open(output_file, "wb", 0)  # todo: handle file closing
+        stdout_file_handle = open(output_file, "wb", 0)
+        stdout_arg = stdout_file_handle
         stderr_arg = subprocess.STDOUT
     else:
         stdout_arg = subprocess.PIPE
@@ -447,15 +450,25 @@ def _start_subprocess(
     )
 
     # Launch process
-    process = subprocess.Popen(
-        cmd,
-        shell=False,  # Security: avoid shell injection  # nosec B603
-        cwd=cwd,
-        stdin=subprocess.DEVNULL,
-        stdout=stdout_arg,
-        stderr=stderr_arg,
-        env=env,
-    )
+    try:
+        process = subprocess.Popen(
+            cmd,
+            shell=False,  # Security: avoid shell injection  # nosec B603
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout_arg,
+            stderr=stderr_arg,
+            env=env,
+        )
+    except Exception:
+        if stdout_file_handle is not None:
+            stdout_file_handle.close()
+        raise
+
+    # Keep a reference to the output file so _kill_process can close it
+    # explicitly.  When stdout=PIPE, process.stdout is the pipe; when
+    # stdout is a file Popen does not expose it, so we store it here.
+    process._stdout_file_handle = stdout_file_handle  # type: ignore[attr-defined]
 
     LOG.debug(f"MAPDL process started with PID: {process.pid}")
     return process
@@ -501,7 +514,9 @@ def _create_temp_input_file(run_location: str) -> None:
     LOG.debug(f"Created temporary input file: {tmp_inp_path}")
 
 
-def _monitor_stdout(stdout: Optional[object]) -> Optional[Queue]:
+def _monitor_stdout(
+    stdout: Optional[object],
+) -> Tuple[Optional[Queue], Optional[threading.Thread]]:
     """Set up background thread to monitor subprocess stdout.
 
     Starts a daemon thread that reads lines from subprocess stdout and
@@ -515,8 +530,9 @@ def _monitor_stdout(stdout: Optional[object]) -> Optional[Queue]:
 
     Returns
     -------
-    Optional[Queue]
-        Queue for reading stdout lines, or None if stdout is not available
+    tuple[Optional[Queue], Optional[threading.Thread]]
+        Queue for reading stdout lines and the daemon thread doing the
+        reading, or ``(None, None)`` if stdout is not available.
 
     Raises
     ------
@@ -529,7 +545,7 @@ def _monitor_stdout(stdout: Optional[object]) -> Optional[Queue]:
     >>> from ansys.mapdl.core.launcher.process import _monitor_stdout
     >>> import subprocess
     >>> process = subprocess.Popen(..., stdout=subprocess.PIPE)
-    >>> stdout_queue = _monitor_stdout(process.stdout)
+    >>> stdout_queue, stdout_thread = _monitor_stdout(process.stdout)
     >>> if stdout_queue:
     ...     line = stdout_queue.get(timeout=1)
 
@@ -537,12 +553,12 @@ def _monitor_stdout(stdout: Optional[object]) -> Optional[Queue]:
     -----
     - Internal utility function
     - Runs in background daemon thread (won't block process exit)
-    - Returns None if stdout cannot be monitored
+    - Returns ``(None, None)`` if stdout cannot be monitored
     - Thread closes stdout when end-of-stream reached
     - Gracefully handles process termination
     """
     if not stdout:
-        return None
+        return None, None
 
     queue: Queue = Queue()
 
@@ -559,7 +575,7 @@ def _monitor_stdout(stdout: Optional[object]) -> Optional[Queue]:
     thread = threading.Thread(target=reader, daemon=True)
     thread.start()
 
-    return queue
+    return queue, thread
 
 
 def _wait_directory_ready(run_location: str, timeout: int) -> None:

--- a/tests/test_launcher/test_process.py
+++ b/tests/test_launcher/test_process.py
@@ -25,6 +25,7 @@
 import os
 from queue import Queue
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -248,10 +249,10 @@ class TestStartSubprocess:
     """Tests for subprocess start function."""
 
     def test_start_subprocess_with_output_file(self):
-        """Test starting subprocess with output file."""
+        """Test starting subprocess with output file stores _stdout_file_handle."""
         with tempfile.TemporaryDirectory() as tmpdir:
             output_file = os.path.join(tmpdir, "output.txt")
-            cmd = ["python", "-c", "print('test')"]
+            cmd = [sys.executable, "-c", "print('test')"]
 
             proc = process._start_subprocess(
                 cmd=cmd,
@@ -262,13 +263,17 @@ class TestStartSubprocess:
 
             assert proc is not None
             assert isinstance(proc, subprocess.Popen)
+            # The file handle must be stored so _kill_process can close it
+            assert proc._stdout_file_handle is not None
+            assert not proc._stdout_file_handle.closed
             proc.wait(timeout=10)
+            proc._stdout_file_handle.close()
             assert proc.poll() is not None
 
     def test_start_subprocess_without_output_file(self):
-        """Test starting subprocess without output file."""
+        """Test starting subprocess without output file has no file handle."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            cmd = ["python", "-c", "print('test')"]
+            cmd = [sys.executable, "-c", "print('test')"]
 
             proc = process._start_subprocess(
                 cmd=cmd,
@@ -279,6 +284,10 @@ class TestStartSubprocess:
 
             assert proc is not None
             assert isinstance(proc, subprocess.Popen)
+            # No file redirect — handle should be None, pipes should be open
+            assert proc._stdout_file_handle is None
+            assert proc.stdout is not None
+            assert proc.stderr is not None
             proc.wait(timeout=10)
 
 
@@ -291,34 +300,47 @@ class TestMonitorStdout:
     """Tests for stdout monitoring."""
 
     def test_monitor_stdout_with_pipe(self):
-        """Test monitoring stdout with pipe."""
+        """Test monitoring stdout with pipe returns (queue, thread)."""
         mock_pipe = Mock()
         mock_pipe.readline.side_effect = [b"line1\n", b"line2\n", b""]
 
-        queue = process._monitor_stdout(mock_pipe)
+        queue, thread = process._monitor_stdout(mock_pipe)
 
         assert queue is not None
         assert isinstance(queue, Queue)
+        assert thread is not None
+        assert isinstance(thread, threading.Thread)
 
         time.sleep(0.3)
 
         assert not queue.empty()
 
     def test_monitor_stdout_without_pipe(self):
-        """Test monitoring stdout returns None without pipe."""
+        """Test monitoring stdout returns (None, None) without pipe."""
         result = process._monitor_stdout(None)
-        assert result is None
+        assert result == (None, None)
 
     def test_monitor_stdout_with_error(self):
-        """Test monitoring stdout handles errors."""
+        """Test monitoring stdout handles errors gracefully."""
         mock_pipe = Mock()
         mock_pipe.readline.side_effect = ValueError("Pipe closed")
 
-        queue = process._monitor_stdout(mock_pipe)
+        queue, thread = process._monitor_stdout(mock_pipe)
 
         time.sleep(0.3)
 
         assert queue is not None
+        assert thread is not None
+
+    def test_monitor_stdout_thread_is_daemon(self):
+        """Test that the reader thread is a daemon thread."""
+        mock_pipe = Mock()
+        mock_pipe.readline.side_effect = [b""]
+
+        _, thread = process._monitor_stdout(mock_pipe)
+
+        assert thread is not None
+        assert thread.daemon is True
 
 
 # ============================================================================
@@ -484,7 +506,7 @@ class TestWaitForProcessReady:
         mock_process.poll.return_value = None
         mock_process.stdout = None
 
-        mock_monitor.return_value = None
+        mock_monitor.return_value = (None, None)
 
         process.wait_for_process_ready(
             process=mock_process,
@@ -517,7 +539,7 @@ class TestWaitForProcessReady:
         mock_process.stdout = mock_stdout
 
         mock_queue = Mock(spec=Queue)
-        mock_monitor.return_value = mock_queue
+        mock_monitor.return_value = (mock_queue, Mock())
 
         process.wait_for_process_ready(
             process=mock_process,
@@ -703,21 +725,22 @@ class TestPhase4QueueMonitoringEdgeCases:
     """
 
     def test_monitor_stdout_creates_queue(self):
-        """Test that _monitor_stdout creates queue when stdout available."""
+        """Test that _monitor_stdout creates (queue, thread) when stdout available."""
         mock_stdout = Mock()
         mock_stdout.readline = Mock(side_effect=[b"line1\n", b"line2\n", b""])
 
-        queue = process._monitor_stdout(mock_stdout)
+        queue, thread = process._monitor_stdout(mock_stdout)
 
         assert queue is not None
-
         assert isinstance(queue, process.Queue)
+        assert thread is not None
+        assert isinstance(thread, threading.Thread)
 
     def test_monitor_stdout_returns_none_when_no_stdout(self):
-        """Test that _monitor_stdout returns None when stdout is None."""
-        queue = process._monitor_stdout(None)
+        """Test that _monitor_stdout returns (None, None) when stdout is None."""
+        result = process._monitor_stdout(None)
 
-        assert queue is None
+        assert result == (None, None)
 
     def test_check_grpc_server_ready_success(self):
         """Test gRPC server ready detection with both patterns."""

--- a/tests/test_launcher/test_process.py
+++ b/tests/test_launcher/test_process.py
@@ -266,9 +266,11 @@ class TestStartSubprocess:
             # The file handle must be stored so _kill_process can close it
             assert proc._stdout_file_handle is not None
             assert not proc._stdout_file_handle.closed
-            proc.wait(timeout=10)
-            proc._stdout_file_handle.close()
-            assert proc.poll() is not None
+            try:
+                proc.wait(timeout=10)
+                assert proc.poll() is not None
+            finally:
+                proc._stdout_file_handle.close()
 
     def test_start_subprocess_without_output_file(self):
         """Test starting subprocess without output file has no file handle."""
@@ -288,7 +290,55 @@ class TestStartSubprocess:
             assert proc._stdout_file_handle is None
             assert proc.stdout is not None
             assert proc.stderr is not None
-            proc.wait(timeout=10)
+
+    def test_start_subprocess_closes_file_handle_when_popen_fails(self):
+        """If Popen raises, the stdout redirect file handle must be closed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = os.path.join(tmpdir, "output.txt")
+            cmd = [sys.executable, "-c", "print('test')"]
+
+            with (
+                patch.object(subprocess, "Popen", side_effect=OSError("boom")),
+                pytest.raises(OSError, match="boom"),
+            ):
+                process._start_subprocess(
+                    cmd=cmd,
+                    cwd=tmpdir,
+                    env=os.environ.copy(),
+                    output_file=output_file,
+                )
+
+            # The handle opened before Popen failed must not have leaked.
+            with open(output_file, "rb") as fh:
+                pass
+            assert fh.closed
+
+    def test_start_subprocess_popen_failure_survives_close_error(self):
+        """A failure while closing the handle must not mask the Popen error."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_file = os.path.join(tmpdir, "output.txt")
+            cmd = [sys.executable, "-c", "print('test')"]
+
+            mock_handle = Mock()
+            mock_handle.close.side_effect = OSError("close failed")
+
+            with (
+                patch.object(subprocess, "Popen", side_effect=OSError("boom")),
+                patch(
+                    "ansys.mapdl.core.launcher.process.open",
+                    return_value=mock_handle,
+                    create=True,
+                ),
+                pytest.raises(OSError, match="boom"),
+            ):
+                process._start_subprocess(
+                    cmd=cmd,
+                    cwd=tmpdir,
+                    env=os.environ.copy(),
+                    output_file=output_file,
+                )
+
+            mock_handle.close.assert_called_once()
 
 
 # ============================================================================
@@ -539,7 +589,8 @@ class TestWaitForProcessReady:
         mock_process.stdout = mock_stdout
 
         mock_queue = Mock(spec=Queue)
-        mock_monitor.return_value = (mock_queue, Mock())
+        mock_thread = Mock()
+        mock_monitor.return_value = (mock_queue, mock_thread)
 
         process.wait_for_process_ready(
             process=mock_process,
@@ -551,6 +602,9 @@ class TestWaitForProcessReady:
         mock_wait_dir.assert_called_once()
         mock_wait_err.assert_called_once()
         mock_grpc.assert_called_once_with(mock_queue, 10)
+        # The startup reader thread must be attached to the process so
+        # downstream teardown logic can join it.
+        assert mock_process._startup_stdout_thread is mock_thread
 
     def test_wait_for_process_ready_process_died(self):
         """Test handling process that died immediately."""


### PR DESCRIPTION
## Summary

Split out of #4629 (see the [split plan](https://github.com/ansys/pymapdl/pull/4629) for context). This is PR 1 of 5: pure launcher-side resource plumbing, no gRPC involvement, no behaviour change.

Fixes two resource-tracking gaps in `src/ansys/mapdl/core/launcher/process.py` reported alongside #4608:

1. **`_monitor_stdout(stdout)`** started a daemon reader thread and discarded the handle, so nothing downstream could ever join it. It now returns `Tuple[Optional[Queue], Optional[threading.Thread]]`, and `wait_for_process_ready()` attaches the thread as `process._startup_stdout_thread` so teardown code can find it.
2. **`_start_subprocess()`** opened the stdout redirect file with a `# todo: handle file closing` comment and never kept a reference for later cleanup. The handle is now stored as `process._stdout_file_handle`, and `subprocess.Popen(...)` is wrapped in `try/except` so the handle is closed and the exception re-raised if `Popen` fails.

## Testing

- Updated every existing `_monitor_stdout` caller in `tests/test_launcher/test_process.py` for the tuple return.
- Added `TestMonitorStdout::test_monitor_stdout_thread_is_daemon`.
- Added assertions that `_stdout_file_handle` is set/closed correctly in `TestStartSubprocess`.
- `PYMAPDL_START_INSTANCE=False pytest tests/test_launcher/`: 593 passed, 1 skipped.
- `pre-commit run --files src/ansys/mapdl/core/launcher/process.py tests/test_launcher/test_process.py`: passed.

Related: #4608

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>