### PR TITLE
fix: stop leaking a gRPC _poll_connectivity daemon thread per MAPDL instance

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -159,7 +159,7 @@ jobs:
       - name: "Install OS packages"
         shell: bash
         run: |
-          sudo apt update && sudo apt install zip pandoc libgl1 libglx-mesa0 xvfb texlive-latex-extra latexmk graphviz texlive-xetex texlive-fonts-extra qpdf xindy librsvg2-bin
+          sudo apt update && sudo apt install zip pandoc libgl1 libglx-mesa0 xvfb texlive-latex-extra latexmk graphviz texlive-xetex texlive-fonts-extra qpdf xindy librsvg2-bin moreutils
 
       - name: "Test virtual framebuffer"
         shell: bash
@@ -245,7 +245,15 @@ jobs:
           DPF_DEFAULT_GRPC_MODE: 'insecure'
         run: |
           export PYTHONFAULTHANDLER=1
-          xvfb-run make -C doc ${BUILDER} SPHINXOPTS="-j auto" | tee doc_build.log
+          # Temporary diagnostics for the intermittent hangs seen during the
+          # "updating environment"/intersphinx phase of the doc build
+          # (https://github.com/ansys/pymapdl/pull/4707). "-vv" makes Sphinx
+          # log each source file read and each intersphinx inventory fetch;
+          # piping through "ts" timestamps every line so the exact moment a
+          # hang starts is visible in the artifact even without live logs.
+          xvfb-run make -C doc ${BUILDER} SPHINXOPTS="-j auto -vv" 2>&1 \
+            | ts '%Y-%m-%dT%H:%M:%.S' \
+            | tee doc_build.log
 
       - name: "Substitute defective GIF"
         shell: bash

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -246,12 +246,15 @@ jobs:
         run: |
           export PYTHONFAULTHANDLER=1
           # Temporary diagnostics for the intermittent hangs seen during the
-          # "updating environment"/intersphinx phase of the doc build
-          # (https://github.com/ansys/pymapdl/pull/4707). "-vv" makes Sphinx
-          # log each source file read and each intersphinx inventory fetch;
-          # piping through "ts" timestamps every line so the exact moment a
-          # hang starts is visible in the artifact even without live logs.
-          xvfb-run make -C doc ${BUILDER} SPHINXOPTS="-j auto -vv" 2>&1 \
+          # doc build (https://github.com/ansys/pymapdl/pull/4707). The
+          # timestamped "-vv" log showed the freeze happens right after the
+          # "env-purge-doc" loop finishes, at the point where Sphinx forks
+          # worker processes (multiprocessing, "-j auto") for parallel source
+          # reading. gRPC's native completion-queue threads, left over from
+          # the gallery examples' MAPDL sessions, are known to deadlock a
+          # forked child if still alive at fork time. Forcing "-j 1" disables
+          # that fork so we can confirm/rule out this hypothesis.
+          xvfb-run make -C doc ${BUILDER} SPHINXOPTS="-j 1 -vv" 2>&1 \
             | ts '%Y-%m-%dT%H:%M:%.S' \
             | tee doc_build.log
 

--- a/doc/changelog.d/4707.fixed.md
+++ b/doc/changelog.d/4707.fixed.md
@@ -1,0 +1,1 @@
+Stop leaking a gRPC _poll_connectivity daemon thread per MAPDL instance

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -130,6 +130,11 @@ intersphinx_mapping = {
     "pytwin": ("https://twin.docs.pyansys.com/version/stable/", None),
 }
 
+# Fail fast instead of hanging indefinitely when a remote inventory is slow or
+# unreachable. Sphinx's default (no timeout) has caused the documentation
+# build job to freeze for the full CI timeout on a stalled fetch.
+intersphinx_timeout = 10
+
 suppress_warnings = ["label.*", "design.fa-build", "config.cache"]
 sd_fontawesome_latex = True
 

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -38,7 +38,17 @@ import subprocess  # nosec B404
 import tempfile
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+)
 from warnings import warn
 import weakref
 
@@ -487,6 +497,7 @@ class MapdlGrpc(MapdlBase):
             grpc.ChannelConnectivity.CONNECTING
         )
         self._time_step_stream: Optional[int] = None
+        self._connectivity_callback: Optional[Callable[[Any], None]] = None
 
         if channel is None:
             self._log.debug("Creating channel to %s:%s", ip, port)
@@ -750,10 +761,25 @@ class MapdlGrpc(MapdlBase):
     def _subscribe_to_channel(self):
         """Subscribe to channel status and store the value in 'mapdl._channel_state'"""
 
+        # A weak reference is used so that the gRPC ``_poll_connectivity``
+        # daemon thread, which keeps the callback alive for as long as the
+        # subscription lasts, does not keep this instance alive too.  A strong
+        # reference here creates an uncollectable cycle
+        # (thread -> state -> callback -> mapdl -> channel -> state) that
+        # prevents ``__del__`` from ever running, leaking both the instance and
+        # the polling thread.
+        self_ref = weakref.ref(self)
+
         # Callback function to monitor state changes
         def connectivity_callback(connectivity):
-            self._log.debug(f"Channel connectivity changed to: {connectivity}")
-            self._channel_state = connectivity
+            mapdl = self_ref()
+            if mapdl is None:
+                return
+            mapdl._log.debug(f"Channel connectivity changed to: {connectivity}")
+            mapdl._channel_state = connectivity
+
+        # Keep a handle so the callback can be unsubscribed on teardown
+        self._connectivity_callback = connectivity_callback
 
         # Subscribe to channel state changes
         self._channel.subscribe(connectivity_callback, try_to_connect=True)
@@ -1864,9 +1890,7 @@ class MapdlGrpc(MapdlBase):
 
         # 2. Close gRPC channel
         try:
-            if hasattr(self, "_channel") and self._channel is not None:
-                self._channel.close()
-                self._log.debug("gRPC channel closed")
+            self._close_grpc_channel()
         except Exception as e:
             self._log.debug("Error closing gRPC channel: %s", e)
 
@@ -1916,6 +1940,41 @@ class MapdlGrpc(MapdlBase):
 
         # 9. Mark exited — must be LAST so that prior steps can still log
         self._exited = True
+
+    def _close_grpc_channel(self) -> None:
+        """Unsubscribe from and close the gRPC channel.
+
+        Removes the connectivity callback registered by
+        :meth:`_subscribe_to_channel` and closes the channel, which is what
+        terminates the gRPC ``_poll_connectivity`` daemon thread.  That thread
+        only exits once the channel has no subscribers left, so failing to do
+        this leaks one daemon thread per instance.
+
+        Safe to call multiple times; subsequent calls are no-ops.  It is also
+        safe to call on an instance that is already marked as exited, which is
+        precisely the case that used to leak, because ``exit()`` returns early
+        for such instances.
+        """
+        channel = getattr(self, "_channel", None)
+        callback = getattr(self, "_connectivity_callback", None)
+
+        self._channel = None
+        self._connectivity_callback = None
+
+        if channel is None:
+            return
+
+        if callback is not None:
+            try:
+                channel.unsubscribe(callback)
+            except Exception as e:
+                self._log.debug(f"Error unsubscribing from gRPC channel: {e}")
+
+        try:
+            channel.close()
+            self._log.debug("gRPC channel closed")
+        except Exception as e:
+            self._log.debug(f"Error closing gRPC channel: {e}")
 
     def _remove_temp_dir_on_exit(self, path=None):
         """Removes the temporary directory created by the launcher.
@@ -4209,7 +4268,17 @@ class MapdlGrpc(MapdlBase):
         method runs, so every attribute access is guarded with ``hasattr`` and
         wrapped in ``try/except``.  The actual cleanup is delegated to
         :meth:`_release_resources`, which is itself idempotent.
+
+        The gRPC channel is closed unconditionally, before any of the
+        early-return checks below, because it is a purely client-side resource
+        whose ``_poll_connectivity`` daemon thread outlives this object
+        otherwise.
         """
+        try:
+            self._close_grpc_channel()
+        except Exception:  # nosec B110 - best-effort cleanup during GC
+            pass
+
         try:
             if self._exited:
                 return

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -20,12 +20,28 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from unittest.mock import patch
+import gc
+from unittest.mock import MagicMock, Mock, patch
+import weakref
 
 from ansys.api.mapdl.v0 import mapdl_pb2 as pb_types
 import pytest
 
-from ansys.mapdl.core.mapdl_grpc import MapdlRuntimeError
+from ansys.mapdl.core.mapdl_grpc import MapdlGrpc, MapdlRuntimeError
+
+
+def _make_mock_mapdl():
+    """Return a MagicMock that carries the real instance attributes needed by
+    :meth:`MapdlGrpc._close_grpc_channel`.
+
+    Calling ``MapdlGrpc.<method>(mock, ...)`` runs the real method body with
+    the mock as ``self``.
+    """
+    m = MagicMock(spec=MapdlGrpc)
+    m._log = MagicMock()
+    m._channel = None
+    m._connectivity_callback = None
+    return m
 
 
 def test_get_float(mapdl):
@@ -103,3 +119,136 @@ def test_get_non_interactive_mode(mapdl):
 
     # reset
     mapdl._store_commands = False
+
+
+class TestCloseGrpcChannel:
+    """Tests for MapdlGrpc._close_grpc_channel."""
+
+    def test_closes_channel_and_nulls_reference(self):
+        """The channel's close() is called and _channel is set to None."""
+        mock = _make_mock_mapdl()
+        channel = Mock()
+        mock._channel = channel
+
+        MapdlGrpc._close_grpc_channel(mock)
+
+        channel.close.assert_called_once()
+        assert mock._channel is None
+
+    def test_noop_when_channel_is_none(self):
+        """No error when _channel is already None."""
+        mock = _make_mock_mapdl()
+        mock._channel = None
+
+        MapdlGrpc._close_grpc_channel(mock)  # must not raise
+
+    def test_idempotent_second_call(self):
+        """Calling twice is safe — second call is a no-op."""
+        mock = _make_mock_mapdl()
+        channel = Mock()
+        mock._channel = channel
+
+        MapdlGrpc._close_grpc_channel(mock)
+        MapdlGrpc._close_grpc_channel(mock)
+
+        channel.close.assert_called_once()
+
+    def test_exception_on_close_is_logged_not_raised(self):
+        """An exception from channel.close() is logged, not re-raised."""
+        mock = _make_mock_mapdl()
+        channel = Mock()
+        channel.close.side_effect = RuntimeError("channel already gone")
+        mock._channel = channel
+
+        MapdlGrpc._close_grpc_channel(mock)  # must not raise
+
+        mock._log.debug.assert_called()
+        assert mock._channel is None
+
+    def test_unsubscribes_callback_before_closing(self):
+        """The connectivity callback is removed before the channel is closed."""
+        mock = _make_mock_mapdl()
+        channel = Mock()
+        callback = lambda connectivity: None  # noqa: E731
+        mock._channel = channel
+        mock._connectivity_callback = callback
+
+        MapdlGrpc._close_grpc_channel(mock)
+
+        channel.unsubscribe.assert_called_once_with(callback)
+        channel.close.assert_called_once()
+        assert mock._connectivity_callback is None
+
+    def test_unsubscribe_failure_does_not_prevent_close(self):
+        """A failing unsubscribe() is logged and close() still runs."""
+        mock = _make_mock_mapdl()
+        channel = Mock()
+        channel.unsubscribe.side_effect = RuntimeError("not subscribed")
+        mock._channel = channel
+        mock._connectivity_callback = lambda connectivity: None  # noqa: E731
+
+        MapdlGrpc._close_grpc_channel(mock)  # must not raise
+
+        channel.close.assert_called_once()
+
+
+class TestConnectivityCallbackDoesNotLeakInstance:
+    """The gRPC poll thread must not keep the MapdlGrpc instance alive.
+
+    The callback registered by ``_subscribe_to_channel`` is held by gRPC for as
+    long as the subscription lasts.  A strong reference to ``self`` there makes
+    the instance uncollectable, so ``__del__`` never runs and the channel is
+    never closed.
+    """
+
+    def test_callback_holds_only_a_weak_reference(self):
+        """The instance is garbage-collected even while the callback lives on."""
+
+        class _Dummy:
+            """Minimal stand-in exposing what _subscribe_to_channel touches."""
+
+            def __init__(self, channel):
+                self._log = MagicMock()
+                self._channel = channel
+                self._channel_state = None
+                self._connectivity_callback = None
+
+            _subscribe_to_channel = MapdlGrpc._subscribe_to_channel
+
+        channel = Mock()
+        dummy = _Dummy(channel)
+        dummy._subscribe_to_channel()
+
+        # gRPC keeps the callback alive; emulate that.
+        callback = channel.subscribe.call_args[0][0]
+        ref = weakref.ref(dummy)
+
+        del dummy
+        gc.collect()
+
+        assert ref() is None, "the connectivity callback leaked the instance"
+
+        # A callback firing after collection must not raise.
+        callback("READY")
+
+    def test_callback_updates_state_while_instance_is_alive(self):
+        """The weak reference still forwards updates for a live instance."""
+
+        class _Dummy:
+            def __init__(self, channel):
+                self._log = MagicMock()
+                self._channel = channel
+                self._channel_state = None
+                self._connectivity_callback = None
+
+            _subscribe_to_channel = MapdlGrpc._subscribe_to_channel
+
+        channel = Mock()
+        dummy = _Dummy(channel)
+        dummy._subscribe_to_channel()
+
+        callback = channel.subscribe.call_args[0][0]
+        callback("READY")
+
+        assert dummy._channel_state == "READY"
+        assert dummy._connectivity_callback is callback


### PR DESCRIPTION
## Summary

Split out of #4629 (see the [split plan](https://github.com/ansys/pymapdl/pull/4629) referenced there for full context). This is PR 2 of 5, and is the single most valuable change in that branch: it fixes the gRPC half of #4608.

## Root cause

`_subscribe_to_channel()` registered a callback that closed over `self`. gRPC retains that callback for the lifetime of the subscription, producing an uncollectable reference cycle rooted in a live thread:

```
poll thread (args) -> state -> callbacks_and_connectivities -> callback
                   -> MapdlGrpc -> _channel -> state
```

Because the cycle is rooted in a live daemon thread, `MapdlGrpc.__del__` could never run, so the channel was never closed and the polling thread never met its exit condition (`not state.callbacks_and_connectivities and not state.try_to_connect`, `grpc/_channel.py`). One leaked daemon thread per abandoned instance, for the lifetime of the interpreter.

## Changes

- `_subscribe_to_channel()` now captures `self_ref = weakref.ref(self)`; the callback resolves it and returns early once the instance is gone.
- New `_close_grpc_channel()`: unsubscribes the callback and closes the channel, each independently `try/except`-guarded and idempotent (safe to call more than once, and on an already-exited instance).
- `_release_resources()` calls `_close_grpc_channel()` as its channel-closing step.
- `__del__` calls `_close_grpc_channel()` unconditionally, before the `_exited`/`_cleanup`/`_start_instance`/`_launched` early returns, since the channel is a purely client-side resource that none of those flags should gate.

**Note:** gRPC's own `Channel.__del__` calls `_unsubscribe_all()`, so the weakref alone is enough to retire the thread; the explicit `close()` only makes it deterministic and releases the socket sooner.

## Testing

- New `TestCloseGrpcChannel` (6 tests): unsubscribe before close, unsubscribe failure doesn't prevent close, exception on close is logged not raised, channel reference nulled, idempotent, no-op when channel is `None`.
- New `TestConnectivityCallbackDoesNotLeakInstance` (2 tests): the instance is garbage-collected while gRPC still holds the callback, and a callback firing after collection does not raise.
- `PYMAPDL_START_INSTANCE=False pytest tests/test_mapdl_grpc.py`: 15 passed.
- `pre-commit run --files src/ansys/mapdl/core/mapdl_grpc.py tests/test_mapdl_grpc.py`: passed.

**Risk:** making `MapdlGrpc` collectable means `__del__` now actually runs during GC and calls into C extensions (`unsubscribe`/`close`). Structurally similar to the DPF crash in #4704. It is `try/except`-wrapped throughout.

Closes the gRPC half of #4608. Related: #4629 (superseded by this focused split), #4704.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>