### PR TITLE
fix: raise MapdlExitedError instead of ValueError when the gRPC channel is closed

### DIFF
--- a/doc/changelog.d/4708.fixed.md
+++ b/doc/changelog.d/4708.fixed.md
@@ -1,0 +1,1 @@
+Raise MapdlExitedError instead of ValueError when the gRPC channel is closed

--- a/src/ansys/mapdl/core/errors.py
+++ b/src/ansys/mapdl/core/errors.py
@@ -429,6 +429,17 @@ def protect_grpc(func: Callable) -> Callable:
                 # Exit while-loop if success
                 break
 
+            except ValueError as error:
+                if "Cannot invoke RPC on closed channel" not in str(error):
+                    raise
+
+                mapdl = retrieve_mapdl_from_args(args)
+                mapdl._log.debug("RPC invoked on a closed channel: MAPDL has exited.")
+                mapdl._exited = True
+                raise MapdlExitedError(
+                    "MAPDL has exited: cannot invoke RPC on a closed channel."
+                ) from error
+
             except grpc.RpcError as error:
                 mapdl = retrieve_mapdl_from_args(args)
 

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1591,7 +1591,21 @@ class MapdlGrpc(MapdlBase):
         if mute is None:
             mute = self._mute
 
-        if self._exited:
+        # Cheap, purely local liveness check: 'channel_state' reads the value
+        # cached by the connectivity callback, whereas 'is_alive' would issue a
+        # '_ctrl("VERSION")' round-trip on every single command. Only the
+        # terminal states are treated as dead; 'CONNECTING' is a normal
+        # transient and must not permanently mark the instance as exited.
+        if self._channel is not None and self.channel_state in (
+            "SHUTDOWN",
+            "TRANSIENT_FAILURE",
+        ):
+            self._exited = True
+            raise MapdlExitedError(
+                f"Mapdl exited (gRPC channel is '{self.channel_state}') before running the command: {cmd}"
+            )
+
+        if self.exited:
             raise MapdlExitedError(
                 f"The MAPDL instance has been exited before running the command: {cmd}"
             )
@@ -1604,11 +1618,16 @@ class MapdlGrpc(MapdlBase):
             raise ValueError("Maximum command length must be less than 640 characters")
 
         self._busy = True
-        if verbose:
-            response = self._send_command_stream(cmd, True)
-        else:
-            response = self._send_command(cmd, mute=mute)
-        self._busy = False
+        try:
+            if verbose:
+                response = self._send_command_stream(cmd, True)
+            else:
+                response = self._send_command(cmd, mute=mute)
+        finally:
+            # '_busy' must be cleared even when the command raises, otherwise
+            # 'is_alive' short-circuits on it forever and the liveness guard
+            # above is permanently disabled.
+            self._busy = False
 
         return response.strip()
 

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1593,8 +1593,9 @@ class MapdlGrpc(MapdlBase):
 
         # Cheap, purely local liveness check: 'channel_state' reads the value
         # cached by the connectivity callback, whereas 'is_alive' would issue a
-        # '_ctrl("VERSION")' round-trip on every single command. Only the
-        # terminal states are treated as dead; 'CONNECTING' is a normal
+        # '_ctrl("VERSION")' round-trip on every single command. Only
+        # 'SHUTDOWN' (channel closed) and 'TRANSIENT_FAILURE' (channel could
+        # not connect) are treated as dead; 'CONNECTING' is a normal
         # transient and must not permanently mark the instance as exited.
         if self._channel is not None and self.channel_state in (
             "SHUTDOWN",

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -20,15 +20,20 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from ansys.mapdl.core.errors import (
     MapdlCommandIgnoredError,
     MapdlException,
+    MapdlExitedError,
     MapdlInvalidRoutineError,
     MapdlRuntimeError,
     protect_from,
+    protect_grpc,
 )
+from ansys.mapdl.core.mapdl_grpc import MapdlGrpc
 from conftest import NullContext
 
 error_shape_error_limits = """
@@ -186,3 +191,38 @@ def test_protect_from(message, condition, context):
     with context:
         myobj = myclass()
         myobj.raising()
+
+
+def test_protect_grpc_translates_closed_channel_value_error():
+    """A 'Cannot invoke RPC on closed channel' ValueError becomes a
+    'MapdlExitedError' and marks the instance as exited."""
+    mock_mapdl = MagicMock(spec=MapdlGrpc)
+    mock_mapdl._log = MagicMock()
+    mock_mapdl._exited = False
+    mock_mapdl.exited = False
+
+    @protect_grpc
+    def raising(self):
+        raise ValueError("Cannot invoke RPC on closed channel")
+
+    with pytest.raises(MapdlExitedError, match="closed channel"):
+        raising(mock_mapdl)
+
+    assert mock_mapdl._exited is True
+
+
+def test_protect_grpc_reraises_unrelated_value_error():
+    """A 'ValueError' unrelated to a closed channel must propagate unchanged."""
+    mock_mapdl = MagicMock(spec=MapdlGrpc)
+    mock_mapdl._log = MagicMock()
+    mock_mapdl._exited = False
+    mock_mapdl.exited = False
+
+    @protect_grpc
+    def raising(self):
+        raise ValueError("some unrelated argument error")
+
+    with pytest.raises(ValueError, match="some unrelated argument error"):
+        raising(mock_mapdl)
+
+    assert mock_mapdl._exited is False

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -27,6 +27,7 @@ import weakref
 from ansys.api.mapdl.v0 import mapdl_pb2 as pb_types
 import pytest
 
+from ansys.mapdl.core.errors import MapdlExitedError
 from ansys.mapdl.core.mapdl_grpc import MapdlGrpc, MapdlRuntimeError
 
 

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -20,12 +20,25 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, Mock, patch
 
 from ansys.api.mapdl.v0 import mapdl_pb2 as pb_types
 import pytest
 
-from ansys.mapdl.core.mapdl_grpc import MapdlRuntimeError
+from ansys.mapdl.core.errors import MapdlExitedError
+from ansys.mapdl.core.mapdl_grpc import MapdlGrpc, MapdlRuntimeError
+
+
+def _make_mock_mapdl():
+    """Return a MagicMock carrying the real instance attributes needed by
+    the ``_run``/``_send_command`` family of methods.
+
+    Calling ``MapdlGrpc.<method>(mock, ...)`` runs the real method body with
+    the mock as ``self``.
+    """
+    m = MagicMock(spec=MapdlGrpc)
+    m._log = MagicMock()
+    return m
 
 
 def test_get_float(mapdl):
@@ -103,3 +116,85 @@ def test_get_non_interactive_mode(mapdl):
 
     # reset
     mapdl._store_commands = False
+
+
+class TestRunExitedGuard:
+    """The liveness guards live in ``_run``, ahead of ``self._busy = True``."""
+
+    @staticmethod
+    def _mock_for_run(channel_state="READY", exited=False):
+        mock = _make_mock_mapdl()
+        mock._mute = False
+        mock._channel = Mock()
+        mock.channel_state = channel_state
+        mock.exited = exited
+        mock._exited = exited
+        mock._busy = False
+        return mock
+
+    @pytest.mark.parametrize("state", ["SHUTDOWN", "TRANSIENT_FAILURE"])
+    def test_raises_on_terminal_channel_state(self, state):
+        """A dead channel marks the instance exited and raises."""
+        mock = self._mock_for_run(channel_state=state)
+
+        with pytest.raises(MapdlExitedError, match=state):
+            MapdlGrpc._run(mock, "/PREP7")
+
+        assert mock._exited is True
+        mock._send_command.assert_not_called()
+
+    @pytest.mark.parametrize("state", ["IDLE", "READY", "CONNECTING"])
+    def test_non_terminal_channel_state_is_not_fatal(self, state):
+        """'CONNECTING' is a normal transient and must not kill the instance."""
+        mock = self._mock_for_run(channel_state=state)
+        mock._send_command.return_value = "OK"
+
+        assert MapdlGrpc._run(mock, "/PREP7") == "OK"
+        assert mock._exited is False
+
+    def test_raises_when_already_exited(self):
+        """An exited instance refuses to run commands."""
+        mock = self._mock_for_run(exited=True)
+
+        with pytest.raises(MapdlExitedError):
+            MapdlGrpc._run(mock, "/PREP7")
+
+        mock._send_command.assert_not_called()
+
+    def test_guard_does_not_issue_an_rpc_per_command(self):
+        """The guard reads the cached channel state, it does not call '_ctrl'."""
+        mock = self._mock_for_run()
+        mock._send_command.return_value = "OK"
+
+        MapdlGrpc._run(mock, "/PREP7")
+
+        mock._ctrl.assert_not_called()
+        mock.is_alive.assert_not_called()
+
+    def test_busy_is_cleared_when_the_command_raises(self):
+        """'_busy' must not stay latched, or the guard is disabled forever."""
+        mock = self._mock_for_run()
+        mock._send_command.side_effect = MapdlRuntimeError("boom")
+
+        with pytest.raises(MapdlRuntimeError):
+            MapdlGrpc._run(mock, "/PREP7")
+
+        assert mock._busy is False
+
+
+class TestSendCommand:
+    """``_send_command`` no longer carries a guard; it just sends."""
+
+    def test_sends_the_command(self):
+        """The command reaches the stub and the response is returned."""
+        mock = _make_mock_mapdl()
+        mock._exited = False
+        mock._stub = MagicMock()
+        resp = MagicMock()
+        resp.response = "OK"
+        mock._stub.SendCommand.return_value = resp
+
+        result = MapdlGrpc._send_command(mock, "/PREP7")
+
+        assert result == "OK"
+        mock._stub.SendCommand.assert_called_once()

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -133,7 +133,7 @@ class TestRunExitedGuard:
         return mock
 
     @pytest.mark.parametrize("state", ["SHUTDOWN", "TRANSIENT_FAILURE"])
-    def test_raises_on_terminal_channel_state(self, state):
+    def test_raises_on_fatal_channel_state(self, state):
         """A dead channel marks the instance exited and raises."""
         mock = self._mock_for_run(channel_state=state)
 

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -202,6 +202,7 @@ class TestSendCommand:
         assert result == "OK"
         mock._stub.SendCommand.assert_called_once()
 
+
 class TestCloseGrpcChannel:
     """Tests for MapdlGrpc._close_grpc_channel."""
 


### PR DESCRIPTION
## Summary

Split out of #4629 (PR 5 of 5, see #4629 for full split context). Depends logically on #4707 (channels only start getting closed deterministically there), but does not textually conflict with it.

## Problem

`protect_grpc` let `ValueError: Cannot invoke RPC on closed channel` propagate unchanged, so callers had to distinguish a genuine argument error from a dead connection by parsing the message themselves.

Separately, the liveness guard that should stop commands from being sent to a dead instance lived inside `_send_command`/`_send_command_stream`, where it never actually fired: `run()` sets `_busy = True` before calling either of them, and `is_alive` short-circuits on `busy`.

## Changes

- `errors.py`, `protect_grpc`: new `except ValueError` arm. Re-raises unless the message contains `"Cannot invoke RPC on closed channel"`; otherwise retrieves the instance, logs, sets `_exited = True`, and raises `MapdlExitedError` chained from the original. Narrowed by message so genuine `ValueError`s still propagate.
- `_run()`: the liveness guard moves here, ahead of `self._busy = True`. It reads the cached `channel_state` (updated by the connectivity callback, at zero cost) instead of `is_alive`, which would add a real `_ctrl("VERSION")` round-trip to **every** command.
- Only `SHUTDOWN` and `TRANSIENT_FAILURE` are treated as fatal. Via `is_alive`, a transient `CONNECTING` would have permanently marked a healthy instance as exited.
- `_busy` is now cleared in a `try/finally`, so a raising command cannot latch it `True` and disable the guard forever.

## Testing

- New `TestRunExitedGuard` (5 tests): terminal vs. non-terminal channel states, raises when already exited, no RPC per command (`_ctrl`/`is_alive` not called), `_busy` cleared when the command raises.
- New `TestSendCommand` (1 test): happy path now that the guard has moved out.
- `PYMAPDL_START_INSTANCE=False pytest tests/test_mapdl_grpc.py`: 16 passed.
- `pre-commit run --files src/ansys/mapdl/core/errors.py src/ansys/mapdl/core/mapdl_grpc.py tests/test_mapdl_grpc.py`: passed.

**Risk:** low-medium — the `_run` guard is on the hot path for every command; the `channel_state` formulation keeps it free of extra RPCs.

Related: #4608, #4629, #4707.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>