### PR TITLE
feat: always release the gRPC channel on exit and support reconnecting

### DIFF
--- a/doc/changelog.d/4710.added.md
+++ b/doc/changelog.d/4710.added.md
@@ -1,0 +1,1 @@
+Always release the gRPC channel on exit and support reconnecting

--- a/src/ansys/mapdl/core/launcher/process.py
+++ b/src/ansys/mapdl/core/launcher/process.py
@@ -277,7 +277,8 @@ def wait_for_process_ready(
     LOG.debug("Checking MAPDL process startup")
 
     # Set up stdout monitoring
-    stdout_queue = _monitor_stdout(process.stdout)
+    stdout_queue, stdout_monitor_thread = _monitor_stdout(process.stdout)
+    process._startup_stdout_thread = stdout_monitor_thread  # type: ignore[attr-defined]
 
     # Check process alive
     check_process_is_alive(process, run_location)
@@ -431,8 +432,10 @@ def _start_subprocess(
     stdout_arg: Union[int, IO[bytes]]
     stderr_arg: int
 
+    stdout_file_handle: Optional[IO[bytes]] = None
     if output_file:
-        stdout_arg = open(output_file, "wb", 0)  # todo: handle file closing
+        stdout_file_handle = open(output_file, "wb", 0)
+        stdout_arg = stdout_file_handle
         stderr_arg = subprocess.STDOUT
     else:
         stdout_arg = subprocess.PIPE
@@ -447,15 +450,25 @@ def _start_subprocess(
     )
 
     # Launch process
-    process = subprocess.Popen(
-        cmd,
-        shell=False,  # Security: avoid shell injection  # nosec B603
-        cwd=cwd,
-        stdin=subprocess.DEVNULL,
-        stdout=stdout_arg,
-        stderr=stderr_arg,
-        env=env,
-    )
+    try:
+        process = subprocess.Popen(
+            cmd,
+            shell=False,  # Security: avoid shell injection  # nosec B603
+            cwd=cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=stdout_arg,
+            stderr=stderr_arg,
+            env=env,
+        )
+    except Exception:
+        if stdout_file_handle is not None:
+            stdout_file_handle.close()
+        raise
+
+    # Keep a reference to the output file so _kill_process can close it
+    # explicitly.  When stdout=PIPE, process.stdout is the pipe; when
+    # stdout is a file Popen does not expose it, so we store it here.
+    process._stdout_file_handle = stdout_file_handle  # type: ignore[attr-defined]
 
     LOG.debug(f"MAPDL process started with PID: {process.pid}")
     return process
@@ -501,7 +514,9 @@ def _create_temp_input_file(run_location: str) -> None:
     LOG.debug(f"Created temporary input file: {tmp_inp_path}")
 
 
-def _monitor_stdout(stdout: Optional[object]) -> Optional[Queue]:
+def _monitor_stdout(
+    stdout: Optional[object],
+) -> Tuple[Optional[Queue], Optional[threading.Thread]]:
     """Set up background thread to monitor subprocess stdout.
 
     Starts a daemon thread that reads lines from subprocess stdout and
@@ -515,8 +530,9 @@ def _monitor_stdout(stdout: Optional[object]) -> Optional[Queue]:
 
     Returns
     -------
-    Optional[Queue]
-        Queue for reading stdout lines, or None if stdout is not available
+    tuple[Optional[Queue], Optional[threading.Thread]]
+        Queue for reading stdout lines and the daemon thread doing the
+        reading, or ``(None, None)`` if stdout is not available.
 
     Raises
     ------
@@ -529,7 +545,7 @@ def _monitor_stdout(stdout: Optional[object]) -> Optional[Queue]:
     >>> from ansys.mapdl.core.launcher.process import _monitor_stdout
     >>> import subprocess
     >>> process = subprocess.Popen(..., stdout=subprocess.PIPE)
-    >>> stdout_queue = _monitor_stdout(process.stdout)
+    >>> stdout_queue, stdout_thread = _monitor_stdout(process.stdout)
     >>> if stdout_queue:
     ...     line = stdout_queue.get(timeout=1)
 
@@ -537,12 +553,12 @@ def _monitor_stdout(stdout: Optional[object]) -> Optional[Queue]:
     -----
     - Internal utility function
     - Runs in background daemon thread (won't block process exit)
-    - Returns None if stdout cannot be monitored
+    - Returns ``(None, None)`` if stdout cannot be monitored
     - Thread closes stdout when end-of-stream reached
     - Gracefully handles process termination
     """
     if not stdout:
-        return None
+        return None, None
 
     queue: Queue = Queue()
 
@@ -559,7 +575,7 @@ def _monitor_stdout(stdout: Optional[object]) -> Optional[Queue]:
     thread = threading.Thread(target=reader, daemon=True)
     thread.start()
 
-    return queue
+    return queue, thread
 
 
 def _wait_directory_ready(run_location: str, timeout: int) -> None:

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1859,26 +1859,55 @@ class MapdlGrpc(MapdlBase):
         Steps performed (in order):
 
         1. Kill the MAPDL server process and remove the lock file.
-        2. Close the gRPC channel.
-        3. Remove the UDS socket file (Unix Domain Socket transport only).
-        4. Remove the port from the global ``_LOCAL_PORTS`` registry.
-        5. Cancel the SLURM/HPC job (if applicable).
-        6. Delete the remote PyMAPDL server instance (if applicable).
-        7. Remove the temporary working directory (if ``remove_temp_dir_on_exit``).
-        8. Clean up logger handlers.
-        9. Mark the instance as exited (``_exited = True``).
+        2. Join the stdout, stderr, and startup PIPE-drainer threads.
+        3. Close the gRPC channel.
+        4. Remove the UDS socket file (Unix Domain Socket transport only).
+        5. Remove the port from the global ``_LOCAL_PORTS`` registry.
+        6. Cancel the SLURM/HPC job (if applicable).
+        7. Delete the remote PyMAPDL server instance (if applicable).
+        8. Mark the instance as exited (``_exited = True``).
+        9. Remove the temporary working directory (if ``remove_temp_dir_on_exit``).
+        10. Clean up logger handlers.
+
+        Parameters
+        ----------
+        path : str, optional
+            Working directory to remove the lock file from and to delete when
+            ``remove_temp_dir_on_exit`` is ``True``. The default is ``None``,
+            in which case ``self._path`` is used.
+
+        Returns
+        -------
+        None
 
         Notes
         -----
-        All steps are individually wrapped in ``try/except`` so that a failure
+        Steps 1 to 7 run while ``_exited`` is still ``False`` so that they can
+        reach the server and emit log records. Step 8 flips the flag *before*
+        the temporary directory is removed, because
+        :meth:`_remove_temp_dir_on_exit` falls back to the ``directory``
+        property, which would otherwise issue an ``/INQUIRE`` command against
+        an already dead server. Logger handlers are torn down last, so every
+        preceding step can still log.
+
+        Each step is individually wrapped in ``try/except`` so that a failure
         in one step does not prevent the remaining resources from being freed.
-        This also makes the method safe to call from ``__del__``, where the
-        interpreter may have already begun tearing down module globals.
+        This also makes the method safe to call during interpreter shutdown,
+        where module globals may already have been torn down.
+
+        Examples
+        --------
+        This method is called internally by :meth:`exit`, so it is rarely
+        invoked directly.
+
+        >>> from ansys.mapdl.core import launch_mapdl
+        >>> mapdl = launch_mapdl()
+        >>> mapdl._release_resources()
+        >>> mapdl.exited
+        True
         """
         if self._exited:
             return
-
-        from ansys.mapdl import core as pymapdl
 
         path = path or getattr(self, "_path", None)
 
@@ -1888,13 +1917,20 @@ class MapdlGrpc(MapdlBase):
         except Exception as e:
             self._log.debug("Error during _exit_mapdl: %s", e)
 
-        # 2. Close gRPC channel
+        # 2. Ensure PIPE-drainer threads (stdout/stderr/startup) are joined so
+        # that background reader threads do not leak after teardown.
+        try:
+            self._join_pipe_drainer_threads()
+        except Exception as e:
+            self._log.debug("Error joining pipe-drainer threads: %s", e)
+
+        # 3. Close gRPC channel
         try:
             self._close_grpc_channel()
         except Exception as e:
             self._log.debug("Error closing gRPC channel: %s", e)
 
-        # 3. Remove UDS socket file
+        # 4. Remove UDS socket file
         try:
             if getattr(self, "transport_mode", None) == "uds":
                 socket_path = os.path.join(self.uds_dir, f"mapdl-{self.port}.sock")
@@ -1904,14 +1940,16 @@ class MapdlGrpc(MapdlBase):
         except Exception as e:
             self._log.debug("Error removing UDS socket: %s", e)
 
-        # 4. Deregister port from global registry
+        # 5. Deregister port from global registry
         try:
+            from ansys.mapdl import core as pymapdl
+
             if self._local and self._port in pymapdl._LOCAL_PORTS:
                 pymapdl._LOCAL_PORTS.remove(self._port)
         except Exception as e:
             self._log.debug("Error removing port from _LOCAL_PORTS: %s", e)
 
-        # 5. Cancel HPC job
+        # 6. Cancel HPC job
         try:
             if self._mapdl_on_hpc and self.finish_job_on_exit:
                 self.kill_job(self.jobid)
@@ -1919,27 +1957,28 @@ class MapdlGrpc(MapdlBase):
         except Exception as e:
             self._log.debug("Error cancelling HPC job: %s", e)
 
-        # 6. Delete remote PyMAPDL server instance
+        # 7. Delete remote PyMAPDL server instance
         try:
             if self._remote_instance:  # pragma: no cover
                 self._remote_instance.delete()
         except Exception as e:
             self._log.debug("Error deleting remote instance: %s", e)
 
-        # 7. Remove temporary working directory
+        # 8. Mark exited — before the temp dir removal, so that the 'directory'
+        # fallback in '_remove_temp_dir_on_exit' cannot query the dead server
+        self._exited = True
+
+        # 9. Remove temporary working directory
         try:
             self._remove_temp_dir_on_exit(path)
         except Exception as e:
             self._log.debug("Error removing temp dir: %s", e)
 
-        # 8. Clean up logger handlers
+        # 10. Clean up logger handlers
         try:
             self._cleanup_loggers()
         except Exception as e:
             self._log.debug("Error during logger cleanup: %s", e)
-
-        # 9. Mark exited — must be LAST so that prior steps can still log
-        self._exited = True
 
     def _close_grpc_channel(self) -> None:
         """Unsubscribe from and close the gRPC channel.
@@ -2021,24 +2060,115 @@ class MapdlGrpc(MapdlBase):
 
         return
 
-    def _kill_process(self):
-        """Kill process stored in self._mapdl_process"""
-        if self._mapdl_process is not None:
-            self._log.debug("Killing process using subprocess.Popen.terminate")
-            process = self._mapdl_process
-            if process.poll() is None:
-                # process hasn't terminated
-                process.terminate()
+    def _close_process_pipes(self, process: subprocess.Popen) -> None:  # type: ignore[type-arg]
+        """Close all open I/O streams attached to *process*.
 
-            # Close any open file handle for stdout redirect
-            fh = getattr(process, "_stdout_file_handle", None)
-            if fh and not getattr(fh, "closed", False):
-                try:
-                    fh.close()
-                    self._log.debug("Closed stdout file handle")
-                    setattr(process, "_stdout_file_handle", None)
-                except OSError as e:
-                    self._log.debug(f"Error closing stdout file handle: {e}")
+        Closes ``process.stdout`` and ``process.stderr`` (PIPE handles) so
+        that PIPE-drainer threads blocked on ``readline`` are unblocked and
+        can exit.  Also closes the ``_stdout_file_handle`` redirect file, if
+        one was attached to the process by ``_start_subprocess``.
+
+        Parameters
+        ----------
+        process : subprocess.Popen
+            The subprocess handle whose streams should be closed.
+
+        Returns
+        -------
+        None
+        """
+        for stream in (process.stdout, process.stderr):
+            try:
+                if stream is not None and not stream.closed:
+                    stream.close()
+            except OSError as e:
+                self._log.debug(f"Error closing process stream: {e}")
+
+        fh = getattr(process, "_stdout_file_handle", None)
+        if fh and not getattr(fh, "closed", False):
+            try:
+                fh.close()
+                self._log.debug("Closed stdout file handle")
+                setattr(process, "_stdout_file_handle", None)
+            except OSError as e:
+                self._log.debug(f"Error closing stdout file handle: {e}")
+
+    def _terminate_process(self, process: subprocess.Popen) -> None:  # type: ignore[type-arg]
+        """Terminate *process*, close its pipes, and wait for it to exit.
+
+        Sends ``SIGTERM``, explicitly closes ``stdout`` and ``stderr`` so any
+        PIPE-drainer threads unblock immediately, then waits up to 2 seconds
+        for the process to exit.  If it has not exited by then, ``SIGKILL`` is
+        sent and the wait is repeated.
+
+        Parameters
+        ----------
+        process : subprocess.Popen
+            The subprocess handle to terminate.
+
+        Returns
+        -------
+        None
+        """
+        if process.poll() is None:
+            self._log.debug("Sending SIGTERM to MAPDL process")
+            process.terminate()
+
+        self._close_process_pipes(process)
+
+        try:
+            process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            self._log.debug("Process did not exit after SIGTERM; sending SIGKILL")
+            process.kill()
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self._log.debug("Process did not exit after SIGKILL")
+
+    def _join_pipe_drainer_threads(self) -> None:
+        """Join all PIPE-drainer threads, giving each up to 2 seconds.
+
+        Waits for ``_stdout_thread``, ``_stderr_thread``, and
+        ``_startup_stdout_thread`` to finish.  A debug message is logged for
+        any thread that does not exit within the timeout.  Every attribute
+        access is ``getattr``-guarded so this is safe to call on a partially
+        constructed instance.
+
+        Returns
+        -------
+        None
+        """
+        for attr in ("_stdout_thread", "_stderr_thread", "_startup_stdout_thread"):
+            t = getattr(self, attr, None)
+            if t is not None and t.is_alive():
+                t.join(timeout=2)
+                if t.is_alive():
+                    self._log.debug(f"Thread {attr} did not exit in time")
+
+    def _kill_process(self) -> None:
+        """Kill the process stored in ``self._mapdl_process``.
+
+        Acquires ``_process_close_lock`` to prevent concurrent teardowns,
+        then delegates to :meth:`_terminate_process` (SIGTERM → pipe-close →
+        wait → SIGKILL).
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+        Does **not** join the pipe-drainer threads here because MAPDL may have
+        spawned child processes that also hold the write ends of stdout/stderr
+        open.  Those children are killed by :meth:`_kill_child_processes`,
+        which must run first.  Call :meth:`_join_pipe_drainer_threads` only
+        after all child processes are gone (see :meth:`_close_process`).
+        """
+        with self._process_close_lock:
+            if self._mapdl_process is not None:
+                self._log.debug("Killing process using subprocess.Popen.terminate")
+                self._terminate_process(self._mapdl_process)
 
     def _kill_child_processes(self, timeout=2):
         pids = self._pids.copy()

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -38,7 +38,17 @@ import subprocess  # nosec B404
 import tempfile
 import threading
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    Tuple,
+    Union,
+)
 from warnings import warn
 import weakref
 
@@ -487,6 +497,7 @@ class MapdlGrpc(MapdlBase):
             grpc.ChannelConnectivity.CONNECTING
         )
         self._time_step_stream: Optional[int] = None
+        self._connectivity_callback: Optional[Callable[[Any], None]] = None
 
         if channel is None:
             self._log.debug("Creating channel to %s:%s", ip, port)
@@ -750,10 +761,25 @@ class MapdlGrpc(MapdlBase):
     def _subscribe_to_channel(self):
         """Subscribe to channel status and store the value in 'mapdl._channel_state'"""
 
+        # A weak reference is used so that the gRPC ``_poll_connectivity``
+        # daemon thread, which keeps the callback alive for as long as the
+        # subscription lasts, does not keep this instance alive too.  A strong
+        # reference here creates an uncollectable cycle
+        # (thread -> state -> callback -> mapdl -> channel -> state) that
+        # prevents ``__del__`` from ever running, leaking both the instance and
+        # the polling thread.
+        self_ref = weakref.ref(self)
+
         # Callback function to monitor state changes
         def connectivity_callback(connectivity):
-            self._log.debug(f"Channel connectivity changed to: {connectivity}")
-            self._channel_state = connectivity
+            mapdl = self_ref()
+            if mapdl is None:
+                return
+            mapdl._log.debug(f"Channel connectivity changed to: {connectivity}")
+            mapdl._channel_state = connectivity
+
+        # Keep a handle so the callback can be unsubscribed on teardown
+        self._connectivity_callback = connectivity_callback
 
         # Subscribe to channel state changes
         self._channel.subscribe(connectivity_callback, try_to_connect=True)
@@ -1864,9 +1890,7 @@ class MapdlGrpc(MapdlBase):
 
         # 2. Close gRPC channel
         try:
-            if hasattr(self, "_channel") and self._channel is not None:
-                self._channel.close()
-                self._log.debug("gRPC channel closed")
+            self._close_grpc_channel()
         except Exception as e:
             self._log.debug("Error closing gRPC channel: %s", e)
 
@@ -1916,6 +1940,41 @@ class MapdlGrpc(MapdlBase):
 
         # 9. Mark exited — must be LAST so that prior steps can still log
         self._exited = True
+
+    def _close_grpc_channel(self) -> None:
+        """Unsubscribe from and close the gRPC channel.
+
+        Removes the connectivity callback registered by
+        :meth:`_subscribe_to_channel` and closes the channel, which is what
+        terminates the gRPC ``_poll_connectivity`` daemon thread.  That thread
+        only exits once the channel has no subscribers left, so failing to do
+        this leaks one daemon thread per instance.
+
+        Safe to call multiple times; subsequent calls are no-ops.  It is also
+        safe to call on an instance that is already marked as exited, which is
+        precisely the case that used to leak, because ``exit()`` returns early
+        for such instances.
+        """
+        channel = getattr(self, "_channel", None)
+        callback = getattr(self, "_connectivity_callback", None)
+
+        self._channel = None
+        self._connectivity_callback = None
+
+        if channel is None:
+            return
+
+        if callback is not None:
+            try:
+                channel.unsubscribe(callback)
+            except Exception as e:
+                self._log.debug(f"Error unsubscribing from gRPC channel: {e}")
+
+        try:
+            channel.close()
+            self._log.debug("gRPC channel closed")
+        except Exception as e:
+            self._log.debug(f"Error closing gRPC channel: {e}")
 
     def _remove_temp_dir_on_exit(self, path=None):
         """Removes the temporary directory created by the launcher.
@@ -4209,7 +4268,17 @@ class MapdlGrpc(MapdlBase):
         method runs, so every attribute access is guarded with ``hasattr`` and
         wrapped in ``try/except``.  The actual cleanup is delegated to
         :meth:`_release_resources`, which is itself idempotent.
+
+        The gRPC channel is closed unconditionally, before any of the
+        early-return checks below, because it is a purely client-side resource
+        whose ``_poll_connectivity`` daemon thread outlives this object
+        otherwise.
         """
+        try:
+            self._close_grpc_channel()
+        except Exception:  # nosec B110 - best-effort cleanup during GC
+            pass
+
         try:
             if self._exited:
                 return

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -2112,41 +2112,6 @@ class MapdlGrpc(MapdlBase):
         except Exception as e:
             self._log.debug(f"Error closing gRPC channel: {e}")
 
-    def _close_grpc_channel(self) -> None:
-        """Unsubscribe from and close the gRPC channel.
-
-        Removes the connectivity callback registered by
-        :meth:`_subscribe_to_channel` and closes the channel, which is what
-        terminates the gRPC ``_poll_connectivity`` daemon thread.  That thread
-        only exits once the channel has no subscribers left, so failing to do
-        this leaks one daemon thread per instance.
-
-        Safe to call multiple times; subsequent calls are no-ops.  It is also
-        safe to call on an instance that is already marked as exited, which is
-        precisely the case that used to leak, because ``exit()`` returns early
-        for such instances.
-        """
-        channel = getattr(self, "_channel", None)
-        callback = getattr(self, "_connectivity_callback", None)
-
-        self._channel = None
-        self._connectivity_callback = None
-
-        if channel is None:
-            return
-
-        if callback is not None:
-            try:
-                channel.unsubscribe(callback)
-            except Exception as e:
-                self._log.debug(f"Error unsubscribing from gRPC channel: {e}")
-
-        try:
-            channel.close()
-            self._log.debug("gRPC channel closed")
-        except Exception as e:
-            self._log.debug(f"Error closing gRPC channel: {e}")
-
     def _remove_temp_dir_on_exit(self, path=None):
         """Removes the temporary directory created by the launcher.
 

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -683,8 +683,43 @@ class MapdlGrpc(MapdlBase):
             # For some reason the session hasn't been created
             self._create_session()
 
+    def _ensure_channel(self) -> None:
+        """Rebuild the gRPC channel if it has been closed.
+
+        A closed gRPC channel cannot be reopened, so after
+        :meth:`_close_grpc_channel` (or :meth:`_disconnect_but_leave_mapdl_running`)
+        has run, ``self._channel`` is ``None``. This rebuilds it via
+        :meth:`_create_channel` and re-subscribes with
+        :meth:`_subscribe_to_channel`, so that :meth:`reconnect_to_mapdl` can
+        resume driving the same MAPDL session.
+
+        Raises
+        ------
+        MapdlRuntimeError
+            If the IP address or port of the instance is unknown, since both
+            are required to rebuild the channel.
+
+        Returns
+        -------
+        None
+        """
+        if self._channel is not None:
+            return
+
+        if self._ip is None or self._port is None:
+            raise MapdlRuntimeError(
+                "Cannot rebuild the gRPC channel: the IP address or port of "
+                "this MAPDL instance is unknown."
+            )
+
+        self._log.debug("Rebuilding gRPC channel to %s:%s", self._ip, self._port)
+        self._channel = self._create_channel(self._ip, self._port)
+        self._subscribe_to_channel()
+
     def _connect_to_mapdl(self, timeout: int):
         """(Re)connect to an existing MAPDL instance"""
+        self._ensure_channel()
+
         try:
             self._multi_connect(timeout=timeout)
         except MapdlConnectionError as err:  # pragma: no cover
@@ -702,6 +737,12 @@ class MapdlGrpc(MapdlBase):
 
         Re-establish an stopped or crashed gRPC connection with an already alive
         MAPDL instance. This function does not relaunch the MAPDL instance.
+
+        Notes
+        -----
+        If the gRPC channel was previously closed (for example after
+        :meth:`exit` released the client side while leaving MAPDL running),
+        the channel is rebuilt and re-subscribed automatically.
 
         Parameters
         ----------
@@ -1787,13 +1828,22 @@ class MapdlGrpc(MapdlBase):
 
         Notes
         -----
-        If Mapdl didn't start the instance, then this will be ignored unless
+        If Mapdl didn't start the instance, then MAPDL is kept alive unless
         ``force=True``.
 
         If ``PYMAPDL_START_INSTANCE`` is set to ``False`` (generally set in
-        remote testing or documentation build), then this will be
-        ignored. Override this behavior with ``force=True`` to always force
+        remote testing or documentation build), then MAPDL is kept alive.
+        Override this behavior with ``force=True`` to always force
         exiting MAPDL regardless of your local environment.
+
+        On every path where MAPDL itself is left running (the ones above,
+        an instance that has already exited, or an instance built while
+        ``pymapdl.BUILDING_GALLERY`` is set), the client side of the
+        connection — the gRPC channel and the PIPE-drainer threads — is
+        still released, because closing a gRPC channel is a purely
+        client-side operation that does not stop the MAPDL server. Call
+        :meth:`reconnect_to_mapdl` to build a fresh channel and resume
+        driving the same MAPDL session.
 
         If ``Mapdl.finish_job_on_exit`` is set to ``True`` and there is a valid
         JobID in ``Mapdl.jobid``, then the SLURM job will be canceled.
@@ -1808,32 +1858,79 @@ class MapdlGrpc(MapdlBase):
             f"Exiting MAPDL gRPC instance {self.ip}:{self.port} on '{self._path}'."
         )
 
-        if self._exited:
-            self._log.debug("Already exited")
-            return
-
-        if save:
-            self._log.debug("Saving MAPDL database")
-            self.save()
-
-        if not force:
-            # Ignore this method if PYMAPDL_START_INSTANCE=False
-            if not self._start_instance or not self._launched:
-                self._log.info(
-                    "Ignoring exit due to PYMAPDL_START_INSTANCE=False or because PyMAPDL didn't launch the instance."
-                )
-                return
-
-            # or building the gallery
-            if pymapdl.BUILDING_GALLERY:
-                self._log.info("Ignoring exit due as BUILDING_GALLERY=True")
-                return
-
         try:
             self._exiting = True
+
+            if self.exited:
+                self._log.debug("Already exited")
+                # '_exited' is also set by the gRPC error handlers when MAPDL
+                # crashes, with no cleanup performed. The helper is
+                # idempotent, so calling it again on a regular repeated exit
+                # costs nothing.
+                self._disconnect_but_leave_mapdl_running()
+                return
+
+            if save:
+                self._log.debug("Saving MAPDL database")
+                self.save()
+
+            if not force:
+                # Ignore this method if PYMAPDL_START_INSTANCE=False
+                if not self._start_instance or not self._launched:
+                    self._log.info(
+                        "Ignoring exit due to PYMAPDL_START_INSTANCE=False or because PyMAPDL didn't launch the instance."
+                    )
+                    self._disconnect_but_leave_mapdl_running()
+                    return
+
+                # or building the gallery
+                if pymapdl.BUILDING_GALLERY:
+                    self._log.info("Ignoring exit due as BUILDING_GALLERY=True")
+                    self._disconnect_but_leave_mapdl_running()
+                    return
+
+            # Step 3 of '_release_resources' closes the gRPC channel.
             self._release_resources(path=self._path)
         finally:
             self._exiting = False
+
+    def _disconnect_but_leave_mapdl_running(self) -> None:
+        """Close the client side of the connection, leaving MAPDL running.
+
+        Closing a gRPC channel is a purely client-side operation: it cancels
+        pending RPCs and releases the socket, but it does not stop the MAPDL
+        server. This is what :meth:`exit` performs on the paths where MAPDL
+        itself must survive, so that the ``_poll_connectivity`` daemon thread
+        and the PIPE-drainer threads do not outlive this object.
+
+        The instance is marked as exited because the channel is gone. Use
+        :meth:`reconnect_to_mapdl` to build a fresh channel and resume driving
+        the same MAPDL session.
+
+        Returns
+        -------
+        None
+
+        Examples
+        --------
+        >>> mapdl.exit()          # PYMAPDL_START_INSTANCE=False
+        >>> mapdl.exited
+        True
+        >>> mapdl.reconnect_to_mapdl()
+        >>> mapdl.exited
+        False
+        """
+        try:
+            self._close_grpc_channel()
+        except Exception as e:
+            self._log.debug("Error closing gRPC channel: %s", e)
+
+        try:
+            self._join_pipe_drainer_threads()
+        except Exception as e:
+            self._log.debug("Error joining pipe-drainer threads: %s", e)
+
+        self._exited = True
 
     def _exit_mapdl(self, path: Optional[str] = None) -> None:
         """Exit MAPDL and remove the lock file in `path`"""

--- a/src/ansys/mapdl/core/pool.py
+++ b/src/ansys/mapdl/core/pool.py
@@ -816,7 +816,8 @@ class MapdlPool:
         Parameters
         ----------
         block : bool, optional
-            When ``True``, wait until all processes are closed.
+            When ``True``, wait until all processes are closed before
+            returning.  Default is ``False``.
 
         Examples
         --------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -541,6 +541,24 @@ class NullContext:
         pass
 
 
+def restore_connection(mapdl) -> None:
+    """Rebuild the gRPC channel if the test just released it.
+
+    ``exit()`` always closes the client side of the connection, even on the
+    paths where MAPDL itself is left running (``PYMAPDL_START_INSTANCE=False``
+    or a gallery build), because closing a gRPC channel does not stop the
+    server. The ``mapdl`` fixture is session-scoped and shared by the whole
+    suite, so a test that calls ``exit()`` must hand the instance back in a
+    usable state. This runs at teardown, so no exited or disconnected state
+    ever crosses a test boundary.
+    """
+    if not hasattr(mapdl, "reconnect_to_mapdl"):
+        return  # the console interface has no gRPC channel
+
+    if mapdl.exited or getattr(mapdl, "_channel", None) is None:
+        mapdl.reconnect_to_mapdl()
+
+
 @pytest.fixture(autouse=True, scope="function")
 def run_before_and_after_tests(
     request: pytest.FixtureRequest,
@@ -554,8 +572,11 @@ def run_before_and_after_tests(
     mapdl = request.getfixturevalue("mapdl")  # get the mapdl fixture
 
     # Always verify clean state before any test that uses mapdl, regardless of
-    # DEBUG_TESTING — prevents silent state leaks (mute, non-interactive) from
-    # a previously failed test propagating to the next test.
+    # DEBUG_TESTING — prevents silent state leaks (mute, non-interactive,
+    # exited) from a previously failed test propagating to the next test.
+    assert (
+        not mapdl.exited
+    ), "mapdl is exited before the test. A previous test likely left it dirty."
     assert (
         not mapdl.mute
     ), "mapdl.mute is True before the test. A previous test likely left it dirty."
@@ -580,6 +601,11 @@ def run_before_and_after_tests(
         assert not mapdl.exited, "MAPDL is exited before the test. It should not!"
 
     yield  # this is where the testing happens
+
+    # Hand the shared instance back usable: a test that called 'exit()' released
+    # the channel, which does not stop MAPDL. Repair it here rather than at the
+    # start of the next test, so that nothing leaks across the boundary.
+    restore_connection(mapdl)
 
     if DEBUG_TESTING:
         log_end_test(mapdl, test_name)

--- a/tests/test_launcher/test_process.py
+++ b/tests/test_launcher/test_process.py
@@ -25,6 +25,7 @@
 import os
 from queue import Queue
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -248,10 +249,10 @@ class TestStartSubprocess:
     """Tests for subprocess start function."""
 
     def test_start_subprocess_with_output_file(self):
-        """Test starting subprocess with output file."""
+        """Test starting subprocess with output file stores _stdout_file_handle."""
         with tempfile.TemporaryDirectory() as tmpdir:
             output_file = os.path.join(tmpdir, "output.txt")
-            cmd = ["python", "-c", "print('test')"]
+            cmd = [sys.executable, "-c", "print('test')"]
 
             proc = process._start_subprocess(
                 cmd=cmd,
@@ -262,13 +263,17 @@ class TestStartSubprocess:
 
             assert proc is not None
             assert isinstance(proc, subprocess.Popen)
+            # The file handle must be stored so _kill_process can close it
+            assert proc._stdout_file_handle is not None
+            assert not proc._stdout_file_handle.closed
             proc.wait(timeout=10)
+            proc._stdout_file_handle.close()
             assert proc.poll() is not None
 
     def test_start_subprocess_without_output_file(self):
-        """Test starting subprocess without output file."""
+        """Test starting subprocess without output file has no file handle."""
         with tempfile.TemporaryDirectory() as tmpdir:
-            cmd = ["python", "-c", "print('test')"]
+            cmd = [sys.executable, "-c", "print('test')"]
 
             proc = process._start_subprocess(
                 cmd=cmd,
@@ -279,6 +284,10 @@ class TestStartSubprocess:
 
             assert proc is not None
             assert isinstance(proc, subprocess.Popen)
+            # No file redirect — handle should be None, pipes should be open
+            assert proc._stdout_file_handle is None
+            assert proc.stdout is not None
+            assert proc.stderr is not None
             proc.wait(timeout=10)
 
 
@@ -291,34 +300,47 @@ class TestMonitorStdout:
     """Tests for stdout monitoring."""
 
     def test_monitor_stdout_with_pipe(self):
-        """Test monitoring stdout with pipe."""
+        """Test monitoring stdout with pipe returns (queue, thread)."""
         mock_pipe = Mock()
         mock_pipe.readline.side_effect = [b"line1\n", b"line2\n", b""]
 
-        queue = process._monitor_stdout(mock_pipe)
+        queue, thread = process._monitor_stdout(mock_pipe)
 
         assert queue is not None
         assert isinstance(queue, Queue)
+        assert thread is not None
+        assert isinstance(thread, threading.Thread)
 
         time.sleep(0.3)
 
         assert not queue.empty()
 
     def test_monitor_stdout_without_pipe(self):
-        """Test monitoring stdout returns None without pipe."""
+        """Test monitoring stdout returns (None, None) without pipe."""
         result = process._monitor_stdout(None)
-        assert result is None
+        assert result == (None, None)
 
     def test_monitor_stdout_with_error(self):
-        """Test monitoring stdout handles errors."""
+        """Test monitoring stdout handles errors gracefully."""
         mock_pipe = Mock()
         mock_pipe.readline.side_effect = ValueError("Pipe closed")
 
-        queue = process._monitor_stdout(mock_pipe)
+        queue, thread = process._monitor_stdout(mock_pipe)
 
         time.sleep(0.3)
 
         assert queue is not None
+        assert thread is not None
+
+    def test_monitor_stdout_thread_is_daemon(self):
+        """Test that the reader thread is a daemon thread."""
+        mock_pipe = Mock()
+        mock_pipe.readline.side_effect = [b""]
+
+        _, thread = process._monitor_stdout(mock_pipe)
+
+        assert thread is not None
+        assert thread.daemon is True
 
 
 # ============================================================================
@@ -484,7 +506,7 @@ class TestWaitForProcessReady:
         mock_process.poll.return_value = None
         mock_process.stdout = None
 
-        mock_monitor.return_value = None
+        mock_monitor.return_value = (None, None)
 
         process.wait_for_process_ready(
             process=mock_process,
@@ -517,7 +539,7 @@ class TestWaitForProcessReady:
         mock_process.stdout = mock_stdout
 
         mock_queue = Mock(spec=Queue)
-        mock_monitor.return_value = mock_queue
+        mock_monitor.return_value = (mock_queue, Mock())
 
         process.wait_for_process_ready(
             process=mock_process,
@@ -703,21 +725,22 @@ class TestPhase4QueueMonitoringEdgeCases:
     """
 
     def test_monitor_stdout_creates_queue(self):
-        """Test that _monitor_stdout creates queue when stdout available."""
+        """Test that _monitor_stdout creates (queue, thread) when stdout available."""
         mock_stdout = Mock()
         mock_stdout.readline = Mock(side_effect=[b"line1\n", b"line2\n", b""])
 
-        queue = process._monitor_stdout(mock_stdout)
+        queue, thread = process._monitor_stdout(mock_stdout)
 
         assert queue is not None
-
         assert isinstance(queue, process.Queue)
+        assert thread is not None
+        assert isinstance(thread, threading.Thread)
 
     def test_monitor_stdout_returns_none_when_no_stdout(self):
-        """Test that _monitor_stdout returns None when stdout is None."""
-        queue = process._monitor_stdout(None)
+        """Test that _monitor_stdout returns (None, None) when stdout is None."""
+        result = process._monitor_stdout(None)
 
-        assert queue is None
+        assert result == (None, None)
 
     def test_check_grpc_server_ready_success(self):
         """Test gRPC server ready detection with both patterns."""

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -21,6 +21,8 @@
 # SOFTWARE.
 
 import gc
+import subprocess
+import threading
 from unittest.mock import MagicMock, Mock, patch
 import weakref
 
@@ -32,16 +34,33 @@ from ansys.mapdl.core.mapdl_grpc import MapdlGrpc, MapdlRuntimeError
 
 def _make_mock_mapdl():
     """Return a MagicMock that carries the real instance attributes needed by
-    :meth:`MapdlGrpc._close_grpc_channel`.
+    the process-teardown family of methods.
 
     Calling ``MapdlGrpc.<method>(mock, ...)`` runs the real method body with
     the mock as ``self``.
     """
     m = MagicMock(spec=MapdlGrpc)
+    m._process_close_lock = threading.Lock()
     m._log = MagicMock()
+    m._stdout_thread = None
+    m._stderr_thread = None
+    m._startup_stdout_thread = None
+    m._mapdl_process = None
     m._channel = None
     m._connectivity_callback = None
     return m
+
+
+def _make_mock_process(poll_return=None):
+    """Return a mock subprocess.Popen with open, closable stdout/stderr."""
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.poll.return_value = poll_return
+    proc.stdout = Mock()
+    proc.stdout.closed = False
+    proc.stderr = Mock()
+    proc.stderr.closed = False
+    proc._stdout_file_handle = None
+    return proc
 
 
 def test_get_float(mapdl):
@@ -119,6 +138,230 @@ def test_get_non_interactive_mode(mapdl):
 
     # reset
     mapdl._store_commands = False
+
+
+class TestCloseProcessPipes:
+    """Tests for MapdlGrpc._close_process_pipes."""
+
+    def test_closes_open_stdout_and_stderr(self):
+        """Open stdout and stderr PIPE handles are both closed."""
+        mock = _make_mock_mapdl()
+        proc = _make_mock_process()
+
+        MapdlGrpc._close_process_pipes(mock, proc)
+
+        proc.stdout.close.assert_called_once()
+        proc.stderr.close.assert_called_once()
+
+    def test_skips_already_closed_streams(self):
+        """Already-closed streams are not closed again."""
+        mock = _make_mock_mapdl()
+        proc = _make_mock_process()
+        proc.stdout.closed = True
+        proc.stderr.closed = True
+
+        MapdlGrpc._close_process_pipes(mock, proc)
+
+        proc.stdout.close.assert_not_called()
+        proc.stderr.close.assert_not_called()
+
+    def test_skips_none_streams(self):
+        """None stdout/stderr (e.g. file redirect) do not raise."""
+        mock = _make_mock_mapdl()
+        proc = _make_mock_process()
+        proc.stdout = None
+        proc.stderr = None
+
+        MapdlGrpc._close_process_pipes(mock, proc)  # must not raise
+
+    def test_oserror_is_logged_not_raised(self):
+        """An OSError on close is logged at debug level and not re-raised."""
+        mock = _make_mock_mapdl()
+        proc = _make_mock_process()
+        proc.stdout.close.side_effect = OSError("broken pipe")
+
+        MapdlGrpc._close_process_pipes(mock, proc)  # must not raise
+
+        mock._log.debug.assert_called()
+
+    def test_closes_stdout_file_handle(self):
+        """The _stdout_file_handle redirect is closed and nulled out."""
+        mock = _make_mock_mapdl()
+        proc = _make_mock_process()
+        fh = Mock()
+        fh.closed = False
+        proc._stdout_file_handle = fh
+
+        MapdlGrpc._close_process_pipes(mock, proc)
+
+        fh.close.assert_called_once()
+        assert proc._stdout_file_handle is None
+
+    def test_skips_already_closed_file_handle(self):
+        """An already-closed _stdout_file_handle is not closed again."""
+        mock = _make_mock_mapdl()
+        proc = _make_mock_process()
+        fh = Mock()
+        fh.closed = True
+        proc._stdout_file_handle = fh
+
+        MapdlGrpc._close_process_pipes(mock, proc)
+
+        fh.close.assert_not_called()
+
+
+class TestTerminateProcess:
+    """Tests for MapdlGrpc._terminate_process."""
+
+    def test_terminate_called_when_process_running(self):
+        """SIGTERM is sent when the process is still alive (poll() is None)."""
+        mock = _make_mock_mapdl()
+        proc = _make_mock_process(poll_return=None)
+
+        MapdlGrpc._terminate_process(mock, proc)
+
+        proc.terminate.assert_called_once()
+
+    def test_terminate_skipped_when_process_already_exited(self):
+        """SIGTERM is not sent when the process has already exited."""
+        mock = _make_mock_mapdl()
+        proc = _make_mock_process(poll_return=0)
+
+        MapdlGrpc._terminate_process(mock, proc)
+
+        proc.terminate.assert_not_called()
+
+    def test_pipes_are_closed(self):
+        """_close_process_pipes is called to close the pipes."""
+        mock = _make_mock_mapdl()
+        proc = _make_mock_process(poll_return=None)
+        mock._close_process_pipes = Mock()
+
+        MapdlGrpc._terminate_process(mock, proc)
+
+        mock._close_process_pipes.assert_called_once_with(proc)
+
+    def test_sigkill_sent_on_timeout(self):
+        """SIGKILL is sent when the process does not exit within 2 s."""
+        mock = _make_mock_mapdl()
+        proc = _make_mock_process(poll_return=None)
+        proc.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="mapdl", timeout=2),
+            None,
+        ]
+
+        MapdlGrpc._terminate_process(mock, proc)
+
+        proc.kill.assert_called_once()
+
+    def test_logs_debug_when_sigkill_also_times_out(self):
+        """A debug message is logged when SIGKILL wait also times out."""
+        mock = _make_mock_mapdl()
+        proc = _make_mock_process(poll_return=None)
+        proc.wait.side_effect = [
+            subprocess.TimeoutExpired(cmd="mapdl", timeout=2),
+            subprocess.TimeoutExpired(cmd="mapdl", timeout=2),
+        ]
+
+        MapdlGrpc._terminate_process(mock, proc)
+
+        mock._log.debug.assert_called()
+
+
+class TestJoinPipeDrainerThreads:
+    """Tests for MapdlGrpc._join_pipe_drainer_threads."""
+
+    def test_joins_all_alive_threads(self):
+        """All three drainer threads are joined when alive."""
+        mock = _make_mock_mapdl()
+        for attr in ("_stdout_thread", "_stderr_thread", "_startup_stdout_thread"):
+            t = MagicMock(spec=threading.Thread)
+            t.is_alive.return_value = True
+            setattr(mock, attr, t)
+
+        MapdlGrpc._join_pipe_drainer_threads(mock)
+
+        for attr in ("_stdout_thread", "_stderr_thread", "_startup_stdout_thread"):
+            getattr(mock, attr).join.assert_called_once_with(timeout=2)
+
+    def test_skips_none_threads(self):
+        """None thread references are silently skipped."""
+        mock = _make_mock_mapdl()
+        # All three remain None
+
+        MapdlGrpc._join_pipe_drainer_threads(mock)  # must not raise
+
+    def test_skips_dead_threads(self):
+        """Threads that are not alive are not joined."""
+        mock = _make_mock_mapdl()
+        t = MagicMock(spec=threading.Thread)
+        t.is_alive.return_value = False
+        mock._stdout_thread = t
+
+        MapdlGrpc._join_pipe_drainer_threads(mock)
+
+        t.join.assert_not_called()
+
+    def test_logs_debug_when_thread_does_not_exit(self):
+        """A debug message is logged when a thread is still alive after join."""
+        mock = _make_mock_mapdl()
+        t = MagicMock(spec=threading.Thread)
+        t.is_alive.side_effect = [True, True]  # alive before AND after join
+        t.name = "_stdout_thread"
+        mock._stdout_thread = t
+
+        MapdlGrpc._join_pipe_drainer_threads(mock)
+
+        mock._log.debug.assert_called()
+
+
+class TestKillProcess:
+    """Tests for MapdlGrpc._kill_process (orchestrator)."""
+
+    def test_no_op_when_no_process(self):
+        """_kill_process is a no-op when _mapdl_process is None."""
+        mock = _make_mock_mapdl()
+        mock._terminate_process = Mock()
+
+        MapdlGrpc._kill_process(mock)
+
+        mock._terminate_process.assert_not_called()
+
+    def test_terminates_when_process_set(self):
+        """_terminate_process is called; joining is deferred to _close_process."""
+        mock = _make_mock_mapdl()
+        mock._mapdl_process = _make_mock_process()
+        mock._terminate_process = Mock()
+
+        MapdlGrpc._kill_process(mock)
+
+        mock._terminate_process.assert_called_once_with(mock._mapdl_process)
+
+    def test_lock_prevents_concurrent_double_teardown(self):
+        """Concurrent calls serialize: the second waits for the first."""
+        import time as _time
+
+        mock = _make_mock_mapdl()
+        call_log = []
+
+        def slow_terminate(proc):
+            call_log.append("start")
+            _time.sleep(0.05)
+            call_log.append("end")
+
+        mock._terminate_process = slow_terminate
+        mock._mapdl_process = _make_mock_process()
+
+        t1 = threading.Thread(target=MapdlGrpc._kill_process, args=(mock,))
+        t2 = threading.Thread(target=MapdlGrpc._kill_process, args=(mock,))
+        t1.start()
+        _time.sleep(0.01)
+        t2.start()
+        t1.join(timeout=2)
+        t2.join(timeout=2)
+
+        # The two "start"/"end" pairs must not interleave
+        assert call_log == ["start", "end", "start", "end"]
 
 
 class TestCloseGrpcChannel:

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -495,3 +495,140 @@ class TestConnectivityCallbackDoesNotLeakInstance:
 
         assert dummy._channel_state == "READY"
         assert dummy._connectivity_callback is callback
+
+
+class TestDisconnectButLeaveMapdlRunning:
+    """``exit()`` always releases the client side, even when MAPDL survives.
+
+    Closing a gRPC channel does not stop the MAPDL server, so the paths that
+    deliberately leave MAPDL running must still release the channel and the
+    PIPE-drainer threads, otherwise their daemon threads leak.
+    """
+
+    @staticmethod
+    def _mock_for_exit(start_instance=True, launched=True):
+        mock = _make_mock_mapdl()
+        mock.exited = False
+        mock._exited = False
+        mock._exiting = False
+        mock._path = ""
+        mock._start_instance = start_instance
+        mock._launched = launched
+        return mock
+
+    @pytest.mark.parametrize(
+        "start_instance,launched", [(False, True), (True, False), (False, False)]
+    )
+    def test_disconnects_when_pymapdl_did_not_launch_mapdl(
+        self, start_instance, launched
+    ):
+        """MAPDL is left running, but the channel is released."""
+        mock = self._mock_for_exit(start_instance, launched)
+
+        MapdlGrpc.exit(mock)
+
+        mock._disconnect_but_leave_mapdl_running.assert_called_once()
+        mock._release_resources.assert_not_called()
+
+    def test_disconnects_when_building_the_gallery(self):
+        """Each gallery example owns its instance, so the channel must close."""
+        mock = self._mock_for_exit()
+
+        with patch("ansys.mapdl.core.BUILDING_GALLERY", True):
+            MapdlGrpc.exit(mock)
+
+        mock._disconnect_but_leave_mapdl_running.assert_called_once()
+        mock._release_resources.assert_not_called()
+
+    def test_force_still_releases_everything(self):
+        """force=True performs the full teardown instead."""
+        mock = self._mock_for_exit(start_instance=False, launched=False)
+
+        MapdlGrpc.exit(mock, force=True)
+
+        mock._release_resources.assert_called_once()
+        mock._disconnect_but_leave_mapdl_running.assert_not_called()
+
+    def test_closes_channel_joins_threads_and_marks_exited(self):
+        """The helper releases both resources and reports the instance dead."""
+        mock = _make_mock_mapdl()
+        mock._exited = False
+
+        MapdlGrpc._disconnect_but_leave_mapdl_running(mock)
+
+        mock._close_grpc_channel.assert_called_once()
+        mock._join_pipe_drainer_threads.assert_called_once()
+        assert mock._exited is True
+
+    def test_a_failing_close_does_not_prevent_the_join(self):
+        """Each step is independent so one failure cannot leak the other."""
+        mock = _make_mock_mapdl()
+        mock._exited = False
+        mock._close_grpc_channel.side_effect = RuntimeError("boom")
+
+        MapdlGrpc._disconnect_but_leave_mapdl_running(mock)
+
+        mock._join_pipe_drainer_threads.assert_called_once()
+        assert mock._exited is True
+
+    def test_already_exited_still_releases_the_client_side(self):
+        """A crashed instance flagged by an error handler must still be freed."""
+        mock = self._mock_for_exit()
+        mock.exited = True
+        mock._exited = True
+
+        MapdlGrpc.exit(mock)
+
+        mock._disconnect_but_leave_mapdl_running.assert_called_once()
+        mock._release_resources.assert_not_called()
+
+
+class TestEnsureChannel:
+    """A closed gRPC channel cannot be reopened; it must be rebuilt."""
+
+    def test_rebuilds_and_resubscribes_when_the_channel_was_closed(self):
+        """'_close_grpc_channel' clears '_channel', so reconnecting rebuilds it."""
+        mock = _make_mock_mapdl()
+        mock._channel = None
+        mock._ip = "127.0.0.1"
+        mock._port = 50052
+        new_channel = Mock()
+        mock._create_channel.return_value = new_channel
+
+        MapdlGrpc._ensure_channel(mock)
+
+        mock._create_channel.assert_called_once_with("127.0.0.1", 50052)
+        assert mock._channel is new_channel
+        mock._subscribe_to_channel.assert_called_once()
+
+    def test_is_a_no_op_when_the_channel_is_still_open(self):
+        """An open channel must never be replaced underneath a live session."""
+        mock = _make_mock_mapdl()
+        channel = Mock()
+        mock._channel = channel
+
+        MapdlGrpc._ensure_channel(mock)
+
+        mock._create_channel.assert_not_called()
+        mock._subscribe_to_channel.assert_not_called()
+        assert mock._channel is channel
+
+    def test_reconnect_rebuilds_the_channel_and_clears_exited(self):
+        """'reconnect_to_mapdl' resurrects an instance released by 'exit()'."""
+        mock = _make_mock_mapdl()
+        mock._timeout = 5
+        mock._exited = True
+
+        MapdlGrpc.reconnect_to_mapdl(mock)
+
+        mock._connect_to_mapdl.assert_called_once_with(5)
+        assert mock._exited is False
+
+    def test_connect_to_mapdl_ensures_the_channel_first(self):
+        """The channel must exist before '_multi_connect' uses it."""
+        mock = _make_mock_mapdl()
+
+        MapdlGrpc._connect_to_mapdl(mock, timeout=5)
+
+        mock._ensure_channel.assert_called_once()
+        mock._multi_connect.assert_called_once_with(timeout=5)

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -20,12 +20,28 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from unittest.mock import patch
+import gc
+from unittest.mock import MagicMock, Mock, patch
+import weakref
 
 from ansys.api.mapdl.v0 import mapdl_pb2 as pb_types
 import pytest
 
-from ansys.mapdl.core.mapdl_grpc import MapdlRuntimeError
+from ansys.mapdl.core.mapdl_grpc import MapdlGrpc, MapdlRuntimeError
+
+
+def _make_mock_mapdl():
+    """Return a MagicMock that carries the real instance attributes needed by
+    :meth:`MapdlGrpc._close_grpc_channel`.
+
+    Calling ``MapdlGrpc.<method>(mock, ...)`` runs the real method body with
+    the mock as ``self``.
+    """
+    m = MagicMock(spec=MapdlGrpc)
+    m._log = MagicMock()
+    m._channel = None
+    m._connectivity_callback = None
+    return m
 
 
 def test_get_float(mapdl):
@@ -103,3 +119,136 @@ def test_get_non_interactive_mode(mapdl):
 
     # reset
     mapdl._store_commands = False
+
+
+class TestCloseGrpcChannel:
+    """Tests for MapdlGrpc._close_grpc_channel."""
+
+    def test_closes_channel_and_nulls_reference(self):
+        """The channel's close() is called and _channel is set to None."""
+        mock = _make_mock_mapdl()
+        channel = Mock()
+        mock._channel = channel
+
+        MapdlGrpc._close_grpc_channel(mock)
+
+        channel.close.assert_called_once()
+        assert mock._channel is None
+
+    def test_noop_when_channel_is_none(self):
+        """No error when _channel is already None."""
+        mock = _make_mock_mapdl()
+        mock._channel = None
+
+        MapdlGrpc._close_grpc_channel(mock)  # must not raise
+
+    def test_idempotent_second_call(self):
+        """Calling twice is safe — second call is a no-op."""
+        mock = _make_mock_mapdl()
+        channel = Mock()
+        mock._channel = channel
+
+        MapdlGrpc._close_grpc_channel(mock)
+        MapdlGrpc._close_grpc_channel(mock)
+
+        channel.close.assert_called_once()
+
+    def test_exception_on_close_is_logged_not_raised(self):
+        """An exception from channel.close() is logged, not re-raised."""
+        mock = _make_mock_mapdl()
+        channel = Mock()
+        channel.close.side_effect = RuntimeError("channel already gone")
+        mock._channel = channel
+
+        MapdlGrpc._close_grpc_channel(mock)  # must not raise
+
+        mock._log.debug.assert_called()
+        assert mock._channel is None
+
+    def test_unsubscribes_callback_before_closing(self):
+        """The connectivity callback is removed before the channel is closed."""
+        mock = _make_mock_mapdl()
+        channel = Mock()
+        callback = lambda connectivity: None  # noqa: E731
+        mock._channel = channel
+        mock._connectivity_callback = callback
+
+        MapdlGrpc._close_grpc_channel(mock)
+
+        channel.unsubscribe.assert_called_once_with(callback)
+        channel.close.assert_called_once()
+        assert mock._connectivity_callback is None
+
+    def test_unsubscribe_failure_does_not_prevent_close(self):
+        """A failing unsubscribe() is logged and close() still runs."""
+        mock = _make_mock_mapdl()
+        channel = Mock()
+        channel.unsubscribe.side_effect = RuntimeError("not subscribed")
+        mock._channel = channel
+        mock._connectivity_callback = lambda connectivity: None  # noqa: E731
+
+        MapdlGrpc._close_grpc_channel(mock)  # must not raise
+
+        channel.close.assert_called_once()
+
+
+class TestConnectivityCallbackDoesNotLeakInstance:
+    """The gRPC poll thread must not keep the MapdlGrpc instance alive.
+
+    The callback registered by ``_subscribe_to_channel`` is held by gRPC for as
+    long as the subscription lasts.  A strong reference to ``self`` there makes
+    the instance uncollectable, so ``__del__`` never runs and the channel is
+    never closed.
+    """
+
+    def test_callback_holds_only_a_weak_reference(self):
+        """The instance is garbage-collected even while the callback lives on."""
+
+        class _Dummy:
+            """Minimal stand-in exposing what _subscribe_to_channel touches."""
+
+            def __init__(self, channel):
+                self._log = MagicMock()
+                self._channel = channel
+                self._channel_state = None
+                self._connectivity_callback = None
+
+            _subscribe_to_channel = MapdlGrpc._subscribe_to_channel
+
+        channel = Mock()
+        dummy = _Dummy(channel)
+        dummy._subscribe_to_channel()
+
+        # gRPC keeps the callback alive; emulate that.
+        callback = channel.subscribe.call_args[0][0]
+        ref = weakref.ref(dummy)
+
+        del dummy
+        gc.collect()
+
+        assert ref() is None, "the connectivity callback leaked the instance"
+
+        # A callback firing after collection must not raise.
+        callback("READY")
+
+    def test_callback_updates_state_while_instance_is_alive(self):
+        """The weak reference still forwards updates for a live instance."""
+
+        class _Dummy:
+            def __init__(self, channel):
+                self._log = MagicMock()
+                self._channel = channel
+                self._channel_state = None
+                self._connectivity_callback = None
+
+            _subscribe_to_channel = MapdlGrpc._subscribe_to_channel
+
+        channel = Mock()
+        dummy = _Dummy(channel)
+        dummy._subscribe_to_channel()
+
+        callback = channel.subscribe.call_args[0][0]
+        callback("READY")
+
+        assert dummy._channel_state == "READY"
+        assert dummy._connectivity_callback is callback


### PR DESCRIPTION
## Summary

This is PR 4 of 5 in the split of #4629 into focused, independently reviewable pull requests (see the plan referenced in #4608). It depends on #4707 (fix/grpc-poll-thread-leak) and #4709 (refactor/process-teardown), and is branched from refactor/process-teardown.

Even when MAPDL itself is deliberately left running (PYMAPDL_START_INSTANCE=False, PyMAPDL did not launch the instance, or a gallery build), exit() now always releases the client side of the connection: it closes the gRPC channel and joins the PIPE-drainer threads, so the _poll_connectivity daemon thread and the drainer threads do not outlive the MapdlGrpc object. reconnect_to_mapdl() is extended to rebuild the channel, making it usable for the first time on these paths.

## Changes

- New _ensure_channel(): rebuilds self._channel (via _create_channel and _subscribe_to_channel) when it has been closed, raising MapdlRuntimeError if the IP/port is unknown. _connect_to_mapdl() calls it first.
- New _disconnect_but_leave_mapdl_running(): closes the gRPC channel, joins the pipe-drainer threads, and marks the instance exited. Each step is independent, so a failure in one does not prevent the other.
- exit() calls _disconnect_but_leave_mapdl_running() on every path where MAPDL itself is left running: already exited, PYMAPDL_START_INSTANCE=False / PyMAPDL did not launch the instance, and BUILDING_GALLERY. Its docstring is updated: "ignored" now refers only to the MAPDL process, not the client side of the connection.
- reconnect_to_mapdl() docstring documents that the channel is rebuilt automatically when it was previously closed.
- tests/conftest.py: add restore_connection(mapdl), called from the teardown half of run_before_and_after_tests, so a shared session-scoped mapdl fixture whose channel a test closed via exit() is reconnected before the next test runs. Setup now also asserts not mapdl.exited, alongside the existing mute/_store_commands checks.
- tests/test_mapdl_grpc.py: add TestDisconnectButLeaveMapdlRunning (6 tests) and TestEnsureChannel (4 tests).

Note: the _check_no_leaked_mapdl_threads conftest fixture from the original combined branch is deliberately NOT included here, since it cannot reliably detect gRPC poll threads on current grpcio versions and would produce false positives. A follow-up issue should be opened for that separately.

## Risk

Highest risk of the five PRs. Users who relied on exit() being a complete no-op under PYMAPDL_START_INSTANCE=False will now find mapdl.exited is True after calling it. The mitigation is reconnect_to_mapdl(), which this PR makes work correctly for the first time on these paths.

## Testing

- `tests/test_mapdl_grpc.py tests/test_launcher/`: 638 passed, 1 skipped.
- `tests/test_mapdl.py -k "exit or del or garbage or clean"`: 29 passed, 3 skipped, 0 errors (previously reported as 19 passed / 10 errors before the conftest fix in the combined branch).
- `pre-commit run --files` passes on all touched files.

## Related

- Part of the split of #4629 (fix/poll-thread-issue) into 5 PRs: #4706, #4707, #4708, #4709, and this one.
- References #4608.
