### PR TITLE
fix: fail fast instead of crash-looping when MAPDL container in doc build keeps restarting

### DIFF
--- a/.ci/start_mapdl.sh
+++ b/.ci/start_mapdl.sh
@@ -94,7 +94,7 @@ CMD=$(cat <<-_EOT_
 run \
   --entrypoint /bin/bash \
   --name ${INSTANCE_NAME} \
-  --restart unless-stopped \
+  --restart on-failure:3 \
   -e ANSYSLMD_LICENSE_FILE=1055@${LICENSE_SERVER} \
   -e ANSYS_LOCK="OFF" \
   ${DPF_ON} \

--- a/.ci/waiting_services.sh
+++ b/.ci/waiting_services.sh
@@ -1,26 +1,74 @@
 #!/bin/bash
+# Waits for the MAPDL (and optionally DPF) gRPC ports to be reachable.
+#
+# Unlike a plain "poll the port forever" loop, this script also watches the
+# state of the Docker container hosting MAPDL. Combined with the bounded
+# `--restart on-failure:N` policy used in start_mapdl.sh, this lets the job
+# fail fast with a clear diagnostic if the container keeps crashing instead
+# of waiting on a port that will never open.
+
+INSTANCE_NAME="${INSTANCE_NAME:-MAPDL_0}"
+TIMEOUT="${TIMEOUT:-300}" # seconds
+
 echo "::group:: Docker services" && docker ps && echo "::endgroup::"
-
-echo "Waiting for the MAPDL service to be up..."
-nc -v -z localhost "$PYMAPDL_PORT"
-
 echo "::group:: ps aux Output" && ps aux && echo "::endgroup::"
 
+# Prints the container logs and its Docker state, then exits with an error.
+fail_fast() {
+    local reason="$1"
+    echo "::group:: ${INSTANCE_NAME} container state"
+    docker inspect "${INSTANCE_NAME}" --format 'Status: {{.State.Status}} | Restarting: {{.State.Restarting}} | RestartCount: {{.RestartCount}} | ExitCode: {{.State.ExitCode}} | Error: {{.State.Error}}' 2>&1
+    echo "::endgroup::"
+    echo "::group:: ${INSTANCE_NAME} container logs"
+    docker logs "${INSTANCE_NAME}" 2>&1 || echo "Could not retrieve container logs."
+    echo "::endgroup::"
+    echo "::error::${reason}"
+    exit 1
+}
 
-echo "::group:: Waiting for the MAPDL port to be open..."
-while ! nc -z localhost "$PYMAPDL_PORT"; do
-    sleep 0.1
-done
-echo "::endgroup::"
-echo "MAPDL service is up!"
+# Waits until the given port is reachable, failing fast (instead of looping
+# forever) if the timeout is hit or the container is stuck restarting/dead.
+wait_for_port() {
+    local port="$1"
+    local label="$2"
+    local elapsed=0
 
+    echo "::group:: Waiting for the ${label} port (${port}) to be open..."
+    while ! nc -z localhost "${port}"; do
+        # Detect a container that keeps crash-looping or has died instead of
+        # burning the full timeout waiting on a port that will never open.
+        local restart_count
+        restart_count=$(docker inspect "${INSTANCE_NAME}" --format '{{.RestartCount}}' 2>/dev/null || echo "0")
+        local status
+        status=$(docker inspect "${INSTANCE_NAME}" --format '{{.State.Status}}' 2>/dev/null || echo "unknown")
+
+        if [ "${status}" = "exited" ] || [ "${status}" = "dead" ]; then
+            echo "::endgroup::"
+            fail_fast "${INSTANCE_NAME} container has status '${status}' (restart policy exhausted) while waiting for the ${label} port."
+        fi
+
+        if [ "${restart_count}" -ge 3 ] 2>/dev/null; then
+            echo "::endgroup::"
+            fail_fast "${INSTANCE_NAME} container has restarted ${restart_count} times while waiting for the ${label} port. Giving up instead of crash-looping."
+        fi
+
+        if [ "${elapsed}" -ge "${TIMEOUT}" ]; then
+            echo "::endgroup::"
+            fail_fast "Timed out after ${TIMEOUT}s waiting for the ${label} port (${port}) to open."
+        fi
+
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    echo "::endgroup::"
+    echo "${label} service is up!"
+}
+
+wait_for_port "$PYMAPDL_PORT" "MAPDL"
 
 echo "::group:: Waiting for the DPF port to be open..."
 if [ "$TEST_DPF_BACKEND" = "true" ]; then
-    while ! nc -z localhost "$DPF_PORT"; do
-        sleep 0.1
-    done
-    echo "DPF service is up!"
+    wait_for_port "$DPF_PORT" "DPF"
 else
     echo "TEST_DPF_BACKEND is not set to true, skipping DPF service check."
 fi

--- a/doc/changelog.d/4711.fixed.md
+++ b/doc/changelog.d/4711.fixed.md
@@ -1,0 +1,1 @@
+Fail fast instead of crash-looping when MAPDL container in doc build keeps restarting


### PR DESCRIPTION
## Summary

The "Build documentation" CI job intermittently fails because the MAPDL
container it launches (`.ci/start_mapdl.sh`) is started with
`--restart unless-stopped`. If MAPDL fails to start correctly inside the
container (for example `mpirun: command not found`, an internal issue in
the vendor `ghcr.io/ansys/mapdl` image, not in this repository), Docker
keeps crash-looping the container forever. `.ci/waiting_services.sh` only
polls the gRPC port in an unbounded loop, so the job hangs for the full CI
timeout (40+ minutes) and eventually every gallery example that calls
`launch_mapdl()` times out, producing hundreds of misleading "MAPDL
process has died" failures that bury the real cause.

Investigation showed the actual `mpirun` resolution logic lives entirely
inside the closed-source Ansys image, not in `.ci/entrypoint.sh` — this
repository has no PATH/MPI sourcing logic to fix there. This PR instead
hardens the CI script's failure handling so a broken container is reported
quickly and clearly, regardless of the underlying image issue.

## Changes

- `.ci/start_mapdl.sh`: change `--restart unless-stopped` to
  `--restart on-failure:3`, so a persistently broken container gives up
  after 3 attempts instead of restarting forever.
- `.ci/waiting_services.sh`:
  - add a bounded `TIMEOUT` (default 300s) to the port-wait loop instead
    of polling indefinitely,
  - check the container's Docker state (`exited`/`dead`) and restart
    count while waiting, and fail fast as soon as the restart policy is
    exhausted instead of waiting for a port that will never open,
  - on failure, immediately print the container's `docker inspect` state
    and `docker logs` with a `::error::` annotation, instead of only
    surfacing `MAPDL_0.log` at the end of the job.

## Validation

- `shellcheck` / pre-commit pass on both files.
- Reproduced locally with Docker:
  - A container configured to always exit 1 with `--restart on-failure:3`
    is now detected and reported in ~10 seconds with clear container state
    and logs, instead of hanging.
  - A healthy container (port opens immediately) still passes with exit
    code 0, confirming no regression to the happy path.

## Related

Follows up on an investigation into intermittent `mpirun: command not
found" failures in the doc-build job; the crash-loop/failure-reporting
issue was in this repository's CI scripts, while the `mpirun` PATH
resolution itself is inside the vendor MAPDL Docker image.