### PR TITLE
docs: fix pymapdl-owned documentation build warnings

### DIFF
--- a/doc/changelog.d/4713.documentation.md
+++ b/doc/changelog.d/4713.documentation.md
@@ -1,0 +1,1 @@
+Fix pymapdl-owned documentation build warnings

--- a/doc/source/api/components.rst
+++ b/doc/source/api/components.rst
@@ -9,4 +9,13 @@ Components
    :toctree: _autosummary
 
    component.ComponentManager
+
+Component is a lightweight ``tuple`` subclass, so its inherited ``tuple``
+methods (``count``, ``index``) and simple ``type``/``items`` properties
+don't need their own generated pages.
+
+.. autosummary::
+   :toctree: _autosummary
+   :template: base.rst
+
    component.Component

--- a/doc/source/api/launcher.rst
+++ b/doc/source/api/launcher.rst
@@ -11,9 +11,6 @@ library `ansys-tools-common.path <ansys_tools_common_>`_.
 .. autosummary::
    :toctree: _autosummary
 
-   get_default_ansys
-   get_default_ansys_path
-   get_default_ansys_version
    launch_mapdl
    launch_mapdl_process
    close_all_local_instances

--- a/doc/source/examples/devportal.rst
+++ b/doc/source/examples/devportal.rst
@@ -22,7 +22,7 @@ connect to Ansys experts and the growing Ansys developer community.
     :gutter: 2
 
     .. grid-item-card:: Biomedical catheter design analysis
-      :img-top: https://developer.ansys.com/sites/default/files/inline-images/BMCatheter_1_0.png
+      :img-top: ../_static/pyansys-logo-light_mode.png
       :link: https://developer.ansys.com/blog/biomedical-catheter-design-analysis
       :text-align: center
       :class-title: pyansys-card-title
@@ -32,7 +32,7 @@ connect to Ansys experts and the growing Ansys developer community.
 
 
     .. grid-item-card:: Postprocessing of simplified bolted connections with the help of PyAnsys
-      :img-top: https://developer.ansys.com/sites/default/files/inline-images/Postprocessing_of_simplified_bolted_connections_with_the_help_of_PyAnsys_image_04.jpg
+      :img-top: ../_static/pyansys-logo-light_mode.png
       :link: https://developer.ansys.com/blog/postprocessing-simplified-bolted-connections-help-pyansys
       :text-align: center
       :class-title: pyansys-card-title

--- a/doc/source/examples/extended_examples/beam_analysis_with_reporting/beam_analysis_report.rst
+++ b/doc/source/examples/extended_examples/beam_analysis_with_reporting/beam_analysis_report.rst
@@ -563,7 +563,7 @@ References
 Additional files
 ================
 
-* :download:`beam_with_report.py <ref_beam_report_example_>`: Complete Python script.
+* :download:`beam_with_report.py <../../../../../examples/00-mapdl-examples/beam_with_report.py>`: Complete Python script.
 
 Examples of the generated report files are:
 

--- a/doc/source/getting_started/install_pymapdl.rst
+++ b/doc/source/getting_started/install_pymapdl.rst
@@ -91,4 +91,4 @@ Check that you have installed the package correctly by importing the module:
 
 
 For information on launching PyMAPDL and connecting it
-to an MAPDL instance, see :ref:`_ref_launch_pymapdl`.
+to an MAPDL instance, see :ref:`ref_launch_pymapdl`.

--- a/doc/source/getting_started/troubleshoot.rst
+++ b/doc/source/getting_started/troubleshoot.rst
@@ -381,7 +381,6 @@ If you are responsible for maintaining Ansys licensing or have a personal instal
 `Ansys Installation and Licensing documentation <ansys_installation_and_licensing_>`_.
 If you cannot find the information you need, open a customer request ticket.
 
-For more information, download the :download:`ANSYS Licensing Guide <lic_guide.pdf>`.
 For an example blog post on licensing issues at ANSYS 2020R1, see `Changes to Licensing at ANSYS 2020R1 <padt_licensing_>`_.
 
 

--- a/doc/source/mapdl_commands/index.rst
+++ b/doc/source/mapdl_commands/index.rst
@@ -197,7 +197,7 @@ Undocumented miscellaneous commands.
    :maxdepth: 1
    :caption: Miscellaneous
 
-   misc
+   misc/index
 
 
 *****************************

--- a/doc/source/substitutions.rst
+++ b/doc/source/substitutions.rst
@@ -1,4 +1,4 @@
-.. |pyansyscontact| replace:: `PyAnsys Core team <pyansys.core@ansys.com>`_
+.. |pyansyscontact| replace:: `PyAnsys Core team <pyansys.core@ansys.com>`__
 
 .. |pyansyscontactemail| replace:: pyansys.core@ansys.com
 

--- a/examples/00-mapdl-examples/psd-vm203.py
+++ b/examples/00-mapdl-examples/psd-vm203.py
@@ -23,9 +23,9 @@
 """
 .. _ref_psd_vm203:
 
-=========================
+===============================================
 Dynamic Load Effect on a Supported Thick Plate
-=========================
+===============================================
 
 This example demonstrates how to perform a random vibration analysis
 using PyMAPDL.


### PR DESCRIPTION
## Summary

The [documentation build job](https://github.com/ansys/pymapdl/actions/runs/31686135695/job/94417731904) produces ~28,300 Sphinx warnings. The vast majority (~99%) originate in the generated `src/ansys/mapdl/core/_commands/` docstrings (undefined labels, broken cross-references, malformed RST, duplicate anchors) that come from [pyconverter-xml2py](https://github.com/ansys/pyconverter-xml2py)/[mapdl-cmd-conv](https://github.com/ansys/mapdl-cmd-conv) and can't be fixed here — those need upstream issues in the converter tools.

This PR fixes the remaining warnings that originate in files owned by this repository.

## Changes

- **`doc/source/getting_started/install_pymapdl.rst`**: fix `:ref:` `_ref_launch_pymapdl` typo (extra leading underscore broke the reference to `ref_launch_pymapdl`).
- **`doc/source/mapdl_commands/index.rst`**: fix toctree entry pointing to nonexistent `mapdl_commands/misc` instead of `mapdl_commands/misc/index`.
- **`doc/source/api/launcher.rst`**: remove stale `get_default_ansys`, `get_default_ansys_path`, and `get_default_ansys_version` autosummary entries. These functions were removed in the launcher refactor (#4416), but the doc page was never updated.
- **`doc/source/getting_started/troubleshoot.rst`**: drop broken `:download:` link to a missing `lic_guide.pdf` (the existing hosted Ansys licensing documentation link right above it already covers this).
- **`doc/source/examples/extended_examples/beam_analysis_with_reporting/beam_analysis_report.rst`**: fix the `beam_with_report.py` download, which used an unresolved substitution instead of a real path.
- **`doc/source/examples/devportal.rst`**: replace two dead remote images (removed from their source Developer Portal articles; `developer.ansys.com` also now redirects to a Cloudflare-gated domain) with the local `pyansys-logo-light_mode.png` asset.
- **`examples/00-mapdl-examples/psd-vm203.py`**: extend the title overline/underline so it matches the title length.
- **`doc/source/api/components.rst`**: fix `Component` autosummary generating orphaned stub pages for its inherited `tuple.count`/`tuple.index` methods and `type`/`items` properties.

  Root-caused with a local Sphinx build: `components.rst` used the default autosummary class template (`ansys-sphinx-theme`'s `class.rst`), which recursively documents every member, including ones inherited from `tuple`. Since `Component` is a lightweight `tuple` subclass, this produced 4 pages with no incoming toctree link, and in some theme-option configurations even triggered a fatal breadcrumb `ThemeError`. `Component` now uses the plain `base.rst` template so only its own class page is generated.

## Verification

- All touched `.rst` files parse cleanly with `docutils`.
- `uv run pre-commit run --files <changed files>` passes.
- The `Component` fix was verified with an isolated Sphinx build using the pinned `ansys-sphinx-theme==1.9.0`, `numpydoc`, and `autosummary` config, nested under a matching `index -> api/index -> components` toctree hierarchy — it produced only `Component.rst` (no `.count`/`.index`/`.items`/`.type` sub-pages) with zero warnings.

## Out of scope

The remaining ~27,900 warnings from generated `_commands/` docstrings need upstream fixes in `pyconverter-xml2py`/`mapdl-cmd-conv` (undefined `:ref:` labels, broken cross-references, malformed RST from unescaped `*`/`_` in converted text, duplicate anchors within docstrings, and APDL lexer failures on non-APDL literal blocks). Also out of scope: duplicate labels across `mapdl_commands/**/*.rst` (needs the converter to include the processor path in generated labels, e.g. `graphics/set_up` vs `post26/set_up`), and a title-underline warning in `develop_pymapdl.rst` (skipped since the GitHub Releases changelog content used for comparison is itself inconsistent).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
