### PR TITLE
fix: force OpenMPI for the amd image flavour in doc-build entrypoint

### DIFF
--- a/.ci/entrypoint.sh
+++ b/.ci/entrypoint.sh
@@ -30,8 +30,13 @@ if [ "$RUN_DPF_SERVER" = "true" ]; then
     fi
 fi
 
-if [[ $MAPDL_IMAGE == *"cicd"* ]]; then
-    echo "Using OpenMPI for CICD version"
+if [[ $MAPDL_IMAGE == *"cicd"* || $MAPDL_IMAGE == *"amd"* ]]; then
+    # The "cicd" and "amd" image flavours are built without Intel MPI
+    # OpenMPI is shipped. Without this explicit "-mpi openmpi" flag, MAPDL's
+    # own `anssh.ini` falls back to auto-detecting the MPI implementation
+    # from the *host's* real CPU, defaulting to Intel MPI whenever the
+    # underlying CI runner isn't an AMD machine.
+    echo "Using OpenMPI for CICD/AMD version"
     export MPI="-mpi openmpi"
 else
     echo "Using default MPI version"

--- a/doc/changelog.d/4715.fixed.md
+++ b/doc/changelog.d/4715.fixed.md
@@ -1,0 +1,1 @@
+Force OpenMPI for the amd image flavour in doc-build entrypoint


### PR DESCRIPTION
## Summary

Fixes the intermittent `mpirun: command not found` failure in the "Build documentation" CI job, which crash-loops the `ghcr.io/ansys/mapdl:v25.2-ubuntu-amd` container under `--restart unless-stopped` and eventually causes hundreds of misleading "MAPDL process has died" gallery-example failures.

## Root cause (reproduced locally)

- The `amd` image flavour is built **without Intel MPI** — only OpenMPI is shipped (see the AMD flavour rules in `ansys-internal/mapdl-docker-image-builder`'s `customizer.sh`, which deletes `tp/MPI/Intel` and forces `OPENMPI` for the `AMD` flavour).
- `.ci/entrypoint.sh` only passed `-mpi openmpi` explicitly when the image tag contained `"cicd"`. For the `amd` tag, no `-mpi` flag is passed, so MAPDL's own `anssh.ini` auto-detects the MPI implementation via `check_for_amd_cpu()` (`grep 'AMD' /proc/cpuinfo`) — inspecting the **CI runner's real host CPU**, not anything in the container/image.
- On any runner whose actual CPU isn't AMD (e.g. an Intel-based GitHub/self-hosted runner), `anssh.ini` defaults to Intel MPI 2021 — which doesn't exist in this image — so `mpirun` is never on `PATH`, producing `mapdl: line 427: mpirun: command not found`. On an AMD-CPU runner, detection picks OpenMPI and it works fine.
- This fully explains the reported non-determinism: "same docker command, same image tag, sometimes works, sometimes doesn't, not tied to any code change" — it depends on which physical/virtual CPU the job happens to land on, not on PyMAPDL or image build changes.

### Reproduction

Running the exact CI invocation for `ghcr.io/ansys/mapdl:v25.2-ubuntu-amd` on an Intel host:

```
$ MPI="" -> Running: .../mapdl -grpc -dir /jobs -dmp  -transport insecure ...
/ansys_inc/v252/ansys/bin/mapdl: line 427: mpirun: command not found
```

Adding `-mpi openmpi` (as already done for `cicd` images) resolves `mpirun` correctly and MAPDL proceeds normally (to the license-server step) regardless of the host's CPU vendor.

## Fix

Extend the existing `cicd` special-case in `.ci/entrypoint.sh` to also match image tags containing `"amd"`, forcing `-mpi openmpi` explicitly instead of relying on MAPDL's risky host-CPU auto-detection.

## Validation

- `shellcheck .ci/entrypoint.sh` passes.
- Manually reproduced the failure and the fix locally against the real `ghcr.io/ansys/mapdl:v25.2-ubuntu-amd` / `v25.2-ubuntu-cicd` images on an Intel-CPU host.