### PR TITLE
docs: improve Component/launcher API docs, fix docstring RST bug

### DIFF
--- a/doc/changelog.d/4716.documentation.md
+++ b/doc/changelog.d/4716.documentation.md
@@ -1,0 +1,1 @@
+Improve Component/launcher API docs, fix docstring RST bug

--- a/doc/source/api/components.rst
+++ b/doc/source/api/components.rst
@@ -10,12 +10,14 @@ Components
 
    component.ComponentManager
 
-Component is a lightweight ``tuple`` subclass, so its inherited ``tuple``
-methods (``count``, ``index``) and simple ``type``/``items`` properties
-don't need their own generated pages.
+The :class:`~ansys.mapdl.core.component.Component` class represents a single
+named component and subclasses the built-in ``tuple`` type to store the
+selected entity IDs. Because it inherits directly from ``tuple``, it also
+exposes the standard ``tuple`` API (such as ``count()`` and ``index()``),
+which is documented in the Python standard library and isn't duplicated here.
+The ``type`` and ``items`` properties are specific to this class and are
+documented on this page instead of being generated as separate pages.
 
-.. autosummary::
-   :toctree: _autosummary
-   :template: base.rst
-
-   component.Component
+.. autoclass:: ansys.mapdl.core.component.Component
+   :members: type, items
+   :show-inheritance:

--- a/doc/source/api/launcher.rst
+++ b/doc/source/api/launcher.rst
@@ -11,6 +11,9 @@ library `ansys-tools-common.path <ansys_tools_common_>`_.
 .. autosummary::
    :toctree: _autosummary
 
+   get_default_ansys
+   get_default_ansys_path
+   get_default_ansys_version
    launch_mapdl
    launch_mapdl_process
    close_all_local_instances

--- a/doc/source/api/launcher.rst
+++ b/doc/source/api/launcher.rst
@@ -11,9 +11,6 @@ library `ansys-tools-common.path <ansys_tools_common_>`_.
 .. autosummary::
    :toctree: _autosummary
 
-   get_default_ansys
-   get_default_ansys_path
-   get_default_ansys_version
    launch_mapdl
    launch_mapdl_process
    close_all_local_instances

--- a/src/ansys/mapdl/core/component.py
+++ b/src/ansys/mapdl/core/component.py
@@ -98,16 +98,16 @@ def _check_valid_pyobj_to_entities(
 
 
 class Component(tuple):
-    """Component object
+    r"""Component object
 
     Object which contain the definition of a component.
 
     Parameters
     ----------
-    type_ : str
+    type\_ : str
         The entity type. For instance "NODES", "KP", "VOLU", etc
 
-    items_ : None, str, int, List[int], np.array[int]]
+    items\_ : None, str, int, List[int], np.array[int]]
         Item ids contained in the component.
 
     Examples

--- a/src/ansys/mapdl/core/component.py
+++ b/src/ansys/mapdl/core/component.py
@@ -107,7 +107,7 @@ class Component(tuple):
     type\_ : str
         The entity type. For instance "NODES", "KP", "VOLU", etc
 
-    items\_ : None, str, int, List[int], np.array[int]]
+    items\_ : None, str, int, Component, List[int], Tuple[int, ...], np.ndarray
         Item ids contained in the component.
 
     Examples


### PR DESCRIPTION
## Summary

Follow-up to #4713 (already merged), addressing feedback:

1. **`doc/source/api/components.rst`**: replaced the vague "don't need their own generated pages" explanation with a clearer, professional description of the `Component` class, and switched from the `:template: base.rst` stub-page workaround to an explicit `autoclass` directive with `:members: type, items`, so both properties are now fully documented on the page (instead of being silently excluded).

2. **`src/ansys/mapdl/core/component.py`**: while wiring up `:members: type, items`, discovered and fixed a latent docstring bug — the numpydoc `Parameters` section used `type_` / `items_` (trailing underscore), which docutils parses as an RST named hyperlink reference, producing `ERROR: Unknown target name` once the docstring was rendered via `autoclass`. Escaped the trailing underscores (`type\_`, `items\_`) and made the docstring raw (`r"""..."""`) so the escape isn't misinterpreted by Python itself.

## Verification

- Built an isolated Sphinx project (real `ansys_sphinx_theme`, nested `index -> api/index -> components` toctree) against this branch: build succeeds with **zero warnings/errors**, and the `Component` page now renders both the `type` and `items` properties with their docstrings, without generating orphaned `.count`/`.index` stub pages for inherited `tuple` methods.
- `pre-commit run --files doc/source/api/launcher.rst doc/source/api/components.rst src/ansys/mapdl/core/component.py` passes (black, isort, flake8, mypy, numpydoc-validation, codespell, etc.).

## Related

Follow-up to #4713.
