### PR TITLE
fix: restore get_default_ansys* helpers removed in launcher refactor

### DIFF
--- a/doc/changelog.d/4717.fixed.md
+++ b/doc/changelog.d/4717.fixed.md
@@ -1,0 +1,1 @@
+Restore get_default_ansys* helpers removed in launcher refactor

--- a/src/ansys/mapdl/core/launcher/__init__.py
+++ b/src/ansys/mapdl/core/launcher/__init__.py
@@ -115,12 +115,12 @@ def get_default_ansys() -> Union[Tuple[str, float], Tuple[Literal[""], Literal["
 
     >>> from ansys.mapdl.core.launcher import get_default_ansys
     >>> get_default_ansys()
-    'C:/Program Files/ANSYS Inc/v211/ANSYS/bin/winx64/ansys211.exe', 21.1
+    ('C:/Program Files/ANSYS Inc/v211/ANSYS/bin/winx64/ansys211.exe', 21.1)
 
     Within Linux
 
     >>> get_default_ansys()
-    (/usr/ansys_inc/v211/ansys/bin/ansys211, 21.1)
+    ('/usr/ansys_inc/v211/ansys/bin/ansys211', 21.1)
     """
     from ansys.tools.common.path import find_mapdl
 
@@ -153,15 +153,16 @@ def get_default_ansys_path() -> str:
     return get_default_ansys()[0]
 
 
-def get_default_ansys_version() -> float:
+def get_default_ansys_version() -> Union[float, Literal[""]]:
     """Search for ansys path within the standard install location.
 
     Returns the version of the latest MAPDL version installed.
 
     Returns
     -------
-    float
+    float or str
         Version float.  For example, 21.1 corresponds to 2021R1.
+        Returns an empty string when MAPDL cannot be found.
 
     Examples
     --------

--- a/src/ansys/mapdl/core/launcher/__init__.py
+++ b/src/ansys/mapdl/core/launcher/__init__.py
@@ -44,9 +44,10 @@ Public API:
 
 import os
 import platform
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple, Union
 
 from ansys.mapdl.core import LOG
+from ansys.mapdl.core._version import SUPPORTED_ANSYS_VERSIONS
 
 from .config import LOCALHOST, MAPDL_DEFAULT_PORT, resolve_launch_config  # noqa: F401
 from .connection import (
@@ -84,12 +85,98 @@ __all__ = [
     "_create_queue_for_std",
     "check_process_is_alive",
     "get_process_at_port",
+    "get_default_ansys",
+    "get_default_ansys_path",
+    "get_default_ansys_version",
 ]
 
 
 def generate_start_parameters(kwargs: dict) -> dict:
     """Generate start parameters dict (backward compatibility shim)."""
     return {k: v for k, v in kwargs.items()}
+
+
+def get_default_ansys() -> Union[Tuple[str, float], Tuple[Literal[""], Literal[""]]]:
+    """Search for ansys path within the standard install location.
+
+    Returns the path and version of the latest MAPDL version installed.
+
+    Returns
+    -------
+    ansys_path : str
+        Full path to the ANSYS executable.
+
+    version : float
+        Version float.  For example, 21.1 corresponds to 2021R1.
+
+    Examples
+    --------
+    Within Windows
+
+    >>> from ansys.mapdl.core.launcher import get_default_ansys
+    >>> get_default_ansys()
+    'C:/Program Files/ANSYS Inc/v211/ANSYS/bin/winx64/ansys211.exe', 21.1
+
+    Within Linux
+
+    >>> get_default_ansys()
+    (/usr/ansys_inc/v211/ansys/bin/ansys211, 21.1)
+    """
+    from ansys.tools.common.path import find_mapdl
+
+    return find_mapdl(supported_versions=SUPPORTED_ANSYS_VERSIONS)
+
+
+def get_default_ansys_path() -> str:
+    """Search for ansys path within the standard install location.
+
+    Returns the path of the latest MAPDL version installed.
+
+    Returns
+    -------
+    str
+        Full path to the ANSYS executable.
+
+    Examples
+    --------
+    Within Windows
+
+    >>> from ansys.mapdl.core.launcher import get_default_ansys_path
+    >>> get_default_ansys_path()
+    'C:/Program Files/ANSYS Inc/v211/ANSYS/bin/winx64/ansys211.exe'
+
+    Within Linux
+
+    >>> get_default_ansys_path()
+    '/usr/ansys_inc/v211/ansys/bin/ansys211'
+    """
+    return get_default_ansys()[0]
+
+
+def get_default_ansys_version() -> float:
+    """Search for ansys path within the standard install location.
+
+    Returns the version of the latest MAPDL version installed.
+
+    Returns
+    -------
+    float
+        Version float.  For example, 21.1 corresponds to 2021R1.
+
+    Examples
+    --------
+    Within Windows
+
+    >>> from ansys.mapdl.core.launcher import get_default_ansys_version
+    >>> get_default_ansys_version()
+    21.1
+
+    Within Linux
+
+    >>> get_default_ansys_version()
+    21.1
+    """
+    return get_default_ansys()[1]
 
 
 def _launch_mapdl_common(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -794,12 +794,22 @@ def mapdl(request, tmpdir_factory):
 #
 
 
+from ansys.mapdl.core.launcher.models import ProcessInfo as _ProcessInfo
 from ansys.mapdl.core.launcher.models import ValidationResult as _ValidationResult
 
 
 # Necessary patches to patch Mapdl launch
 def _returns(return_=None):
     return lambda *args, **kwargs: return_
+
+
+def _fake_launch_mapdl_process(config, env_vars=None, *args, **kwargs):
+    """Fake replacement for ``launcher.process.launch_mapdl_process``.
+
+    Avoids spawning a real MAPDL subprocess and waiting for its gRPC server
+    to come up, returning fabricated process information instead.
+    """
+    return _ProcessInfo(process=None, port=config.port, ip=config.ip, pid=99999)
 
 
 # Methods to patch in MAPDL when launching
@@ -842,9 +852,11 @@ _meth_patch_MAPDL_launch = [
 _meth_patch_MAPDL = _meth_patch_MAPDL_launch.copy()
 _meth_patch_MAPDL.extend(
     [
-        # launcher methods
-        ("ansys.mapdl.core.launcher.launch_grpc", _returns(None)),
-        ("ansys.mapdl.core.launcher.check_mapdl_launch", _returns(None)),
+        # launcher methods: avoid actually launching a MAPDL process.
+        (
+            "ansys.mapdl.core.launcher._launch_mapdl_process",
+            _fake_launch_mapdl_process,
+        ),
     ]
 )
 

--- a/tests/test_launcher/test_default_ansys.py
+++ b/tests/test_launcher/test_default_ansys.py
@@ -1,0 +1,54 @@
+# Copyright (C) 2016 - 2026 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2016 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Unit tests for the ``get_default_ansys*`` backward-compatibility helpers."""
+
+from unittest.mock import Mock, patch
+
+from ansys.mapdl.core.launcher import (
+    get_default_ansys,
+    get_default_ansys_path,
+    get_default_ansys_version,
+)
+
+
+def test_get_default_ansys():
+    with patch("ansys.tools.common.path.find_mapdl") as mock_find_mapdl:
+        mock_find_mapdl.return_value = ("/usr/ansys_inc/v211/ansys/bin/ansys211", 21.1)
+        assert get_default_ansys() == ("/usr/ansys_inc/v211/ansys/bin/ansys211", 21.1)
+        mock_find_mapdl.assert_called_once()
+
+
+def test_get_default_ansys_path():
+    with patch(
+        "ansys.mapdl.core.launcher.get_default_ansys",
+        Mock(return_value=("/usr/ansys_inc/v211/ansys/bin/ansys211", 21.1)),
+    ):
+        assert get_default_ansys_path() == "/usr/ansys_inc/v211/ansys/bin/ansys211"
+
+
+def test_get_default_ansys_version():
+    with patch(
+        "ansys.mapdl.core.launcher.get_default_ansys",
+        Mock(return_value=("/usr/ansys_inc/v211/ansys/bin/ansys211", 21.1)),
+    ):
+        assert get_default_ansys_version() == 21.1


### PR DESCRIPTION
## Description

The launcher refactor in #4416 (domain-driven modularization of `src/ansys/mapdl/core/launcher.py` into `src/ansys/mapdl/core/launcher/`) dropped three public functions that are still documented in `doc/source/api/launcher.rst`:

- `get_default_ansys`
- `get_default_ansys_path`
- `get_default_ansys_version`

This PR restores them (as light wrappers around `ansys.tools.common.path.find_mapdl`, matching their pre-refactor behavior and docstrings) in `ansys.mapdl.core.launcher`.

While auditing the refactor for other missing functions, I found that `tests/conftest.py`'s `PATCH_MAPDL` fixture patched two functions (`launcher.launch_grpc`, `launcher.check_mapdl_launch`) that no longer exist post-refactor. Their combined responsibility (spawning the MAPDL subprocess and waiting for the gRPC server) is now handled by `launcher._launch_mapdl_process`, so the fixture now patches that instead, avoiding an `AttributeError` that was previously masked by an unrelated `xfail` marker on `test_set_no_abort_parameter_passing`.

## Changes

- `src/ansys/mapdl/core/launcher/__init__.py`: re-add `get_default_ansys`, `get_default_ansys_path`, `get_default_ansys_version` and export them in `__all__`.
- `tests/conftest.py`: fix `PATCH_MAPDL` to patch the current `_launch_mapdl_process` function instead of the removed `launch_grpc`/`check_mapdl_launch`.
- `tests/test_launcher/test_default_ansys.py`: new unit tests for the restored functions.

## Testing

- `uv run pytest tests/test_launcher/ tests/test_mapdl.py` - all pass except 2 pre-existing failures that require a real MAPDL instance (present on main too, unrelated to this change).
- `uv run pre-commit run --all-files` on changed files passes.
