### PR TITLE
fix: set timeout for documentation build job to 60 minutes

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -72,6 +72,7 @@ jobs:
   doc-build:
     name: Build documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read  # Needed to read repository contents for documentation build
       packages: read  # Needed to pull Docker images from GitHub packages

--- a/doc/changelog.d/4718.fixed.md
+++ b/doc/changelog.d/4718.fixed.md
@@ -1,0 +1,1 @@
+Set timeout for documentation build job to 60 minutes


### PR DESCRIPTION
## Description
As the title. It should not take more than 60min.

## Issue linked
NA
