### PR TITLE
fix: run doc-style unconditionally so docs build on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,6 @@ jobs:
   doc-style:
     name: "Documentation style ${{ matrix.folder }}"
     runs-on: ubuntu-latest
-    if: always() && (needs.pull-request-name.result == 'success' || needs.pull-request-name.result == 'skipped')
-    needs: [ pull-request-name ]
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
   doc-style:
     name: "Documentation style ${{ matrix.folder }}"
     runs-on: ubuntu-latest
+    if: always() && (needs.pull-request-name.result == 'success' || needs.pull-request-name.result == 'skipped')
     needs: [ pull-request-name ]
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
     name: "Documentation style ${{ matrix.folder }}"
     runs-on: ubuntu-latest
     needs: [ pull-request-name ]
+    # This jobs runs if the above is skipped or successful. This is to show nicer graphs in the summary windows.
     if: always() && (needs.pull-request-name.result == 'success' || needs.pull-request-name.result == 'skipped')
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,8 @@ jobs:
   doc-style:
     name: "Documentation style ${{ matrix.folder }}"
     runs-on: ubuntu-latest
+    needs: [ pull-request-name ]
+    if: always() && (needs.pull-request-name.result == 'success' || needs.pull-request-name.result == 'skipped')
     permissions:
       contents: read
     strategy:

--- a/doc/changelog.d/4720.fixed.md
+++ b/doc/changelog.d/4720.fixed.md
@@ -1,0 +1,1 @@
+Run doc-style unconditionally so docs build on push to main


### PR DESCRIPTION
## Description
After merging #4719, documentation was no longer being built/deployed on pushes to `main` (dev docs) or on tag pushes (release docs).

Root cause: `doc-style` had `needs: [ pull-request-name ]`, and `pull-request-name` only runs `if: github.event_name == 'pull_request'`. On `push`, `schedule`, and `workflow_dispatch` events, `pull-request-name` is skipped, and since `doc-style` had no explicit `if:` of its own, GitHub Actions' implicit `success()` requirement on `needs` caused `doc-style` to be skipped too — cascading through `docs-build` → `package` → `release`/`upload-dev-docs`/`doc-deploy-pr`.

## Fix
Removed the unnecessary `needs: [ pull-request-name ]` dependency from `doc-style`. There is no functional reason `doc-style` (a documentation style check) needs to be serialized after the unrelated PR-title check, so `doc-style` now runs unconditionally on all trigger events again, restoring documentation builds/deployments on `push`, `schedule`, and `workflow_dispatch`.

## Issue linked
NA
