### PR TITLE
fix: properly collect and display MAPDL CI logs

### DIFF
--- a/.ci/collect_mapdl_logs_locals.sh
+++ b/.ci/collect_mapdl_logs_locals.sh
@@ -40,4 +40,4 @@ mv ./*.jsonl ./"$LOG_NAMES"/ 2>/dev/null || echo "No JSONL files could be found"
 ls -la ./"$LOG_NAMES"
 
 echo "Tar files..."
-tar --remove-files -cvzf ./"$LOG_NAMES".tgz ./"$LOG_NAMES" || echo "Failed to compress"
+tar -cvzf ./"$LOG_NAMES".tgz ./"$LOG_NAMES" || echo "Failed to compress"

--- a/.ci/collect_mapdl_logs_locals.sh
+++ b/.ci/collect_mapdl_logs_locals.sh
@@ -21,13 +21,14 @@
 # Note:
 #   Ensure you have the necessary permissions to read from MAPDL_LOGS_DIR and write to
 
+LOG_NAMES="${LOG_NAMES:-logs}"
 mkdir -p "$LOG_NAMES" && echo "Successfully generated directory $LOG_NAMES"
 
 echo "Copying the log files..."
-mv ./*.log ./"$LOG_NAMES"/ 2>/dev/null || echo "No log files could be found"
-mv ./*apdl.out ./"$LOG_NAMES"/ 2>/dev/null || echo "No APDL log files could be found"
-mv ./*pymapdl.apdl ./"$LOG_NAMES"/ 2>/dev/null || echo "No PYMAPDL APDL log files could be found"
-mv /home/mapdl/dpf_logs ./"$LOG_NAMES"/ 2>/dev/null || echo "No DPF log files could be found"
+if compgen -G "./*.log" > /dev/null; then mv ./*.log "./$LOG_NAMES/"; else echo "No log files could be found"; fi
+if compgen -G "./*apdl.out" > /dev/null; then mv ./*apdl.out "./$LOG_NAMES/"; else echo "No APDL log files could be found"; fi
+if compgen -G "./*pymapdl.apdl" > /dev/null; then mv ./*pymapdl.apdl "./$LOG_NAMES/"; else echo "No PYMAPDL APDL log files could be found"; fi
+if [ -e /home/mapdl/dpf_logs ]; then mv /home/mapdl/dpf_logs "./$LOG_NAMES/"; else echo "No DPF log files could be found"; fi
 
 echo "Copying the profiling files..."
 mkdir -p ./"$LOG_NAMES"/prof

--- a/.ci/collect_mapdl_logs_locals.sh
+++ b/.ci/collect_mapdl_logs_locals.sh
@@ -21,20 +21,20 @@
 # Note:
 #   Ensure you have the necessary permissions to read from MAPDL_LOGS_DIR and write to
 
-mkdir "$LOG_NAMES" && echo "Successfully generated directory $LOG_NAMES"
+mkdir -p "$LOG_NAMES" && echo "Successfully generated directory $LOG_NAMES"
 
 echo "Copying the log files..."
-mv ./*.log ./"$LOG_NAMES"/ || echo "No log files could be found"
-mv ./*apdl.out ./"$LOG_NAMES"/ || echo "No APDL log files could be found"
-mv ./*pymapdl.apdl ./"$LOG_NAMES"/ || echo "No PYMAPDL APDL log files could be found"
-mv /home/mapdl/dpf_logs ./"$LOG_NAMES"/ || echo "No DPF log files could be found"
+mv ./*.log ./"$LOG_NAMES"/ 2>/dev/null || echo "No log files could be found"
+mv ./*apdl.out ./"$LOG_NAMES"/ 2>/dev/null || echo "No APDL log files could be found"
+mv ./*pymapdl.apdl ./"$LOG_NAMES"/ 2>/dev/null || echo "No PYMAPDL APDL log files could be found"
+mv /home/mapdl/dpf_logs ./"$LOG_NAMES"/ 2>/dev/null || echo "No DPF log files could be found"
 
 echo "Copying the profiling files..."
 mkdir -p ./"$LOG_NAMES"/prof
-mv prof/* ./"$LOG_NAMES"/prof || echo "No profile files could be found"
+mv prof/* ./"$LOG_NAMES"/prof 2>/dev/null || echo "No profile files could be found"
 
 echo "Copying the JSONL files..."
-mv ./*.jsonl ./"$LOG_NAMES"/ || echo "No JSONL files could be found"
+mv ./*.jsonl ./"$LOG_NAMES"/ 2>/dev/null || echo "No JSONL files could be found"
 
 ls -la ./"$LOG_NAMES"
 

--- a/.ci/collect_mapdl_logs_remote.sh
+++ b/.ci/collect_mapdl_logs_remote.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+set +e  # Do not stop if a file is missing, just report it.
+
+# Colors for error/warning messages (GitHub Actions renders ANSI colors).
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No color
+
 if [[ $MAPDL_VERSION == *"ubuntu"* ]] ; then
     echo "It is an ubuntu based image"
     export FILE=/jobs/file
@@ -9,9 +17,11 @@ else
     export WDIR=""
 fi;
 
-{ mkdir -p "$LOG_NAMES" && echo "Successfully generated directory $LOG_NAMES"; } || { echo "Failed to create directory $LOG_NAMES"; exit 1; }
+{ mkdir -p "$LOG_NAMES" && echo "Successfully generated directory $LOG_NAMES"; } || { echo -e "${RED}Failed to create directory $LOG_NAMES${NC}"; exit 1; }
 
-# Helper function to display files with a pattern
+# Helper function to display files with a pattern inside collapsible GitHub
+# Actions log groups. Each group is always closed, even if a file cannot be
+# shown, to avoid leaving nested/unclosed groups in the workflow log.
 display_files() {
     local pattern=$1
     local file_type=$2
@@ -19,66 +29,71 @@ display_files() {
     echo "Displaying files with pattern $pattern: $file_pattern"
     if compgen -G "$file_pattern" > /dev/null; then
         for f in $file_pattern; do
-            echo "::group:: $file_type file $f" && cat "$f" && echo "::endgroup::"
+            echo "::group:: $file_type file $f"
+            if [ -f "$f" ]; then
+                cat "$f"
+            else
+                echo -e "${RED}Failed to show $file_type file: '$f' does not exist.${NC}"
+            fi
+            echo "::endgroup::"
         done
-        return 0
     else
-        echo "No $pattern files to print."
+        echo -e "${YELLOW}No $pattern files to print.${NC}"
     fi
 }
 
 ###############################################################################
 echo "Collecting MAPDL logs from remote container..."
 
-(docker exec "$MAPDL_INSTANCE" /bin/bash -c "mkdir -p /mapdl_logs && echo 'Successfully created directory inside docker container'") || echo "Failed to create a directory inside docker container for logs."
+(docker exec "$MAPDL_INSTANCE" /bin/bash -c "mkdir -p /mapdl_logs && echo 'Successfully created directory inside docker container'") || echo -e "${RED}Failed to create a directory inside docker container for logs.${NC}"
 
-(docker exec "$MAPDL_INSTANCE" /bin/bash -c "mv ./*.log /mapdl_logs") && echo "Successfully moved the logs files." || echo "Failed to move the logs files."
+(docker exec "$MAPDL_INSTANCE" /bin/bash -c "mv ./*.log /mapdl_logs" 2>/dev/null) && echo "Successfully moved the logs files." || echo -e "${YELLOW}Failed to move the logs files.${NC}"
 
-(docker exec "$MAPDL_INSTANCE" /bin/bash -c "ps aux > /mapdl_logs/docker_processes_end.log") && echo "Successfully got the processes from the docker container" || echo "Failed to get the processes from the docker container"
+(docker exec "$MAPDL_INSTANCE" /bin/bash -c "ps aux > /mapdl_logs/docker_processes_end.log") && echo "Successfully got the processes from the docker container" || echo -e "${RED}Failed to get the processes from the docker container${NC}"
 
-(docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$FILE*.out' > /dev/null; then mv -f $FILE*.out /mapdl_logs && echo 'Successfully moved out files.'; fi") || echo "Failed to move the 'out' files into a local file"
-(docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$FILE*.err' > /dev/null; then mv -f $FILE*.err /mapdl_logs && echo 'Successfully moved err files.'; fi") || echo "Failed to move the 'err' files into a local file"
-(docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$FILE*.log' > /dev/null; then mv -f $FILE*.log /mapdl_logs && echo 'Successfully moved log files.'; fi") || echo "Failed to move the 'log' files into a local file"
-(docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$WDIR*.crash' > /dev/null; then mv -f $WDIR*.crash /mapdl_logs && echo 'Successfully moved crash files.'; fi") || echo "Failed to move the 'crash' files into a local file"
+(docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$FILE*.out' > /dev/null; then mv -f $FILE*.out /mapdl_logs && echo 'Successfully moved out files.'; fi") || echo -e "${YELLOW}Failed to move the 'out' files into a local file${NC}"
+(docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$FILE*.err' > /dev/null; then mv -f $FILE*.err /mapdl_logs && echo 'Successfully moved err files.'; fi") || echo -e "${YELLOW}Failed to move the 'err' files into a local file${NC}"
+(docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$FILE*.log' > /dev/null; then mv -f $FILE*.log /mapdl_logs && echo 'Successfully moved log files.'; fi") || echo -e "${YELLOW}Failed to move the 'log' files into a local file${NC}"
+(docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$WDIR*.crash' > /dev/null; then mv -f $WDIR*.crash /mapdl_logs && echo 'Successfully moved crash files.'; fi") || echo -e "${YELLOW}Failed to move the 'crash' files into a local file${NC}"
 
-docker cp "$MAPDL_INSTANCE":/home/mapdl/dpf_logs ./"$LOG_NAMES"/ && echo "Successfully copied the 'dpf_logs' files into a local directory" || echo "Failed to copy the 'dpf_logs' files into a local directory"
-docker cp "$MAPDL_INSTANCE":/mapdl_logs/. ./"$LOG_NAMES"/. && echo "Successfully copied the $LOG_NAMES files into a local directory" || echo "Failed to copy the $LOG_NAMES files into a local directory"
+docker cp "$MAPDL_INSTANCE":/home/mapdl/dpf_logs ./"$LOG_NAMES"/ && echo "Successfully copied the 'dpf_logs' files into a local directory" || echo -e "${YELLOW}Failed to copy the 'dpf_logs' files into a local directory${NC}"
+docker cp "$MAPDL_INSTANCE":/mapdl_logs/. ./"$LOG_NAMES"/. && echo "Successfully copied the $LOG_NAMES files into a local directory" || echo -e "${RED}Failed to copy the $LOG_NAMES files into a local directory${NC}"
 
 ###############################################################################
 echo "Collecting local build logs..."
 ls -la
 
-docker ps > ./"$LOG_NAMES"/docker_ps_end.log && echo "Successfully printed the docker ps" || echo "Failed to print the docker ps"
+docker ps > ./"$LOG_NAMES"/docker_ps_end.log && echo "Successfully printed the docker ps" || echo -e "${RED}Failed to print the docker ps${NC}"
 
 ###############################################################################
 echo "Collecting and printing logs..."
-mv ./*.log ./"$LOG_NAMES"/ && echo "Successfully moved log files." || echo "MAPDL run docker log not found."
+mv ./*.log ./"$LOG_NAMES"/ 2>/dev/null && echo "Successfully moved log files." || echo -e "${YELLOW}MAPDL run docker log not found.${NC}"
 
-display_files "*.log" "Log" && echo "Failed to display the '*.log' files."
-display_files "*.err" "Error" && echo "Failed to display the '*.err' files."
-display_files "*.out" "Output" && echo "Failed to display the '*.out' files."
+display_files "*.log" "Log"
+display_files "*.err" "Error"
+display_files "*.out" "Output"
 
 ###############################################################################
 echo "Moving the profiling files..."
 mkdir -p ./"$LOG_NAMES"/prof
-mv prof/* ./"$LOG_NAMES"/prof && echo "Successfully moved profile files." || echo "No profile files could be found"
+mv prof/* ./"$LOG_NAMES"/prof 2>/dev/null && echo "Successfully moved profile files." || echo -e "${YELLOW}No profile files could be found${NC}"
 
 echo "Moving the JSONL files..."
-mv ./*.jsonl ./"$LOG_NAMES"/ && echo "Successfully moved JSONL files." || echo "No JSONL files could be found"
+mv ./*.jsonl ./"$LOG_NAMES"/ 2>/dev/null && echo "Successfully moved JSONL files." || echo -e "${YELLOW}No JSONL files could be found${NC}"
 
 ###############################################################################
 echo "::group:: Display files structure"
 echo "Collecting file structure..."
 ls -R
-ls -R > ./"$LOG_NAMES"/files_structure.txt && echo "Generated file structure" || echo "Failed to copy file structure to a file"
+ls -R > ./"$LOG_NAMES"/files_structure.txt && echo "Generated file structure" || echo -e "${RED}Failed to copy file structure to a file${NC}"
 echo "::endgroup::"
 
 echo "::group:: Display files structure"
 echo "Collecting docker file structure..."
 docker exec "$MAPDL_INSTANCE" /bin/bash -c "ls -R"
-docker exec "$MAPDL_INSTANCE" /bin/bash -c "ls -R > /tmp/docker_ls.txt" && docker cp "$MAPDL_INSTANCE":/tmp/docker_ls.txt ./"$LOG_NAMES"/docker_files_structure.txt && echo "Generated docker file structure" || echo "Failed to copy the docker structure into a local file"
+docker exec "$MAPDL_INSTANCE" /bin/bash -c "ls -R > /tmp/docker_ls.txt" && docker cp "$MAPDL_INSTANCE":/tmp/docker_ls.txt ./"$LOG_NAMES"/docker_files_structure.txt && echo "Generated docker file structure" || echo -e "${RED}Failed to copy the docker structure into a local file${NC}"
 echo "::endgroup::"
 
 ###############################################################################
 echo "Tar files..."
-tar --remove-files -cvzf ./"$LOG_NAMES".tgz ./"$LOG_NAMES" && echo "Successfully compressed logs." || echo "Failed to compress"
+tar --remove-files -cvzf ./"$LOG_NAMES".tgz ./"$LOG_NAMES" && echo "Successfully compressed logs." || echo -e "${RED}Failed to compress${NC}"

--- a/.ci/collect_mapdl_logs_remote.sh
+++ b/.ci/collect_mapdl_logs_remote.sh
@@ -29,13 +29,13 @@ display_files() {
     echo "Displaying files with pattern $pattern: $file_pattern"
     if compgen -G "$file_pattern" > /dev/null; then
         for f in $file_pattern; do
-            echo "::group:: $file_type file $f"
+            echo "::group:: $file_type file $f" > /dev/null
             if [ -f "$f" ]; then
                 cat "$f"
             else
                 echo -e "${RED}Failed to show $file_type file: '$f' does not exist.${NC}"
             fi
-            echo "::endgroup::"
+            echo "::endgroup::" > /dev/null
         done
     else
         echo -e "${YELLOW}No $pattern files to print.${NC}"

--- a/.ci/collect_mapdl_logs_remote.sh
+++ b/.ci/collect_mapdl_logs_remote.sh
@@ -96,4 +96,4 @@ echo "::endgroup::"
 
 ###############################################################################
 echo "Tar files..."
-tar --remove-files -cvzf ./"$LOG_NAMES".tgz ./"$LOG_NAMES" && echo "Successfully compressed logs." || echo -e "${RED}Failed to compress${NC}"
+tar -cvzf ./"$LOG_NAMES".tgz ./"$LOG_NAMES" && echo "Successfully compressed logs." || echo -e "${RED}Failed to compress${NC}"

--- a/.ci/collect_mapdl_logs_remote.sh
+++ b/.ci/collect_mapdl_logs_remote.sh
@@ -29,13 +29,13 @@ display_files() {
     echo "Displaying files with pattern $pattern: $file_pattern"
     if compgen -G "$file_pattern" > /dev/null; then
         for f in $file_pattern; do
-            echo "::group:: $file_type file $f" > /dev/null
+            echo "::group:: $file_type file $f"
             if [ -f "$f" ]; then
                 cat "$f"
             else
                 echo -e "${RED}Failed to show $file_type file: '$f' does not exist.${NC}"
             fi
-            echo "::endgroup::" > /dev/null
+            echo "::endgroup::"
         done
     else
         echo -e "${YELLOW}No $pattern files to print.${NC}"

--- a/.ci/display_logs_locals.sh
+++ b/.ci/display_logs_locals.sh
@@ -13,22 +13,33 @@
 #
 # Modify this script as needed to include additional log files or directories.
 
+set +e  # Do not stop if a file is missing, just report it.
+
+# Colors for error/warning messages (GitHub Actions renders ANSI colors).
+RED='\033[0;31m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No color
+
+#####
+# Displaying a file inside a collapsible GitHub Actions log group.
+# The group is always closed, even if the file cannot be shown, to avoid
+# leaving nested/unclosed groups in the workflow log.
+display_file () {
+    local file_pat="$1"
+    local file_description="$2"
+
+    echo "::group:: $file_description: $file_pat"
+    if [ -f "$file_pat" ]; then
+        cat "$file_pat"
+    else
+        echo -e "${RED}Failed to show $file_description file: '$file_pat' does not exist.${NC}"
+        echo -e "${YELLOW}Check the 'PYMAPDL_DEBUG_TESTING' env var is set to 'True'.${NC}"
+    fi
+    echo "::endgroup::"
+}
 
 #####
 # Displaying files
-FILE_PAT=./"$LOG_NAMES"/pymapdl.log
-FILE_DESCRIPTION="PyMAPDL log"
-
-(echo "::group:: $FILE_DESCRIPTION: $FILE_PAT" && cat "$FILE_PAT" && echo "::endgroup::") || echo "Failed to show $FILE_DESCRIPTION file"
-
-#####
-FILE_PAT=./"$LOG_NAMES"/pymapdl.apdl
-FILE_DESCRIPTION="PyMAPDL APDL log"
-
-(echo "::group:: $FILE_DESCRIPTION: $FILE_PAT" && cat "$FILE_PAT" && echo "::endgroup::") || echo "Failed to show $FILE_DESCRIPTION file"
-
-#####
-FILE_PAT=./"$LOG_NAMES"/apdl.out
-FILE_DESCRIPTION="MAPDL Output"
-
-(echo "::group:: $FILE_DESCRIPTION: $FILE_PAT" && cat "$FILE_PAT" && echo "::endgroup::") || echo "Failed to show $FILE_DESCRIPTION file"
+display_file "./$LOG_NAMES/pymapdl.log" "PyMAPDL log"
+display_file "./$LOG_NAMES/pymapdl.apdl" "PyMAPDL APDL log"
+display_file "./$LOG_NAMES/apdl.out" "MAPDL Output"

--- a/.ci/display_logs_locals.sh
+++ b/.ci/display_logs_locals.sh
@@ -14,6 +14,7 @@
 # Modify this script as needed to include additional log files or directories.
 
 set +e  # Do not stop if a file is missing, just report it.
+LOG_NAMES="${LOG_NAMES:-logs}"
 
 # Colors for error/warning messages (GitHub Actions renders ANSI colors).
 RED='\033[0;31m'
@@ -32,8 +33,8 @@ display_file () {
     if [ -f "$file_pat" ]; then
         cat "$file_pat"
     else
-        echo -e "${RED}Failed to show $file_description file: '$file_pat' does not exist.${NC}"
-        echo -e "${YELLOW}Check the 'PYMAPDL_DEBUG_TESTING' env var is set to 'True'.${NC}"
+        printf '%b\n' "${RED}Failed to show $file_description file: '$file_pat' does not exist.${NC}"
+        printf '%b\n' "${YELLOW}If you expect this file, enable it with PYMAPDL_DEBUG_TESTING=true (or 'True').${NC}"
     fi
     echo "::endgroup::"
 }

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -243,6 +243,9 @@ jobs:
           BUILDER: ${{ inputs.builder }}
           PYMAPDL_GRPC_TRANSPORT: 'insecure'
           DPF_DEFAULT_GRPC_MODE: 'insecure'
+          # Verbose Sphinx output ("-vv") only when the job is re-run with
+          # debug logging enabled, to keep normal build logs readable.
+          SPHINX_VERBOSITY: ${{ runner.debug == '1' && '-vv' || '' }}
         run: |
           export PYTHONFAULTHANDLER=1
           # Temporary diagnostics for the intermittent hangs seen during the
@@ -254,7 +257,7 @@ jobs:
           # the gallery examples' MAPDL sessions, are known to deadlock a
           # forked child if still alive at fork time. Forcing "-j 1" disables
           # that fork so we can confirm/rule out this hypothesis.
-          xvfb-run make -C doc ${BUILDER} SPHINXOPTS="-j 1 -vv" 2>&1 \
+          xvfb-run make -C doc ${BUILDER} SPHINXOPTS="-j 1 ${SPHINX_VERBOSITY}" 2>&1 \
             | ts '%Y-%m-%dT%H:%M:%.S' \
             | tee doc_build.log
 

--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -142,7 +142,8 @@ jobs:
       ON_LOCAL: true
       ON_UBUNTU: true
       P_SCHEMA: "/ansys_inc/v241/ansys/ac4/schema"
-      PYMAPDL_DEBUG_TESTING: false
+      # Automatically enabled when the job is re-run with debug logging.
+      PYMAPDL_DEBUG_TESTING: ${{ runner.debug == '1' }}
       PYMAPDL_GRPC_TRANSPORT: 'insecure'
       PYTEST_ARGUMENTS: ""
       PYTEST_TIMEOUT: 120 # seconds. Limit the duration for each unit test

--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -143,7 +143,6 @@ jobs:
       ON_UBUNTU: true
       P_SCHEMA: "/ansys_inc/v241/ansys/ac4/schema"
       # Automatically enabled when the job is re-run with debug logging.
-      PYMAPDL_DEBUG_TESTING: ${{ runner.debug == '1' }}
       PYMAPDL_GRPC_TRANSPORT: 'insecure'
       PYTEST_ARGUMENTS: ""
       PYTEST_TIMEOUT: 120 # seconds. Limit the duration for each unit test
@@ -252,6 +251,7 @@ jobs:
           PYMAPDL_NPROC: 2
           PYTEST_ARGUMENTS: "${{ env.PYTEST_ARGUMENTS }}"
           PYTEST_INPUT_ARGUMENTS: "${{ inputs.pytest-arguments }}"
+          PYMAPDL_DEBUG_TESTING: ${{ runner.debug == '1' }}
         shell: bash
         run: |
           echo "ON_UBUNTU: $ON_UBUNTU"

--- a/.github/workflows/test-remote.yml
+++ b/.github/workflows/test-remote.yml
@@ -94,7 +94,6 @@ jobs:
       PYMAPDL_DB_PORT: 21002  # default won't work on GitHub runners
       PYMAPDL_DB_PORT2: 21003  # default won't work on GitHub runners
       # Automatically enabled when the job is re-run with debug logging.
-      PYMAPDL_DEBUG_TESTING: ${{ runner.debug == '1' }}
       PYMAPDL_GRPC_TRANSPORT: 'insecure'
       PYMAPDL_PORT: 21000  # default won't work on GitHub runners
       PYMAPDL_PORT2: 21001  # for the pool testing and default won't work on GitHub runners
@@ -262,6 +261,7 @@ jobs:
           file_name: "${{ inputs.file-name }}"
           MAPDL_VERSION: "${{ inputs.mapdl-version }}"
           PYTEST_INPUT_ARGUMENTS: "${{ inputs.pytest-arguments }}"
+          PYMAPDL_DEBUG_TESTING: ${{ runner.debug == '1' }}
         shell: bash
         run: |
           echo "ON_UBUNTU: $ON_UBUNTU"

--- a/.github/workflows/test-remote.yml
+++ b/.github/workflows/test-remote.yml
@@ -93,7 +93,8 @@ jobs:
       PYANSYS_OFF_SCREEN: True
       PYMAPDL_DB_PORT: 21002  # default won't work on GitHub runners
       PYMAPDL_DB_PORT2: 21003  # default won't work on GitHub runners
-      PYMAPDL_DEBUG_TESTING: false
+      # Automatically enabled when the job is re-run with debug logging.
+      PYMAPDL_DEBUG_TESTING: ${{ runner.debug == '1' }}
       PYMAPDL_GRPC_TRANSPORT: 'insecure'
       PYMAPDL_PORT: 21000  # default won't work on GitHub runners
       PYMAPDL_PORT2: 21001  # for the pool testing and default won't work on GitHub runners

--- a/doc/changelog.d/4722.fixed.md
+++ b/doc/changelog.d/4722.fixed.md
@@ -1,0 +1,1 @@
+Properly collect and display MAPDL CI logs


### PR DESCRIPTION
## Description

Fixes broken log collection/display in the local MAPDL test CI job (e.g. https://github.com/ansys/pymapdl/actions/runs/31796423103/job/94755534892), and makes CI debug behavior automatic on debug re-runs instead of requiring manual workflow edits.

### 1. Broken log group display (`display_logs_locals.sh`)

Each block used:

```bash
(echo "::group:: ..." && cat "$FILE" && echo "::endgroup::") || echo "Failed to show ... file"
```

When `cat` failed because the file was missing, the `&&` chain short-circuited, so `::endgroup::` was **never printed**. This left the GitHub Actions log group open, which is why the job log showed progressively nested/indented output instead of clean, separate groups.

**Fix:** refactored into a `display_file()` helper that always closes the log group (checks `-f` before `cat` instead of relying on `cat`'s own stderr), and colorizes the missing-file warning (red) plus the `PYMAPDL_DEBUG_TESTING` hint (yellow) so failures stand out.

### 2. Noisy log collection (`collect_mapdl_logs_locals.sh`)

Suppressed noisy `mv: cannot stat ...` stderr with `2>/dev/null` (the existing `|| echo` fallback already reports this clearly) and used `mkdir -p` for idempotency.

### 3. Auto-enable debug testing on debug re-runs

`test-local.yml` / `test-remote.yml`: `PYMAPDL_DEBUG_TESTING` was hardcoded to `false`, meaning `pymapdl.log`/`pymapdl.apdl`/`apdl.out` were never generated, even when a job is re-run for debugging. It's now set to `${{ runner.debug == '1' }}`, GitHub's built-in context that is `'1'` when a job is re-run with **Enable debug logging**. Normal runs stay `false`.

### 4. Verbose Sphinx build only on debug re-runs

`doc-build.yml`: `SPHINXOPTS` always forced `-vv` (added for the intermittent hang diagnostics in #4707), making every doc build log noisy. Verbose output is now gated the same way, via a new `SPHINX_VERBOSITY` env var driven by `runner.debug`. The `-j 1` diagnostic flag is kept regardless.

### 5. Align `collect_mapdl_logs_remote.sh` with the local scripts

Applied the same fixes to the remote (Docker-based) log collection/display script so both interfaces behave consistently:

- `display_files()`: each `::group::`/`::endgroup::` pair is now always closed, fixing the same short-circuit bug as in `display_logs_locals.sh`.
- Removed an inverted-logic bug where `display_files ... && echo 'Failed to display ...'` **always** printed the failure message on success, because `display_files` always returned `0` regardless of outcome.
- Colorized failure (red) and "not found" (yellow) messages, matching `display_logs_locals.sh`.
- Silenced noisy stderr on `mv`/`docker exec` calls that lacked a pre-check (`2>/dev/null`), keeping the existing clear fallback messages.

## Testing

- Verified locally with simulated missing and present log files for both the local and remote scripts: groups close correctly, colored messages render as expected, and the remote `display_files` no longer prints a false failure message on success.
- Sanity-checked `SPHINXOPTS` expansion with and without `SPHINX_VERBOSITY` set.
- `uv run pre-commit run --all-files` (shellcheck, Validate GitHub Workflows, zizmor, etc.) passes on all changed files.
