### PR TITLE
fix: reset mapdl._exited via finally in test_timeout_when_exiting

### DIFF
--- a/doc/changelog.d/4723.fixed.md
+++ b/doc/changelog.d/4723.fixed.md
@@ -1,0 +1,1 @@
+Reset mapdl._exited via finally in test_timeout_when_exiting

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -3010,43 +3010,46 @@ def test_timeout_when_exiting(mapdl, is_exited):
 
     handle_generic_grpc_error = errors.handle_generic_grpc_error
 
-    with (
-        patch("ansys.mapdl.core.mapdl_grpc.pb_types.CmdRequest") as mock_cmdrequest,
-        patch(
-            "ansys.mapdl.core.mapdl_grpc.MapdlGrpc.is_alive", new_callable=PropertyMock
-        ) as mock_is_alive,
-        patch.object(mapdl, "_connect") as mock_connect,
-        patch(
-            "ansys.mapdl.core.errors.handle_generic_grpc_error", autospec=True
-        ) as mock_handle,
-        patch.object(mapdl, "_exit_mapdl") as mock_exit_mapdl,
-    ):
+    try:
+        with (
+            patch("ansys.mapdl.core.mapdl_grpc.pb_types.CmdRequest") as mock_cmdrequest,
+            patch(
+                "ansys.mapdl.core.mapdl_grpc.MapdlGrpc.is_alive",
+                new_callable=PropertyMock,
+            ) as mock_is_alive,
+            patch.object(mapdl, "_connect") as mock_connect,
+            patch(
+                "ansys.mapdl.core.errors.handle_generic_grpc_error", autospec=True
+            ) as mock_handle,
+            patch.object(mapdl, "_exit_mapdl") as mock_exit_mapdl,
+        ):
 
-        mock_exit_mapdl.return_value = None  # Avoid exiting
-        mock_is_alive.return_value = False
-        mock_connect.return_value = None  # patched to avoid timeout
-        mock_cmdrequest.side_effect = raise_exception
-        mock_handle.side_effect = handle_generic_grpc_error
+            mock_exit_mapdl.return_value = None  # Avoid exiting
+            mock_is_alive.return_value = False
+            mock_connect.return_value = None  # patched to avoid timeout
+            mock_cmdrequest.side_effect = raise_exception
+            mock_handle.side_effect = handle_generic_grpc_error
 
-        with pytest.raises(MapdlExitedError):
-            mapdl.prep7()
+            with pytest.raises(MapdlExitedError):
+                mapdl.prep7()
 
-        # After
-        assert mapdl._exited
+            # After
+            assert mapdl._exited
 
-        assert mock_handle.call_count == 1
+            assert mock_handle.call_count == 1
 
-        if is_exited:
-            # Checking no trying to reconnect
-            assert mock_connect.call_count == 0
-            assert mock_cmdrequest.call_count == 1
-            assert mock_is_alive.call_count == 1
+            if is_exited:
+                # Checking no trying to reconnect
+                assert mock_connect.call_count == 0
+                assert mock_cmdrequest.call_count == 1
+                assert mock_is_alive.call_count == 1
 
-        else:
-            assert mock_connect.call_count == errors.N_ATTEMPTS
-            assert mock_cmdrequest.call_count == errors.N_ATTEMPTS + 1
-            assert mock_is_alive.call_count == errors.N_ATTEMPTS + 1
+            else:
+                assert mock_connect.call_count == errors.N_ATTEMPTS
+                assert mock_cmdrequest.call_count == errors.N_ATTEMPTS + 1
+                assert mock_is_alive.call_count == errors.N_ATTEMPTS + 1
 
+    finally:
         mapdl._exited = False
 
 


### PR DESCRIPTION
## Problem

`tests/test_mapdl.py::test_timeout_when_exiting` temporarily flips the shared, session-scoped `mapdl._exited` flag to simulate a dead MAPDL instance, and was relying on an unconditional line at the end of the test body to reset it back to `False`.

If any assertion in the test failed (or the test was retried by `pytest-rerunfailures`, configured via `--reruns=1`) before reaching that reset line, `mapdl._exited` stayed `True` on the shared fixture. Every subsequent test's autouse `run_before_and_after_tests` fixture unconditionally asserts `mapdl.prep7()`, which immediately raises `MapdlExitedError` once `_exited` is stuck `True` — with no repair logic active when `PYMAPDL_DEBUG_TESTING=False` (the default in CI).

This was observed in CI job [`Local: v25.2-ubuntu-cicd / Test MAPDL locally`](https://github.com/ansys/pymapdl/actions/runs/31796423103/job/94755534892?pr=4709): `test_timeout_when_exiting[False]` errored at setup on rerun, then `test_cdread` errored identically right after, hitting `--maxfail=2` and aborting the whole test run.

## Fix

Wrap the test body in `try/finally` so `mapdl._exited = False` always runs, regardless of whether the test body raises or is retried, preventing the shared `mapdl` fixture from being left in a poisoned state.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>