### PR TITLE
ci: capture OOM/exit-code diagnostics for MAPDL remote containers

### DIFF
--- a/.ci/collect_mapdl_logs_remote.sh
+++ b/.ci/collect_mapdl_logs_remote.sh
@@ -51,7 +51,7 @@ ls -la
 docker ps > ./"$LOG_NAMES"/docker_ps_end.log && echo "Successfully printed the docker ps" || echo "Failed to print the docker ps"
 
 # Capture docker events (die/restart/oom) for post-mortem analysis of unexpected container restarts.
-docker events --since 1h --until "$(date +%Y-%m-%dT%H:%M:%S)" --filter "container=$MAPDL_INSTANCE" --filter "event=die" --filter "event=restart" --filter "event=oom" \
+docker events --since 1h --until "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --filter "container=$MAPDL_INSTANCE" --filter "event=die" --filter "event=restart" --filter "event=oom" \
     > ./"$LOG_NAMES"/docker_events.log 2>&1 && echo "Successfully collected docker events" || echo "Failed to collect docker events"
 
 ###############################################################################

--- a/.ci/collect_mapdl_logs_remote.sh
+++ b/.ci/collect_mapdl_logs_remote.sh
@@ -50,6 +50,10 @@ ls -la
 
 docker ps > ./"$LOG_NAMES"/docker_ps_end.log && echo "Successfully printed the docker ps" || echo "Failed to print the docker ps"
 
+# Capture docker events (die/restart/oom) for post-mortem analysis of unexpected container restarts.
+docker events --since 1h --until "$(date +%Y-%m-%dT%H:%M:%S)" --filter "container=$MAPDL_INSTANCE" --filter "event=die" --filter "event=restart" --filter "event=oom" \
+    > ./"$LOG_NAMES"/docker_events.log 2>&1 && echo "Successfully collected docker events" || echo "Failed to collect docker events"
+
 ###############################################################################
 echo "Collecting and printing logs..."
 mv ./*.log ./"$LOG_NAMES"/ && echo "Successfully moved log files." || echo "MAPDL run docker log not found."

--- a/.github/workflows/test-remote.yml
+++ b/.github/workflows/test-remote.yml
@@ -290,7 +290,7 @@ jobs:
         run: |
           echo "Searching dmesg/journal for OOM-killer activity (best effort, may be unavailable on hosted runners)..."
           (dmesg 2>/dev/null | grep -i -E "killed process|out of memory|oom" ) || echo "No OOM entries found in dmesg (or dmesg unavailable)."
-          (sudo journalctl -k --since "-30 min" 2>/dev/null | grep -i -E "killed process|out of memory|oom" ) || echo "No OOM entries found in journalctl (or journalctl unavailable)."
+          (sudo -n journalctl -k --since "-30 min" 2>/dev/null | grep -i -E "killed process|out of memory|oom" ) || echo "No OOM entries found in journalctl (or journalctl unavailable)."
 
       - name: "Upload pytest reports to GitHub"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1

--- a/.github/workflows/test-remote.yml
+++ b/.github/workflows/test-remote.yml
@@ -276,10 +276,21 @@ jobs:
           MAPDL_0: ${{ steps.mapdl_0.outputs.container-name }}
           MAPDL_1: ${{ steps.mapdl_1.outputs.container-name }}
         run: |
-          N_RESTART=$(docker inspect --format '{{ .RestartCount }}'  "${MAPDL_0}")
-          echo "Number of restarts in the MAPDL_0 container: $N_RESTART"
-          N_RESTART=$(docker inspect --format '{{ .RestartCount }}'  "${MAPDL_1}")
-          echo "Number of restarts in the MAPDL_1 container: $N_RESTART"
+          for CONTAINER in "${MAPDL_0}" "${MAPDL_1}"; do
+            N_RESTART=$(docker inspect --format '{{ .RestartCount }}' "${CONTAINER}")
+            OOM_KILLED=$(docker inspect --format '{{ .State.OOMKilled }}' "${CONTAINER}")
+            EXIT_CODE=$(docker inspect --format '{{ .State.ExitCode }}' "${CONTAINER}")
+            STATE_ERROR=$(docker inspect --format '{{ .State.Error }}' "${CONTAINER}")
+            FINISHED_AT=$(docker inspect --format '{{ .State.FinishedAt }}' "${CONTAINER}")
+            echo "Container ${CONTAINER}: restarts=$N_RESTART, OOMKilled=$OOM_KILLED, exit_code=$EXIT_CODE, state_error='$STATE_ERROR', last_finished_at=$FINISHED_AT"
+          done
+
+      - name: "Check for OOM kills in the kernel log"
+        if: always()
+        run: |
+          echo "Searching dmesg/journal for OOM-killer activity (best effort, may be unavailable on hosted runners)..."
+          (dmesg 2>/dev/null | grep -i -E "killed process|out of memory|oom" ) || echo "No OOM entries found in dmesg (or dmesg unavailable)."
+          (sudo journalctl -k --since "-30 min" 2>/dev/null | grep -i -E "killed process|out of memory|oom" ) || echo "No OOM entries found in journalctl (or journalctl unavailable)."
 
       - name: "Upload pytest reports to GitHub"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1

--- a/doc/changelog.d/4724.maintenance.md
+++ b/doc/changelog.d/4724.maintenance.md
@@ -1,0 +1,1 @@
+Capture OOM/exit-code diagnostics for MAPDL remote containers


### PR DESCRIPTION
## Context

While investigating an unrelated failure (`test_cuadratic_beam` erroring with a gRPC `TRANSIENT_FAILURE`/reconnect-exhaustion in the remote v24.2 job), the collected CI logs showed the `MAPDL_0` container had `RestartCount: 1`, and `docker ps` snapshots showed the container had only been "Up 19 seconds" despite being "Created 7 minutes ago" — i.e., it crashed and was auto-restarted mid-run, breaking the existing gRPC connection.

However, the current log collection did not capture *why* the container restarted (OOM kill vs. crash vs. something else), making root-causing these transient failures difficult after the fact.

## Change

Extends the remote workflow's log collection with lightweight diagnostics, no behavior change to tests:

- `Print amount of restarts` step now also reports, per container: `OOMKilled`, `ExitCode`, `State.Error`, and `FinishedAt`.
- New `Check for OOM kills in the kernel log` step greps `dmesg`/`journalctl -k` for OOM-killer activity (best effort; some hosted runners may not expose this).
- `.ci/collect_mapdl_logs_remote.sh` now also collects `docker events` (`die`/`restart`/`oom`) for the MAPDL container into `docker_events.log`, which is included in the existing log-display output.

## Why this matters

Next time a remote MAPDL container restarts mid-test-run, we should be able to confirm from the job log alone whether it was an OOM kill (and act on it, e.g. lowering `MEMORY_DB_MB`/`MEMORY_WORKSPACE_MB` or setting explicit container memory limits) or something else, instead of needing to manually reconstruct `docker inspect` state from partial artifacts after the container has already been replaced.

Follow-up to the investigation discussed on #4708/#4709; not a fix for the flake itself, purely diagnostic tooling.