### PR TITLE
fix: add job timeouts and thread-based pytest-timeout to prevent stuck CI jobs

### DIFF
--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -129,6 +129,11 @@ jobs:
   test-local:
     name: Test MAPDL locally
     runs-on: ${{ inputs.runner }}
+    # Safety net: successful runs typically take 15-20 minutes. Without this,
+    # a hung test (e.g. a VTK/Xvfb rendering deadlock that pytest-timeout
+    # cannot interrupt) can block the runner for up to GitHub's 360-minute
+    # default job timeout before anyone notices.
+    timeout-minutes: 60
     permissions:
       contents: read  # Needed to read repository contents for tests
       packages: read  # Needed to pull Docker images from GitHub packages

--- a/.github/workflows/test-remote.yml
+++ b/.github/workflows/test-remote.yml
@@ -74,6 +74,11 @@ jobs:
   test-remote:
     name: Test PyMAPDL with remote MAPDL instances
     runs-on: ubuntu-latest
+    # Safety net: successful runs typically take 10-15 minutes. Without this,
+    # a hung test (e.g. a VTK/Xvfb rendering deadlock that pytest-timeout
+    # cannot interrupt) can block the runner for up to GitHub's 360-minute
+    # default job timeout before anyone notices.
+    timeout-minutes: 60
     permissions:
       contents: read  # Needed to read repository contents for tests
       packages: read  # Needed to pull Docker images from GitHub packages

--- a/doc/changelog.d/4727.fixed.md
+++ b/doc/changelog.d/4727.fixed.md
@@ -1,0 +1,1 @@
+Add job timeouts and thread-based pytest-timeout to prevent stuck CI jobs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,12 @@ addopts = [
   "--reruns=1",
   "--strict-markers",
   "--timeout=180",
+  # The default "signal" method relies on SIGALRM being handled between
+  # Python bytecode instructions, so it can't interrupt a test stuck in a
+  # blocking native call (e.g. a VTK/Xvfb rendering deadlock), which can hang
+  # a CI job for hours instead of failing after --timeout. "thread" method
+  # dumps tracebacks and forces the process to exit when a test overruns.
+  "--timeout-method=thread",
   "-ra",
   "-vvv",
 ]


### PR DESCRIPTION
## Description

Investigated two unrelated PRs (#4722 and #4724) whose `Local: v25.1-ubuntu-cicd / Test MAPDL locally` job got stuck for ~2h47m and had to be cancelled manually:

- https://github.com/ansys/pymapdl/actions/runs/32002015639/job/95304391468?pr=4724
- https://github.com/ansys/pymapdl/actions/runs/32002722633/job/95306511508?pr=4722

Both hung in the **same step** (`Unit testing`), stuck in a PyVista/VTK plotting test in `tests/test_post.py::Test_static_solve` (`test_plot_voltage` / `test_plot_nodal_eqv_stress`), with **zero output** until manually cancelled. Since the two PRs are unrelated in content, this points to an infrastructure/flaky-rendering issue rather than a code regression.

### Root causes

1. `xvfb-run` + VTK off-screen rendering can deadlock in native X11/OpenGL code, which never returns control to Python.
2. `pytest-timeout`'s default `signal` method relies on `SIGALRM` being handled between Python bytecode instructions, so it can't interrupt a test stuck in a blocking native call. The configured `--timeout=180` never fired.
3. Neither `test-local.yml` nor `test-remote.yml` set `timeout-minutes` on their jobs, so GitHub Actions' 360-minute default job timeout was the only backstop, letting the job hang for hours before a human intervened.

### Fixes

- Add `timeout-minutes: 60` to the `test-local` and `test-remote` reusable workflow jobs. Successful runs typically take 10-20 minutes, so this leaves generous headroom while capping worst-case hangs.
- Switch `pytest-timeout` to `--timeout-method=thread` in `pyproject.toml`. This method dumps tracebacks and forces the process to exit when a test overruns, instead of relying on a signal that a blocked native call can swallow.

This doesn't fix the underlying VTK/Xvfb rendering deadlock itself (which appears to be an intermittent CI infrastructure issue), but it ensures future occurrences fail fast with diagnostics instead of silently blocking a runner for hours.

## Testing

- `uv run pre-commit run --all-files` passes.
- Validated workflow YAML and `pyproject.toml` syntax.
