### PR TITLE
fix: avoid deadlock closing MAPDL process pipes during exit

### DIFF
--- a/doc/changelog.d/4729.fixed.md
+++ b/doc/changelog.d/4729.fixed.md
@@ -1,0 +1,1 @@
+Avoid deadlock closing MAPDL process pipes during exit

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -2211,12 +2211,23 @@ class MapdlGrpc(MapdlBase):
                 self._log.debug(f"Error closing stdout file handle: {e}")
 
     def _terminate_process(self, process: subprocess.Popen) -> None:  # type: ignore[type-arg]
-        """Terminate *process*, close its pipes, and wait for it to exit.
+        """Terminate *process*, wait for it to exit, then close its pipes.
 
-        Sends ``SIGTERM``, explicitly closes ``stdout`` and ``stderr`` so any
-        PIPE-drainer threads unblock immediately, then waits up to 2 seconds
-        for the process to exit.  If it has not exited by then, ``SIGKILL`` is
-        sent and the wait is repeated.
+        Sends ``SIGTERM`` and waits up to 2 seconds for the process to exit.
+        If it has not exited by then, ``SIGKILL`` is sent and the wait is
+        repeated. The stdout/stderr PIPEs are only closed *after* the process
+        has exited (or the waits above have been exhausted), and that close
+        itself is bounded by a watchdog thread.
+
+        Notes
+        -----
+        Closing the PIPEs while the process (or one of its children — see
+        :meth:`_kill_child_processes`, which must run first) still holds the
+        write end open can deadlock: the PIPE-drainer thread is blocked
+        inside ``readline()`` holding the stream's internal lock, so
+        ``stream.close()`` from this thread blocks forever waiting on that
+        same lock instead of raising. Waiting for the process to exit first,
+        and bounding the close with a watchdog thread, prevents that hang.
 
         Parameters
         ----------
@@ -2231,8 +2242,6 @@ class MapdlGrpc(MapdlBase):
             self._log.debug("Sending SIGTERM to MAPDL process")
             process.terminate()
 
-        self._close_process_pipes(process)
-
         try:
             process.wait(timeout=2)
         except subprocess.TimeoutExpired:
@@ -2242,6 +2251,21 @@ class MapdlGrpc(MapdlBase):
                 process.wait(timeout=2)
             except subprocess.TimeoutExpired:
                 self._log.debug("Process did not exit after SIGKILL")
+
+        # Close the PIPEs on a daemon watchdog thread bounded to 5 seconds,
+        # instead of calling '_close_process_pipes' directly, so a close that
+        # unexpectedly blocks (for example, an untracked grandchild process
+        # still holding the write end open) cannot hang this thread forever.
+        closer = threading.Thread(
+            target=self._close_process_pipes, args=(process,), daemon=True
+        )
+        closer.start()
+        closer.join(timeout=5)
+        if closer.is_alive():
+            self._log.debug(
+                "Closing MAPDL process PIPEs did not complete in time; "
+                "continuing without waiting further."
+            )
 
     def _join_pipe_drainer_threads(self) -> None:
         """Join all PIPE-drainer threads, giving each up to 2 seconds.
@@ -2331,11 +2355,19 @@ class MapdlGrpc(MapdlBase):
         """
         self._log.debug("Closing processes")
         if self._local:
+            # Kill child processes *before* the main process. Child/grandchild
+            # processes (for example, MAPDL's distributed/MPI workers) can
+            # inherit the stdout/stderr PIPE write ends. If they are still
+            # alive when '_kill_process' closes those PIPEs, the
+            # PIPE-drainer threads blocked in 'readline()' never see EOF, and
+            # 'stream.close()' deadlocks waiting on the same internal lock
+            # the reader thread holds. Killing every descendant first
+            # guarantees no process still holds the write end open, so
+            # closing the PIPEs cannot hang.
+            self._kill_child_processes(timeout=timeout)
+
             # killing main process (subprocess)
             self._kill_process()
-
-            # Killing child processes
-            self._kill_child_processes(timeout=timeout)
 
         if self.is_alive:
             raise MapdlRuntimeError("MAPDL could not be exited.")


### PR DESCRIPTION
## Description

Investigating a long thread-dump trace observed in CI (https://github.com/ansys/pymapdl/actions/runs/32033209663?pr=4709, job `Local: v26.1-ubuntu-cicd`), `tests/test_pool.py::TestMapdlPool::test_heal` hung for the full 3-minute `pytest-timeout` budget. The thread dump's `MainThread` stack showed it stuck at `stream.close()`:

```
tests/test_pool.py:166 test_heal
  pool[0].exit()
mapdl_grpc.py:1914 exit -> _release_resources
mapdl_grpc.py:2040 _release_resources -> _exit_mapdl
mapdl_grpc.py:1965 _exit_mapdl -> _close_process
mapdl_grpc.py:2351 _close_process -> _kill_process
mapdl_grpc.py:2304 _kill_process -> _terminate_process
mapdl_grpc.py:2250 _terminate_process -> _close_process_pipes
mapdl_grpc.py:2216 _close_process_pipes -> stream.close()
```

### Root cause

`_close_process` killed the main MAPDL process (which closes its stdout/stderr PIPEs) **before** killing child/grandchild processes. If MAPDL had spawned children that inherited the PIPE write ends, the PIPE-drainer threads (`enqueue_output`/`reader`) stayed blocked inside `readline()` (never seeing EOF), holding the stream's internal lock. `stream.close()`, called from a different thread, then deadlocks waiting on that same lock instead of raising — with no bound, since the pipe close itself has no timeout.

MAPDL normally exits in well under 10-20s; this deadlock made `exit()` hang indefinitely until the CI job's hard timeout killed the whole process.

### Fix

- Reorder `_close_process`: kill all child/grandchild processes **first**, then the main process, so no process still holds the PIPE write end open when it is closed.
- In `_terminate_process`: wait for the process to actually exit (SIGTERM -> SIGKILL) **before** closing its PIPEs, and bound the close itself with a 5s daemon watchdog thread as defense-in-depth against any remaining edge case.

## Testing

- `uv run pre-commit run --files src/ansys/mapdl/core/mapdl_grpc.py` passes.
- `uv run pytest tests/test_mapdl_grpc.py` (mock-based, no live MAPDL): all `TestTerminateProcess`, `TestKillProcess`, and `TestCloseProcessPipes` tests pass (40 passed; 2 unrelated pre-existing failures require a live MAPDL instance).
