### PR TITLE
fix: never tear down shared logger state from __del__

### DIFF
--- a/doc/changelog.d/4730.fixed.md
+++ b/doc/changelog.d/4730.fixed.md
@@ -1,0 +1,1 @@
+Never tear down shared logger state from __del__

--- a/src/ansys/mapdl/core/mapdl_core.py
+++ b/src/ansys/mapdl/core/mapdl_core.py
@@ -2541,11 +2541,18 @@ class _MapdlCore(Commands):
         raise NotImplementedError("Implemented by child class")
 
     def _cleanup_loggers(self):
-        """Clean up all the loggers"""
-        # Detached from ``__del__`` for easier testing
-        # if not hasattr(self, "_log"):
-        #     return  # Early exit if logger has been already cleaned.
+        """Clean up all the loggers.
 
+        Notes
+        -----
+        Only ever call this from the explicit, deterministic :meth:`exit`
+        path (through ``_release_resources(cleanup_loggers=True)``), never
+        from ``__del__``/garbage collection. This instance's logger and its
+        handlers are shared, process-wide ``logging`` state (see
+        :class:`ansys.mapdl.core.logging.Logger`), so closing them from
+        non-deterministic GC-driven code can race with another, still-alive
+        ``Mapdl`` instance still logging through the same handler.
+        """
         logger = self._log
         logger.setLevel(logging.CRITICAL + 1)
 

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -1966,7 +1966,9 @@ class MapdlGrpc(MapdlBase):
         else:
             self._exit_mapdl_server()
 
-    def _release_resources(self, path: Optional[str] = None) -> None:
+    def _release_resources(
+        self, path: Optional[str] = None, cleanup_loggers: bool = True
+    ) -> None:
         """Release all resources held by this MAPDL instance.
 
         This is the single, idempotent cleanup entry-point used by both
@@ -1984,7 +1986,7 @@ class MapdlGrpc(MapdlBase):
         7. Delete the remote PyMAPDL server instance (if applicable).
         8. Mark the instance as exited (``_exited = True``).
         9. Remove the temporary working directory (if ``remove_temp_dir_on_exit``).
-        10. Clean up logger handlers.
+        10. Clean up logger handlers (only when ``cleanup_loggers`` is ``True``).
 
         Parameters
         ----------
@@ -1992,6 +1994,20 @@ class MapdlGrpc(MapdlBase):
             Working directory to remove the lock file from and to delete when
             ``remove_temp_dir_on_exit`` is ``True``. The default is ``None``,
             in which case ``self._path`` is used.
+        cleanup_loggers : bool, optional
+            Whether to tear down this instance's logger handlers (step 10).
+            The default is ``True``, which is what :meth:`exit` uses since it
+            runs at a deterministic point chosen by the caller.
+
+            ``__del__`` passes ``False``: the ``pymapdl_global`` logger and
+            its handlers are shared, process-wide state (see
+            :class:`ansys.mapdl.core.logging.Logger`), and closing a handler
+            from garbage-collection-driven code can race with another,
+            still-alive ``Mapdl`` instance that logs through the same
+            handler — surfacing as ``ValueError: I/O operation on closed
+            file`` or ``AttributeError`` on ``self._log`` elsewhere. Shared,
+            non-exclusively-owned resources like the logger are only ever
+            released from the explicit, deterministic :meth:`exit` path.
 
         Returns
         -------
@@ -2091,11 +2107,17 @@ class MapdlGrpc(MapdlBase):
         except Exception as e:
             self._log.debug("Error removing temp dir: %s", e)
 
-        # 10. Clean up logger handlers
-        try:
-            self._cleanup_loggers()
-        except Exception as e:
-            self._log.debug("Error during logger cleanup: %s", e)
+        # 10. Clean up logger handlers.
+        # Skipped when called from ``__del__`` (``cleanup_loggers=False``):
+        # the logger and its handlers are shared, process-wide state, and
+        # tearing them down from non-deterministic, GC-driven code can race
+        # with another still-alive ``Mapdl`` instance logging through the
+        # same handler. See the ``cleanup_loggers`` parameter documentation.
+        if cleanup_loggers:
+            try:
+                self._cleanup_loggers()
+            except Exception as e:
+                self._log.debug("Error during logger cleanup: %s", e)
 
     def _close_grpc_channel(self) -> None:
         """Unsubscribe from and close the gRPC channel.
@@ -4520,6 +4542,18 @@ class MapdlGrpc(MapdlBase):
         early-return checks below, because it is a purely client-side resource
         whose ``_poll_connectivity`` daemon thread outlives this object
         otherwise.
+
+        ``_release_resources`` is called with ``cleanup_loggers=False``.
+        Unlike the gRPC channel or the MAPDL process, which this instance
+        exclusively owns, the logger and its handlers are shared, process-wide
+        state (see :class:`ansys.mapdl.core.logging.Logger`). Closing a
+        handler from here — non-deterministic, garbage-collection-driven code
+        that can run at any point, including while another ``Mapdl`` instance
+        is still logging through the same handler — is what causes errors
+        such as ``ValueError: I/O operation on closed file`` or
+        ``AttributeError`` on ``self._log`` elsewhere. Only :meth:`exit`,
+        which runs at a point deterministically chosen by the caller, is
+        allowed to tear down logging resources.
         """
         try:
             self._close_grpc_channel()
@@ -4545,7 +4579,7 @@ class MapdlGrpc(MapdlBase):
             return
 
         try:
-            self._release_resources(getattr(self, "_path", None))
+            self._release_resources(getattr(self, "_path", None), cleanup_loggers=False)
         except (
             Exception
         ):  # nosec B110 - best-effort cleanup during GC; logging is unreliable here

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -3256,6 +3256,67 @@ def test_del_honours_cleanup_on_exit_false():
     mapdl.__del__ = lambda: None  # prevent cleanup on GC
 
 
+@stack(*PATCH_MAPDL_START)
+def test_del_does_not_cleanup_loggers():
+    """``__del__`` must never tear down the (shared) logger.
+
+    The logger and its handlers are shared, process-wide ``logging`` state.
+    Closing them from garbage-collection-driven code can race with another,
+    still-alive ``Mapdl`` instance still logging through the same handler
+    (surfacing as ``ValueError: I/O operation on closed file`` or
+    ``AttributeError`` on ``self._log`` elsewhere). Only the explicit
+    :meth:`exit` path is allowed to release logging resources.
+    """
+    start_parm = {
+        "ip": "123.45.67.99",
+        "local": True,
+        "set_no_abort": False,
+        "launched": True,
+        "start_instance": True,
+        "transport_mode": "insecure",
+    }
+
+    mapdl = pymapdl.Mapdl(disable_run_at_connect=False, **start_parm)
+    mapdl._cleanup = True  # mirrors cleanup_on_exit=True regardless of env
+
+    with patch.object(mapdl, "_release_resources") as mock_release:
+        mapdl.__del__()
+
+    mock_release.assert_called_once()
+    _, kwargs = mock_release.call_args
+    assert kwargs.get("cleanup_loggers") is False
+
+    mapdl.__del__ = lambda: None  # prevent double cleanup on GC
+
+
+@stack(*PATCH_MAPDL_START)
+def test_exit_cleans_up_loggers_but_del_does_not():
+    """``exit()`` releases logger resources; ``__del__`` leaves them alone."""
+    from unittest.mock import MagicMock
+
+    start_parm = {
+        "ip": "123.45.67.99",
+        "local": True,
+        "set_no_abort": False,
+        "launched": True,
+        "start_instance": True,
+        "transport_mode": "insecure",
+    }
+
+    mapdl = pymapdl.Mapdl(disable_run_at_connect=False, **start_parm)
+    mapdl._channel = MagicMock()
+
+    with (
+        patch.object(mapdl, "_exit_mapdl"),
+        patch.object(mapdl, "_cleanup_loggers") as mock_loggers,
+    ):
+        mapdl.exit(force=True)
+
+    mock_loggers.assert_called_once()
+
+    mapdl.__del__ = lambda: None  # prevent cleanup on GC
+
+
 @pytest.mark.parametrize("prop", ["mute"])
 def test_muted(mapdl, prop):
     assert not mapdl.mute


### PR DESCRIPTION
## Summary

`__del__` runs as non-deterministic, garbage-collection-driven code and can fire while another `Mapdl` instance is still logging through the same shared `pymapdl_global` logger/handlers. This surfaces as `ValueError: I/O operation on closed file` or `AttributeError` on `self._log` during teardown, particularly under pytest where many `Mapdl` instances are created/destroyed in quick succession.

## Changes

- `_release_resources()` gains a `cleanup_loggers: bool = True` parameter. Step 10 (logger teardown) only runs when `True`.
- `exit()` keeps the default (`True`) — the explicit, deterministic path still cleans up loggers.
- `__del__()` now passes `cleanup_loggers=False` — GC-driven teardown only releases resources this instance exclusively owns (gRPC channel, process, threads) and leaves shared logging state alone.
- Docstrings on `_release_resources`, `__del__`, and `_cleanup_loggers` explain the rationale.
- Added `test_del_does_not_cleanup_loggers` and `test_exit_cleans_up_loggers_but_del_does_not` to lock in the behavior.

## Testing

- Targeted tests (`release_resources`, `del_`, `exit_is_idempotent`, `exit_cleans_up_loggers`) pass.
- `black`, `isort`, `flake8`, `mypy`, `numpydoc-validation`, `codespell`, `bandit` all pass via pre-commit.

## Notes

This does not yet address the underlying shallow-copy shared-stream issue in `Logger._make_child_logger` — it only ensures GC-driven teardown can no longer trigger the race. A deeper fix (private, non-shared per-instance streams) can follow if stream-related flakiness resurfaces on the explicit `exit()` path.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>