### PR TITLE
test: reduce test_licensing and test_grpc test times

### DIFF
--- a/doc/changelog.d/4733.test.md
+++ b/doc/changelog.d/4733.test.md
@@ -1,0 +1,1 @@
+Reduce test_licensing and test_grpc test times

--- a/tests/test_grpc.py
+++ b/tests/test_grpc.py
@@ -33,7 +33,7 @@ from unittest.mock import patch
 import grpc
 import pytest
 
-from ansys.mapdl.core import examples
+from ansys.mapdl.core import errors, examples
 from ansys.mapdl.core.common_grpc import DEFAULT_CHUNKSIZE
 from ansys.mapdl.core.errors import (
     MapdlCommandIgnoredError,
@@ -829,7 +829,7 @@ def test_subscribe_to_channel(mapdl, cleared):
 
 
 @requires("remote")
-def test_exception_message_length(mapdl, cleared):
+def test_exception_message_length(mapdl, cleared, monkeypatch):
     # This test does not fail if running on local
     channel = grpc.insecure_channel(
         mapdl._channel_str,
@@ -843,6 +843,13 @@ def test_exception_message_length(mapdl, cleared):
     mapdl2.prep7()
     mapdl2.dim("myarr", "", 1e5)
     mapdl2.vfill("myarr", "rand", 0, 1)  # filling array with random numbers
+
+    # 'protect_grpc' retries any 'grpc.RpcError' (including
+    # 'RESOURCE_EXHAUSTED', triggered below) up to 'N_ATTEMPTS' times with
+    # exponential backoff before it inspects the error code and raises.
+    # That backoff sums to several real seconds and is not what this test
+    # verifies, so it's skipped here.
+    monkeypatch.setattr(errors, "sleep", lambda *args, **kwargs: None)
 
     # Retrieving
     with pytest.raises(MapdlgRPCError, match="Received message larger than max"):
@@ -866,6 +873,12 @@ def test_generic_grpc_exception(monkeypatch, grpc_channel):
 
     # Monkey patch to raise the same issue.
     monkeypatch.setattr(mapdl, "prep7", _raise_error_code)
+
+    # Since 'mapdl' is not marked as exited yet, 'protect_grpc' retries up
+    # to 'N_ATTEMPTS' times with exponential backoff (summing to several
+    # real seconds) before giving up. The retry timing itself is not what
+    # this test verifies, so it's skipped here.
+    monkeypatch.setattr(errors, "sleep", lambda *args, **kwargs: None)
 
     with pytest.raises(
         MapdlRuntimeError, match="MAPDL server connection terminated unexpectedly while"

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -22,9 +22,11 @@
 
 """Test PyMAPDL license.py module."""
 
+import io
 import os
 import time
 import types
+from unittest.mock import patch
 
 import pytest
 
@@ -262,18 +264,67 @@ def test_check_license_file_exception(license_checker):
 
 
 @requires("ansys-tools-common")
-def test_license_wait():
-    license_checker = licensing.LicenseChecker()
-    assert not license_checker._lic_file_thread
-    assert not license_checker._checkout_thread
+def test_license_wait(tmpdir):
+    # This test exercises the real checkout/file-parsing logic in
+    # 'LicenseChecker' without depending on an actual license server or a
+    # real 'ansysli_util' binary. The slowness and high variability of this
+    # test used to come from 'subprocess.Popen' reaching out to a real (and
+    # possibly unavailable/slow) license server in '_checkout_license', and
+    # from polling for a real 'licdebug' file that may take a while to
+    # appear. Faking the subprocess response and pointing the checker at a
+    # controlled temporary file keeps the parsing/threading logic under
+    # test while making the test fast and deterministic.
+    tmp_file = tmpdir.join("licdebug.log")
+    fake_util_path = tmpdir.join("ansysli_util")
+    fake_util_path.write("")  # dummy file so 'os.path.isfile' succeeds
 
-    license_checker.start(checkout_license=True)
-    assert license_checker._lic_file_thread
-    assert license_checker._checkout_thread
+    class FakeProcess:
+        """Mimics the subprocess.Popen object returned by a license checkout."""
 
-    license_checker.wait()
-    assert license_checker._lic_file_thread
-    assert license_checker._checkout_thread
+        def __init__(self, output: str):
+            self.stdout = io.BytesIO(output.encode())
+
+    with (
+        patch.object(
+            licensing,
+            "get_ansys_license_debug_file_path",
+            return_value=str(tmpdir),
+        ),
+        patch.object(
+            licensing,
+            "get_ansys_license_debug_file_name",
+            return_value=os.path.basename(tmp_file),
+        ),
+        patch.object(
+            licensing,
+            "get_ansys_license_utility_path",
+            return_value=str(fake_util_path),
+        ),
+        patch.object(
+            licensing.subprocess,
+            "Popen",
+            return_value=FakeProcess(FAKE_CHECKOUT_SUCCESS),
+        ) as mock_popen,
+    ):
+        # Write the fake checkout log asynchronously so the license file
+        # thread has to actually poll and tail the file, like it would in
+        # production.
+        write_log(tmp_file)
+
+        license_checker = licensing.LicenseChecker()
+        assert not license_checker._lic_file_thread
+        assert not license_checker._checkout_thread
+
+        license_checker.start(checkout_license=True)
+        assert license_checker._lic_file_thread
+        assert license_checker._checkout_thread
+
+        license_checker.wait()
+        assert license_checker._lic_file_thread
+        assert license_checker._checkout_thread
+
+    assert license_checker.check()
+    mock_popen.assert_called()
 
 
 def test_license_check():


### PR DESCRIPTION
## Summary

Reduces the runtime of three slow tests in `tests/test_licensing.py` and `tests/test_grpc.py` without changing their pass/fail behavior or removing coverage.

## Changes

- `test_license_wait`: mocks `subprocess.Popen` and the license debug file path instead of hitting a real license server, while still exercising the real checkout/parsing logic through a controlled temp file.
- `test_generic_grpc_exception` / `test_exception_message_length`: skip the real exponential backoff sleep in `protect_grpc`'s retry loop (~6.2s), which was being incidentally exercised without adding any coverage.

## Impact

Verified against a live MAPDL container: combined runtime for these three tests dropped from 14.50s to 3.12s with identical pass/fail behavior.

## Validation

- Ran the targeted tests against a live MAPDL container before and after the change, confirming identical outcomes with reduced runtime.
