### PR TITLE
fix: serialize concurrent mesh cache gRPC calls with a shared lock

### DIFF
--- a/doc/changelog.d/4738.fixed.md
+++ b/doc/changelog.d/4738.fixed.md
@@ -1,0 +1,1 @@
+Serialize concurrent mesh cache gRPC calls with a shared lock

--- a/src/ansys/mapdl/core/mesh_grpc.py
+++ b/src/ansys/mapdl/core/mesh_grpc.py
@@ -79,12 +79,9 @@ class MeshGrpc:
 
         self._freeze_model = False
         self._ignore_cache_reset = False
-        # MAPDL serves one request at a time. '_update_cache' kicks off
-        # '_update_cache_element_desc', '_update_cache_nnum' and
-        # '_update_node_coord' in separate threads so callers can keep working
-        # while they run, but this single lock still serializes the gRPC call
-        # each one makes, so at most one request is ever in flight on the
-        # server, regardless of which thread is holding it.
+        # MAPDL serves one request at a time. Some mesh cache updates run in
+        # separate threads, but this lock serializes the gRPC requests issued by
+        # MeshGrpc (only one mesh-related request is in flight at a time).
         self._thread_lock_grpc = threading.Lock()
         self._reset_cache()
 

--- a/src/ansys/mapdl/core/mesh_grpc.py
+++ b/src/ansys/mapdl/core/mesh_grpc.py
@@ -79,8 +79,13 @@ class MeshGrpc:
 
         self._freeze_model = False
         self._ignore_cache_reset = False
-        self._thread_lock_nodes = threading.Lock()
-        self._thread_lock_elem = threading.Lock()
+        # MAPDL serves one request at a time. '_update_cache' kicks off
+        # '_update_cache_element_desc', '_update_cache_nnum' and
+        # '_update_node_coord' in separate threads so callers can keep working
+        # while they run, but this single lock still serializes the gRPC call
+        # each one makes, so at most one request is ever in flight on the
+        # server, regardless of which thread is holding it.
+        self._thread_lock_grpc = threading.Lock()
         self._reset_cache()
 
     def __repr__(self):
@@ -171,7 +176,9 @@ class MeshGrpc:
             with self._mapdl.save_selection:
                 self._mapdl.nsle("S", mute=True)
 
-                # not thread safe
+                # '_update_cache_elem' runs first and alone: it is not
+                # guarded by '_thread_lock_grpc' and must finish before the
+                # threads below start, otherwise it could race with them.
                 self._update_cache_elem()
 
                 threads = [
@@ -195,14 +202,15 @@ class MeshGrpc:
 
     @threaded
     def _update_cache_nnum(self):
-        if self._cache_nnum is None:
-            self.logger.debug("Updating nodes cache")
-            nnum = self._mapdl.get_array("NODE", item1="NLIST")
-            self._cache_nnum = nnum.astype(np.int32)
+        with self._thread_lock_grpc:
+            if self._cache_nnum is None:
+                self.logger.debug("Updating nodes cache")
+                nnum = self._mapdl.get_array("NODE", item1="NLIST")
+                self._cache_nnum = nnum.astype(np.int32)
 
-        if self._cache_nnum.size == 1:
-            if self._cache_nnum[0] == 0:
-                self._cache_nnum = np.empty(0, np.int32)
+            if self._cache_nnum.size == 1:
+                if self._cache_nnum[0] == 0:
+                    self._cache_nnum = np.empty(0, np.int32)
 
     @property
     def _nnum(self):
@@ -216,9 +224,10 @@ class MeshGrpc:
 
     @threaded
     def _update_cache_element_desc(self):
-        if self._cache_element_desc is None:
-            self.logger.debug("Updating elements (desc) cache")
-            self._cache_element_desc = self._load_element_types()
+        with self._thread_lock_grpc:
+            if self._cache_element_desc is None:
+                self.logger.debug("Updating elements (desc) cache")
+                self._cache_element_desc = self._load_element_types()
 
     @property
     def _ekey(self):
@@ -235,9 +244,9 @@ class MeshGrpc:
 
     @threaded
     def _update_node_coord(self):
-        # with self._thread_lock_nodes:
-        if self._node_coord is None:
-            self._node_coord = self._load_nodes()
+        with self._thread_lock_grpc:
+            if self._node_coord is None:
+                self._node_coord = self._load_nodes()
 
     @property
     def _ans_etype(self):


### PR DESCRIPTION
## Summary

`MeshGrpc._update_cache` starts three threads (`_update_cache_element_desc`, `_update_cache_nnum`, `_update_node_coord`) that each issue a gRPC call to MAPDL. MAPDL serves one request at a time, so overlapping these calls risked corrupting server-side state — a plausible trigger for a segmentation violation observed in `*VGET` during CI (see #4735 discussion).

The previous per-cache locks (`_thread_lock_nodes`, `_thread_lock_elem`) were dead code:
- `_thread_lock_nodes` was never actually acquired (the `with` statement was commented out).
- `_thread_lock_elem` was never referenced anywhere in the class.

So despite looking thread-safe, nothing was actually serializing these calls.

## Changes

- `src/ansys/mapdl/core/mesh_grpc.py`: replace the two dead locks with a single `_thread_lock_grpc`, acquired around each thread's gRPC call (`_update_cache_nnum`, `_update_cache_element_desc`, `_update_node_coord`). The three threads still run concurrently for any local, non-gRPC work, but at most one gRPC request is ever in flight on the MAPDL server at a time.
- Clarified the comment above `_update_cache_elem()`, which still runs first and unguarded (must finish before the threaded calls start).

This keeps the existing threaded design (as requested) instead of removing it, while fixing the actual race.

## Test plan

- [x] `uv run pre-commit run --files src/ansys/mapdl/core/mesh_grpc.py` passes
- [x] `PYMAPDL_START_INSTANCE=False uv run pytest tests/test_mesh_grpc.py` — 25 passed, no MAPDL launch required
