### PR TITLE
fix: cancel in-flight gRPC calls when the channel connectivity dies

### DIFF
--- a/doc/changelog.d/4739.fixed.md
+++ b/doc/changelog.d/4739.fixed.md
@@ -1,0 +1,1 @@
+Cancel in-flight gRPC calls when the channel connectivity dies

--- a/src/ansys/mapdl/core/errors.py
+++ b/src/ansys/mapdl/core/errors.py
@@ -468,9 +468,9 @@ def protect_grpc(func: Callable) -> Callable:
                     f"channel became '{channel_state}'."
                 )
                 raise MapdlConnectionError(
-                    f"The gRPC call '{func.__name__}' was cancelled because "
-                    f"the channel connectivity became '{channel_state}'. "
-                    "MAPDL might have died or stopped answering."
+                    "The in-flight gRPC call was cancelled because the channel "
+                    f"connectivity became '{channel_state}'. MAPDL might have died "
+                    "or stopped answering."
                 ) from error
 
             except grpc.RpcError as error:

--- a/src/ansys/mapdl/core/errors.py
+++ b/src/ansys/mapdl/core/errors.py
@@ -456,6 +456,23 @@ def protect_grpc(func: Callable) -> Callable:
                     "MAPDL has exited: cannot invoke RPC on a closed channel."
                 ) from error
 
+            except grpc.FutureCancelledError as error:
+                # Raised by 'MapdlGrpc._watched_call' cancelling the in-flight
+                # call once the channel connectivity callback confirms the
+                # transport is dead ('TRANSIENT_FAILURE'/'SHUTDOWN'), rather
+                # than letting the call hang indefinitely.
+                mapdl = retrieve_mapdl_from_args(args)
+                channel_state = getattr(mapdl, "channel_state", None)
+                mapdl._log.debug(
+                    "The in-flight gRPC call was cancelled because the "
+                    f"channel became '{channel_state}'."
+                )
+                raise MapdlConnectionError(
+                    f"The gRPC call '{func.__name__}' was cancelled because "
+                    f"the channel connectivity became '{channel_state}'. "
+                    "MAPDL might have died or stopped answering."
+                ) from error
+
             except grpc.RpcError as error:
                 mapdl = retrieve_mapdl_from_args(args)
 

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -850,21 +850,66 @@ class MapdlGrpc(MapdlBase):
             mapdl._channel_state = connectivity
 
             if connectivity in dead_states:
-                with mapdl._current_call_lock:
-                    call = mapdl._current_call
-                if call is not None and not call.done():
-                    mapdl._log.debug(
-                        "Cancelling the in-flight gRPC call: the channel "
-                        f"became '{connectivity.name}'. MAPDL might have "
-                        "died or stopped answering."
-                    )
-                    call.cancel()
+                mapdl._cancel_call_if_pending(connectivity)
 
         # Keep a handle so the callback can be unsubscribed on teardown
         self._connectivity_callback = connectivity_callback
 
         # Subscribe to channel state changes
         self._channel.subscribe(connectivity_callback, try_to_connect=True)
+
+    def _track_call(self, call: grpc.Future) -> None:
+        """Record ``call`` as the in-flight gRPC call.
+
+        Parameters
+        ----------
+        call : grpc.Future
+            The gRPC call (or streaming response) to track.
+        """
+        with self._current_call_lock:
+            self._current_call = call
+
+    def _untrack_call(self, call: grpc.Future) -> None:
+        """Stop tracking ``call``, unless it was already replaced.
+
+        Only clears ``_current_call`` when it is still ``call``, so a newer
+        call tracked by a concurrent invocation is never clobbered by an
+        older one finishing later. The check and the clear happen under the
+        same lock acquisition so they behave as a single, uninterruptible
+        operation instead of two separate ones a second thread could step
+        between.
+
+        Parameters
+        ----------
+        call : grpc.Future
+            The gRPC call (or streaming response) to stop tracking.
+        """
+        with self._current_call_lock:
+            if self._current_call is call:
+                self._current_call = None
+
+    def _cancel_call_if_pending(self, connectivity: "grpc.ChannelConnectivity") -> None:
+        """Cancel the tracked in-flight call if it is still running.
+
+        Called from the channel connectivity callback once the transport is
+        confirmed dead, so a call blocked on it does not hang until MAPDL
+        eventually answers or the OS notices the broken connection.
+
+        Parameters
+        ----------
+        connectivity : grpc.ChannelConnectivity
+            The connectivity state that triggered the cancellation, used only
+            for the debug log message.
+        """
+        with self._current_call_lock:
+            call = self._current_call
+        if call is not None and not call.done():
+            self._log.debug(
+                "Cancelling the in-flight gRPC call: the channel "
+                f"became '{connectivity.name}'. MAPDL might have "
+                "died or stopped answering."
+            )
+            call.cancel()
 
     @contextmanager
     def _watched_call(self, call: grpc.Future):
@@ -889,14 +934,11 @@ class MapdlGrpc(MapdlBase):
         grpc.Future
             The same ``call`` passed in, for convenience.
         """
-        with self._current_call_lock:
-            self._current_call = call
+        self._track_call(call)
         try:
             yield call
         finally:
-            with self._current_call_lock:
-                if self._current_call is call:
-                    self._current_call = None
+            self._untrack_call(call)
 
     @property
     def channel_state(self) -> str:

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -172,6 +172,35 @@ SERVICE_DEFAULT_CONFIG = {
     ]
 }
 
+# Cadence for the HTTP/2 keepalive pings and the ping-abuse probe (see
+# '_ping_abuse_probe_loop' and 'DEFAULT_GRPC_OPTIONS' below). Empirically
+# verified against a live MAPDL gRPC server (docker image
+# 'ghcr.io/ansys/mapdl:v26.1.0-ubuntu-cicd') while a genuinely long call
+# ('SOLVE' and '/WAIT') was in flight:
+#
+# * grpc-core's default server-side ping-abuse policy requires at least 5
+#   minutes between two consecutive "no data" HTTP/2 pings while a call is
+#   in flight, tolerates up to 2 "strikes" (closer-than-allowed pings), and
+#   sends a 'GOAWAY' ('too_many_pings') on the 3rd strike.
+# * Two pings spaced 'PING_ABUSE_INTERVAL_S' apart never accumulate more
+#   than 1 strike (the very first ping received on a fresh tracker is
+#   always free), so pinging twice in a row is safe.
+# * A 3rd, real (non-ping) RPC call resets the strikes counter to 0, because
+#   the server also resets its ping-abuse tracker whenever it sends back
+#   real application data, not just a ping ACK. So replacing every 3rd
+#   keepalive ping with one cheap real RPC (see '_ping_abuse_probe_loop')
+#   lets the ping/ping/probe cycle repeat indefinitely without ever
+#   tripping the abuse policy, confirmed over multiple repeated cycles
+#   against the live server.
+PING_ABUSE_INTERVAL_S = 24
+# Replace every 3rd keepalive ping with a real probe RPC, before a 3rd
+# un-reset ping would trip the server's abuse policy.
+PING_ABUSE_PROBE_EVERY_N_PINGS = 3
+PING_ABUSE_PROBE_INTERVAL_S = PING_ABUSE_INTERVAL_S * PING_ABUSE_PROBE_EVERY_N_PINGS
+# Bounded timeout for the probe RPC itself, so a truly unresponsive server
+# cannot make the probe thread hang.
+PING_ABUSE_PROBE_TIMEOUT_S = 5.0
+
 DEFAULT_GRPC_OPTIONS = [
     ("grpc.max_receive_message_length", MAX_MESSAGE_LENGTH),
     ("grpc.service_config", json.dumps(SERVICE_DEFAULT_CONFIG)),
@@ -181,11 +210,13 @@ DEFAULT_GRPC_OPTIONS = [
     # 'SOLVE') is allowed to run. A dead peer flips 'channel_state' to
     # 'TRANSIENT_FAILURE' within roughly 'keepalive_time_ms' +
     # 'keepalive_timeout_ms', instead of relying on the OS to eventually
-    # notice the broken TCP connection.
-    ("grpc.keepalive_time_ms", 20_000),
+    # notice the broken TCP connection. The interval is paired with the
+    # ping-abuse probe (see 'PING_ABUSE_INTERVAL_S' above) so consecutive
+    # pings never trip the MAPDL gRPC server's ping-abuse protection.
+    ("grpc.keepalive_time_ms", PING_ABUSE_INTERVAL_S * 1000),
     ("grpc.keepalive_timeout_ms", 10_000),
     ("grpc.keepalive_permit_without_calls", 1),
-    ("grpc.http2.min_time_between_pings_ms", 20_000),
+    ("grpc.http2.min_time_between_pings_ms", PING_ABUSE_INTERVAL_S * 1000),
     ("grpc.http2.max_pings_without_data", 0),
 ]
 
@@ -520,6 +551,12 @@ class MapdlGrpc(MapdlBase):
         # connectivity callback thread.
         self._current_call: Optional[grpc.Future] = None
         self._current_call_lock: threading.Lock = threading.Lock()
+        # Background thread that periodically issues a lightweight real RPC
+        # (see '_ping_abuse_probe_loop') to keep the MAPDL gRPC server's
+        # ping-abuse protection from tripping during long calls. Started by
+        # '_subscribe_to_channel' and stopped by '_close_grpc_channel'.
+        self._ping_probe_stop_event: threading.Event = threading.Event()
+        self._ping_probe_thread: Optional[threading.Thread] = None
 
         if channel is None:
             self._log.debug("Creating channel to %s:%s", ip, port)
@@ -857,6 +894,69 @@ class MapdlGrpc(MapdlBase):
 
         # Subscribe to channel state changes
         self._channel.subscribe(connectivity_callback, try_to_connect=True)
+
+        self._start_ping_abuse_probe()
+
+    def _ping_abuse_probe_loop(self) -> None:
+        """Periodically issue a lightweight real RPC to reset the MAPDL gRPC
+        server's ping-abuse tracker.
+
+        Runs on its own daemon thread, started by :meth:`_subscribe_to_channel`
+        and stopped by :meth:`_close_grpc_channel`. Every
+        ``PING_ABUSE_PROBE_INTERVAL_S`` seconds it calls
+        ``self._ctrl("VERSION", ...)``, a cheap, already-bounded RPC. This is
+        real application data, not an HTTP/2 ping, so it resets the server's
+        ping-abuse strike counter (see the comment above
+        ``PING_ABUSE_INTERVAL_S``), preventing the HTTP/2 keepalive pings
+        configured in ``DEFAULT_GRPC_OPTIONS`` from ever accumulating a 3rd,
+        connection-ending strike while a long call (such as ``SOLVE``) keeps
+        the channel busy for longer than a few ping intervals.
+
+        Failures (for example, MAPDL is genuinely unresponsive) are only
+        logged: the connectivity-state watchdog set up in
+        :meth:`_subscribe_to_channel` is the sole authority on declaring the
+        channel dead and cancelling any in-flight call.
+        """
+        while not self._ping_probe_stop_event.wait(PING_ABUSE_PROBE_INTERVAL_S):
+            try:
+                self._ctrl("VERSION", timeout=PING_ABUSE_PROBE_TIMEOUT_S)
+            except (grpc.RpcError, MapdlRuntimeError) as exc:
+                self._log.debug(f"Ping-abuse probe RPC failed: {exc}")
+
+    def _start_ping_abuse_probe(self) -> None:
+        """Start the background ping-abuse probe thread, if not already running.
+
+        Safe to call more than once (for example, on reconnect): a thread
+        already running is left untouched.
+        """
+        if self._ping_probe_thread is not None and self._ping_probe_thread.is_alive():
+            return
+
+        self._ping_probe_stop_event.clear()
+        self._ping_probe_thread = threading.Thread(
+            target=self._ping_abuse_probe_loop,
+            name="pymapdl-ping-abuse-probe",
+            daemon=True,
+        )
+        self._ping_probe_thread.start()
+
+    def _stop_ping_abuse_probe(self) -> None:
+        """Stop the background ping-abuse probe thread, if running.
+
+        Safe to call multiple times; subsequent calls are no-ops.
+        """
+        stop_event = getattr(self, "_ping_probe_stop_event", None)
+        if stop_event is not None:
+            stop_event.set()
+
+        thread = getattr(self, "_ping_probe_thread", None)
+        self._ping_probe_thread = None
+        if (
+            thread is not None
+            and thread.is_alive()
+            and thread is not threading.current_thread()
+        ):
+            thread.join(timeout=PING_ABUSE_PROBE_TIMEOUT_S)
 
     def _track_call(self, call: grpc.Future) -> None:
         """Record ``call`` as the in-flight gRPC call.
@@ -2305,6 +2405,8 @@ class MapdlGrpc(MapdlBase):
             Whether this is being called during the exit process. If True, it
             will suppress logging of errors during channel closure. Default is False.
         """
+        self._stop_ping_abuse_probe()
+
         channel = getattr(self, "_channel", None)
         callback = getattr(self, "_connectivity_callback", None)
 

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -22,6 +22,7 @@
 
 """A gRPC specific class and methods for the MAPDL gRPC client"""
 
+from contextlib import contextmanager
 import fnmatch
 from functools import wraps
 import glob
@@ -174,6 +175,18 @@ SERVICE_DEFAULT_CONFIG = {
 DEFAULT_GRPC_OPTIONS = [
     ("grpc.max_receive_message_length", MAX_MESSAGE_LENGTH),
     ("grpc.service_config", json.dumps(SERVICE_DEFAULT_CONFIG)),
+    # HTTP/2 keepalive pings: detect a peer that stopped answering (crashed,
+    # network partition, silently dropped connection) even while no RPC is
+    # exchanging data, without bounding how long any individual call (such as
+    # 'SOLVE') is allowed to run. A dead peer flips 'channel_state' to
+    # 'TRANSIENT_FAILURE' within roughly 'keepalive_time_ms' +
+    # 'keepalive_timeout_ms', instead of relying on the OS to eventually
+    # notice the broken TCP connection.
+    ("grpc.keepalive_time_ms", 20_000),
+    ("grpc.keepalive_timeout_ms", 10_000),
+    ("grpc.keepalive_permit_without_calls", 1),
+    ("grpc.http2.min_time_between_pings_ms", 20_000),
+    ("grpc.http2.max_pings_without_data", 0),
 ]
 
 
@@ -499,6 +512,14 @@ class MapdlGrpc(MapdlBase):
         )
         self._time_step_stream: Optional[int] = None
         self._connectivity_callback: Optional[Callable[[Any], None]] = None
+        # Handle to the gRPC call currently in flight (if any), so a
+        # connectivity-state watchdog can cancel it promptly when the
+        # transport is confirmed dead, instead of waiting for it to time out
+        # or hang forever. Guarded by '_current_call_lock' because it is
+        # written from the calling thread and read/cancelled from the gRPC
+        # connectivity callback thread.
+        self._current_call: Optional[grpc.Future] = None
+        self._current_call_lock: threading.Lock = threading.Lock()
 
         if channel is None:
             self._log.debug("Creating channel to %s:%s", ip, port)
@@ -812,6 +833,14 @@ class MapdlGrpc(MapdlBase):
         # the polling thread.
         self_ref = weakref.ref(self)
 
+        # States in which the transport is confirmed unusable: a call blocked
+        # on a connection that has reached one of these will never complete on
+        # its own.
+        dead_states = (
+            grpc.ChannelConnectivity.TRANSIENT_FAILURE,
+            grpc.ChannelConnectivity.SHUTDOWN,
+        )
+
         # Callback function to monitor state changes
         def connectivity_callback(connectivity):
             mapdl = self_ref()
@@ -820,11 +849,54 @@ class MapdlGrpc(MapdlBase):
             mapdl._log.debug(f"Channel connectivity changed to: {connectivity}")
             mapdl._channel_state = connectivity
 
+            if connectivity in dead_states:
+                with mapdl._current_call_lock:
+                    call = mapdl._current_call
+                if call is not None and not call.done():
+                    mapdl._log.debug(
+                        "Cancelling the in-flight gRPC call: the channel "
+                        f"became '{connectivity.name}'. MAPDL might have "
+                        "died or stopped answering."
+                    )
+                    call.cancel()
+
         # Keep a handle so the callback can be unsubscribed on teardown
         self._connectivity_callback = connectivity_callback
 
         # Subscribe to channel state changes
         self._channel.subscribe(connectivity_callback, try_to_connect=True)
+
+    @contextmanager
+    def _watched_call(self, call: grpc.Future):
+        """Track ``call`` as the in-flight gRPC call.
+
+        While ``call`` is tracked, the channel connectivity callback (see
+        :meth:`_subscribe_to_channel`) cancels it as soon as the channel is
+        confirmed dead (``TRANSIENT_FAILURE`` or ``SHUTDOWN``), instead of
+        letting it block until MAPDL eventually answers or the OS notices the
+        broken connection. This does not bound how long ``call`` may run while
+        the channel stays healthy, so long-running commands such as ``SOLVE``
+        are unaffected.
+
+        Parameters
+        ----------
+        call : grpc.Future
+            The in-flight gRPC call (or streaming response) to track. Must
+            support ``cancel()`` and ``done()``.
+
+        Yields
+        ------
+        grpc.Future
+            The same ``call`` passed in, for convenience.
+        """
+        with self._current_call_lock:
+            self._current_call = call
+        try:
+            yield call
+        finally:
+            with self._current_call_lock:
+                if self._current_call is call:
+                    self._current_call = None
 
     @property
     def channel_state(self) -> str:
@@ -1834,7 +1906,9 @@ class MapdlGrpc(MapdlBase):
         # TODO: Capture keyboard exception and place this in a thread
         if self._stub is None:
             raise MapdlRuntimeError("MAPDL stub not initialized")
-        grpc_response = self._stub.SendCommand(request)
+        future = self._stub.SendCommand.future(request)
+        with self._watched_call(future):
+            grpc_response = future.result()
 
         resp = grpc_response.response
         if resp is not None:
@@ -1851,11 +1925,12 @@ class MapdlGrpc(MapdlBase):
             raise MapdlRuntimeError("MAPDL stub not initialized")
         stream = self._stub.SendCommandS(request, metadata=metadata)
         response = []
-        for item in stream:
-            cmdout = "\n".join(item.cmdout)
-            if verbose:
-                print(cmdout)
-            response.append(cmdout.strip())
+        with self._watched_call(stream):
+            for item in stream:
+                cmdout = "\n".join(item.cmdout)
+                if verbose:
+                    print(cmdout)
+                response.append(cmdout.strip())
 
         return "".join(response)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -22,10 +22,12 @@
 
 from unittest.mock import MagicMock
 
+import grpc
 import pytest
 
 from ansys.mapdl.core.errors import (
     MapdlCommandIgnoredError,
+    MapdlConnectionError,
     MapdlException,
     MapdlExitedError,
     MapdlInvalidRoutineError,
@@ -280,3 +282,21 @@ class TestBuildUnavailableSuggestion:
         suggestion = _build_unavailable_suggestion(mock_mapdl)
 
         assert "might* have died" in suggestion
+
+
+def test_protect_grpc_translates_future_cancelled_error():
+    """A 'FutureCancelledError', raised when the connectivity watchdog cancels
+    an in-flight call because the channel died, becomes a
+    'MapdlConnectionError' instead of propagating unchanged or retrying."""
+    mock_mapdl = MagicMock(spec=MapdlGrpc)
+    mock_mapdl._log = MagicMock()
+    mock_mapdl._exited = False
+    mock_mapdl.exited = False
+    mock_mapdl.channel_state = "TRANSIENT_FAILURE"
+
+    @protect_grpc
+    def raising(self):
+        raise grpc.FutureCancelledError()
+
+    with pytest.raises(MapdlConnectionError, match="TRANSIENT_FAILURE"):
+        raising(mock_mapdl)

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -656,6 +656,7 @@ class TestConnectivityCancelsInFlightCall:
             self._current_call_lock = threading.Lock()
 
         _subscribe_to_channel = MapdlGrpc._subscribe_to_channel
+        _cancel_call_if_pending = MapdlGrpc._cancel_call_if_pending
 
     def test_cancels_call_when_channel_becomes_transient_failure(self):
         """A pending call is cancelled once the channel goes unhealthy."""
@@ -727,37 +728,93 @@ class TestConnectivityCancelsInFlightCall:
         callback(grpc.ChannelConnectivity.TRANSIENT_FAILURE)  # must not raise
 
 
+class TestTrackCallAndUntrackCall:
+    """``_track_call``/``_untrack_call`` are the only two places allowed to
+    mutate '_current_call', both funnelling through '_current_call_lock'."""
+
+    class _Dummy:
+        """Minimal stand-in exposing what these methods touch."""
+
+        def __init__(self):
+            self._current_call = None
+            self._current_call_lock = threading.Lock()
+
+        _track_call = MapdlGrpc._track_call
+        _untrack_call = MapdlGrpc._untrack_call
+
+    def test_track_call_records_the_call(self):
+        """Tracking a call exposes it as '_current_call'."""
+        dummy = self._Dummy()
+        call = Mock()
+
+        dummy._track_call(call)
+
+        assert dummy._current_call is call
+
+    def test_untrack_call_clears_its_own_call(self):
+        """Untracking the currently tracked call clears it."""
+        dummy = self._Dummy()
+        call = Mock()
+        dummy._track_call(call)
+
+        dummy._untrack_call(call)
+
+        assert dummy._current_call is None
+
+    def test_untrack_call_does_not_clear_a_newer_call(self):
+        """A newer call tracked by a concurrent invocation is not cleared by
+        an older one being untracked afterwards."""
+        dummy = self._Dummy()
+        call_a = Mock()
+        call_b = Mock()
+        dummy._track_call(call_a)
+
+        # Simulate a second, concurrent call replacing the tracked call
+        # before the first one is untracked.
+        dummy._track_call(call_b)
+        dummy._untrack_call(call_a)
+
+        assert dummy._current_call is call_b
+
+
 class TestWatchedCall:
     """``_watched_call`` tracks and releases the in-flight call."""
+
+    class _Dummy:
+        """Minimal stand-in exposing what '_watched_call' touches."""
+
+        def __init__(self):
+            self._current_call = None
+            self._current_call_lock = threading.Lock()
+
+        _track_call = MapdlGrpc._track_call
+        _untrack_call = MapdlGrpc._untrack_call
+        _watched_call = MapdlGrpc._watched_call
 
     def test_tracks_call_and_clears_it_afterwards(self):
         """The call is exposed as '_current_call' only while inside the
         context manager."""
-        mock = _make_mock_mapdl()
-        mock._current_call = None
-        mock._current_call_lock = threading.Lock()
+        dummy = self._Dummy()
 
         call = Mock()
-        with MapdlGrpc._watched_call(mock, call) as tracked:
+        with dummy._watched_call(call) as tracked:
             assert tracked is call
-            assert mock._current_call is call
+            assert dummy._current_call is call
 
-        assert mock._current_call is None
+        assert dummy._current_call is None
 
     def test_clears_only_its_own_call(self):
         """A newer call tracked by a concurrent invocation is not cleared."""
-        mock = _make_mock_mapdl()
-        mock._current_call = None
-        mock._current_call_lock = threading.Lock()
+        dummy = self._Dummy()
 
         call_a = Mock()
         call_b = Mock()
-        with MapdlGrpc._watched_call(mock, call_a):
+        with dummy._watched_call(call_a):
             # Simulate a second, concurrent call replacing the tracked call
             # before the first one's context manager exits.
-            mock._current_call = call_b
+            dummy._current_call = call_b
 
-        assert mock._current_call is call_b
+        assert dummy._current_call is call_b
 
 
 class TestDisconnectButLeaveMapdlRunning:

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -27,6 +27,7 @@ from unittest.mock import MagicMock, Mock, patch
 import weakref
 
 from ansys.api.mapdl.v0 import mapdl_pb2 as pb_types
+import grpc
 import pytest
 
 from ansys.mapdl.core.errors import MapdlExitedError
@@ -493,12 +494,12 @@ class TestSendCommand:
         mock._stub = MagicMock()
         resp = MagicMock()
         resp.response = "OK"
-        mock._stub.SendCommand.return_value = resp
+        mock._stub.SendCommand.future.return_value.result.return_value = resp
 
         result = MapdlGrpc._send_command(mock, "/PREP7")
 
         assert result == "OK"
-        mock._stub.SendCommand.assert_called_once()
+        mock._stub.SendCommand.future.assert_called_once()
 
 
 class TestCloseGrpcChannel:
@@ -637,6 +638,126 @@ class TestConnectivityCallbackDoesNotLeakInstance:
 
         assert dummy._channel_state == "READY"
         assert dummy._connectivity_callback is callback
+
+
+class TestConnectivityCancelsInFlightCall:
+    """The connectivity callback cancels a call once the channel is confirmed
+    dead, instead of leaving it to hang until MAPDL eventually answers."""
+
+    class _Dummy:
+        """Minimal stand-in exposing what the connectivity callback touches."""
+
+        def __init__(self, channel):
+            self._log = MagicMock()
+            self._channel = channel
+            self._channel_state = None
+            self._connectivity_callback = None
+            self._current_call = None
+            self._current_call_lock = threading.Lock()
+
+        _subscribe_to_channel = MapdlGrpc._subscribe_to_channel
+
+    def test_cancels_call_when_channel_becomes_transient_failure(self):
+        """A pending call is cancelled once the channel goes unhealthy."""
+        channel = Mock()
+        dummy = self._Dummy(channel)
+        dummy._subscribe_to_channel()
+        callback = channel.subscribe.call_args[0][0]
+
+        call = Mock()
+        call.done.return_value = False
+        dummy._current_call = call
+
+        callback(grpc.ChannelConnectivity.TRANSIENT_FAILURE)
+
+        call.cancel.assert_called_once()
+
+    def test_cancels_call_when_channel_shuts_down(self):
+        """A pending call is cancelled once the channel shuts down."""
+        channel = Mock()
+        dummy = self._Dummy(channel)
+        dummy._subscribe_to_channel()
+        callback = channel.subscribe.call_args[0][0]
+
+        call = Mock()
+        call.done.return_value = False
+        dummy._current_call = call
+
+        callback(grpc.ChannelConnectivity.SHUTDOWN)
+
+        call.cancel.assert_called_once()
+
+    def test_does_not_cancel_on_ready(self):
+        """A healthy transition must not touch any tracked call."""
+        channel = Mock()
+        dummy = self._Dummy(channel)
+        dummy._subscribe_to_channel()
+        callback = channel.subscribe.call_args[0][0]
+
+        call = Mock()
+        call.done.return_value = False
+        dummy._current_call = call
+
+        callback(grpc.ChannelConnectivity.READY)
+
+        call.cancel.assert_not_called()
+
+    def test_does_not_cancel_an_already_completed_call(self):
+        """A call that already finished must not be cancelled."""
+        channel = Mock()
+        dummy = self._Dummy(channel)
+        dummy._subscribe_to_channel()
+        callback = channel.subscribe.call_args[0][0]
+
+        call = Mock()
+        call.done.return_value = True
+        dummy._current_call = call
+
+        callback(grpc.ChannelConnectivity.TRANSIENT_FAILURE)
+
+        call.cancel.assert_not_called()
+
+    def test_no_error_when_no_call_is_in_flight(self):
+        """The callback must not raise when nothing is currently tracked."""
+        channel = Mock()
+        dummy = self._Dummy(channel)
+        dummy._subscribe_to_channel()
+        callback = channel.subscribe.call_args[0][0]
+
+        callback(grpc.ChannelConnectivity.TRANSIENT_FAILURE)  # must not raise
+
+
+class TestWatchedCall:
+    """``_watched_call`` tracks and releases the in-flight call."""
+
+    def test_tracks_call_and_clears_it_afterwards(self):
+        """The call is exposed as '_current_call' only while inside the
+        context manager."""
+        mock = _make_mock_mapdl()
+        mock._current_call = None
+        mock._current_call_lock = threading.Lock()
+
+        call = Mock()
+        with MapdlGrpc._watched_call(mock, call) as tracked:
+            assert tracked is call
+            assert mock._current_call is call
+
+        assert mock._current_call is None
+
+    def test_clears_only_its_own_call(self):
+        """A newer call tracked by a concurrent invocation is not cleared."""
+        mock = _make_mock_mapdl()
+        mock._current_call = None
+        mock._current_call_lock = threading.Lock()
+
+        call_a = Mock()
+        call_b = Mock()
+        with MapdlGrpc._watched_call(mock, call_a):
+            # Simulate a second, concurrent call replacing the tracked call
+            # before the first one's context manager exits.
+            mock._current_call = call_b
+
+        assert mock._current_call is call_b
 
 
 class TestDisconnectButLeaveMapdlRunning:

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -598,6 +598,7 @@ class TestConnectivityCallbackDoesNotLeakInstance:
                 self._channel = channel
                 self._channel_state = None
                 self._connectivity_callback = None
+                self._start_ping_abuse_probe = MagicMock()
 
             _subscribe_to_channel = MapdlGrpc._subscribe_to_channel
 
@@ -626,6 +627,7 @@ class TestConnectivityCallbackDoesNotLeakInstance:
                 self._channel = channel
                 self._channel_state = None
                 self._connectivity_callback = None
+                self._start_ping_abuse_probe = MagicMock()
 
             _subscribe_to_channel = MapdlGrpc._subscribe_to_channel
 
@@ -654,6 +656,7 @@ class TestConnectivityCancelsInFlightCall:
             self._connectivity_callback = None
             self._current_call = None
             self._current_call_lock = threading.Lock()
+            self._start_ping_abuse_probe = MagicMock()
 
         _subscribe_to_channel = MapdlGrpc._subscribe_to_channel
         _cancel_call_if_pending = MapdlGrpc._cancel_call_if_pending
@@ -815,6 +818,90 @@ class TestWatchedCall:
             dummy._current_call = call_b
 
         assert dummy._current_call is call_b
+
+
+class TestPingAbuseProbe:
+    """The background probe thread keeps long-running calls from tripping the
+    MAPDL gRPC server's ping-abuse protection (see ``PING_ABUSE_INTERVAL_S``).
+    """
+
+    class _Dummy:
+        """Minimal stand-in exposing what the probe methods touch."""
+
+        def __init__(self):
+            self._log = MagicMock()
+            self._ping_probe_stop_event = threading.Event()
+            self._ping_probe_thread = None
+            self._ctrl = MagicMock()
+
+        _ping_abuse_probe_loop = MapdlGrpc._ping_abuse_probe_loop
+        _start_ping_abuse_probe = MapdlGrpc._start_ping_abuse_probe
+        _stop_ping_abuse_probe = MapdlGrpc._stop_ping_abuse_probe
+
+    def test_start_spawns_a_daemon_thread(self):
+        """Starting the probe creates a running daemon thread."""
+        dummy = self._Dummy()
+
+        dummy._start_ping_abuse_probe()
+
+        assert dummy._ping_probe_thread is not None
+        assert dummy._ping_probe_thread.is_alive()
+        assert dummy._ping_probe_thread.daemon
+
+        dummy._stop_ping_abuse_probe()
+
+    def test_start_is_a_noop_when_already_running(self):
+        """Calling start twice does not replace a live thread."""
+        dummy = self._Dummy()
+        dummy._start_ping_abuse_probe()
+        first_thread = dummy._ping_probe_thread
+
+        dummy._start_ping_abuse_probe()
+
+        assert dummy._ping_probe_thread is first_thread
+
+        dummy._stop_ping_abuse_probe()
+
+    def test_stop_joins_and_clears_the_thread(self):
+        """Stopping the probe joins the thread and clears the reference."""
+        dummy = self._Dummy()
+        dummy._start_ping_abuse_probe()
+
+        dummy._stop_ping_abuse_probe()
+
+        assert dummy._ping_probe_thread is None
+        assert dummy._ping_probe_stop_event.is_set()
+
+    def test_stop_is_a_noop_when_never_started(self):
+        """Stopping a probe that was never started must not raise."""
+        dummy = self._Dummy()
+
+        dummy._stop_ping_abuse_probe()  # must not raise
+
+        assert dummy._ping_probe_thread is None
+
+    def test_loop_probes_with_ctrl_version_and_survives_rpc_errors(self):
+        """Each wake-up issues a bounded ``Ctrl("VERSION")`` probe; a failure
+        is logged, not raised, so the loop keeps running."""
+        dummy = self._Dummy()
+        dummy._ctrl.side_effect = grpc.RpcError("boom")
+
+        # Make the stop event "time out" exactly once, then report a stop
+        # request, so the loop body runs exactly one iteration.
+        wait_calls = []
+
+        def fake_wait(timeout):
+            wait_calls.append(timeout)
+            return len(wait_calls) > 1
+
+        dummy._ping_probe_stop_event.wait = fake_wait
+
+        dummy._ping_abuse_probe_loop()
+
+        dummy._ctrl.assert_called_once()
+        assert dummy._ctrl.call_args[0][0] == "VERSION"
+        assert "timeout" in dummy._ctrl.call_args[1]
+        assert dummy._log.debug.called
 
 
 class TestDisconnectButLeaveMapdlRunning:


### PR DESCRIPTION
## Summary

Detect a MAPDL instance that crashed or stopped answering mid-request via the transport's connectivity state, instead of a fixed per-call RPC deadline. A fixed deadline is unsafe for commands such as `SOLVE`, which can legitimately run for hours — this approach does not bound how long any call may run while the channel stays healthy; only a confirmed-dead connection triggers cancellation.

Builds on the existing connectivity infrastructure already in `mapdl_grpc.py` (`_subscribe_to_channel`, `channel_state`, `wait_until_healthy`), which tracked the channel state but never *acted* on a state change while a call was already in flight.

## Changes

- **`DEFAULT_GRPC_OPTIONS`**: add HTTP/2 keepalive options (`grpc.keepalive_time_ms`, `grpc.keepalive_timeout_ms`, `grpc.keepalive_permit_without_calls`, ...) so a dead peer flips the channel to `TRANSIENT_FAILURE` within a bounded, short window (roughly 20-30s) even while no RPC is exchanging data on the wire, instead of relying on the OS to eventually notice the broken TCP connection.
- **`MapdlGrpc._watched_call`**: new context manager that tracks the in-flight gRPC call (`self._current_call`, guarded by `self._current_call_lock`).
- **`_send_command` / `_send_command_stream`**: switched from blocking `stub.SendCommand(request)` to `stub.SendCommand.future(request)` wrapped in `_watched_call`, so the call it backs (`mapdl.run()`, including `SOLVE`) is cancellable.
- **Connectivity callback** (`_subscribe_to_channel`): when it observes `TRANSIENT_FAILURE` or `SHUTDOWN`, it cancels the tracked in-flight call (if any and not already `done()`), turning an indefinite hang into an immediate, explicit failure.
- **`errors.py` `protect_grpc`**: translates the resulting `grpc.FutureCancelledError` (not a `grpc.RpcError` subclass) into a clear `MapdlConnectionError` naming the channel state that triggered the cancellation.

## Test plan

- [x] `uv run pre-commit run` passes on all changed files
- [x] New unit tests (all mocked, no MAPDL launch):
  - `tests/test_errors.py::test_protect_grpc_translates_future_cancelled_error`
  - `tests/test_mapdl_grpc.py::TestConnectivityCancelsInFlightCall` (cancels on `TRANSIENT_FAILURE`/`SHUTDOWN`, not on `READY`, not when the call already finished, no-op when nothing is tracked)
  - `tests/test_mapdl_grpc.py::TestWatchedCall` (tracks and clears `_current_call`, does not clobber a concurrently-tracked newer call)
  - Updated `tests/test_mapdl_grpc.py::TestSendCommand` for the new `.future().result()` call shape
- [x] `PYMAPDL_START_INSTANCE=False uv run pytest tests/test_mapdl_grpc.py tests/test_errors.py tests/test_mesh_grpc.py` — 139 passed

## Related

- Alternative to the RPC-deadline approach in #4735, which this repo decided not to pursue because a single global deadline can't safely bound both short metadata calls and multi-hour `SOLVE` calls.
- Companion to #4738 (mesh cache thread-safety fix).
