### PR TITLE
refactor: expose click-independent functions for each pymapdl CLI command

### DIFF
--- a/doc/changelog.d/4746.miscellaneous.md
+++ b/doc/changelog.d/4746.miscellaneous.md
@@ -1,0 +1,1 @@
+Expose click-independent functions for each pymapdl CLI command

--- a/doc/source/api/cli.rst
+++ b/doc/source/api/cli.rst
@@ -1,0 +1,63 @@
+.. _ref_cli_api:
+
+Command line interface
+=======================
+
+Every ``pymapdl`` sub-command is a thin `Click <click_docs_>`_ wrapper
+(``<name>_cli``) around a plain function (``<name>``) that lives in the same
+module, for example :func:`ansys.mapdl.core.cli.stop.stop`. Import the plain
+function to get the behavior of a command from Python, without going through a
+shell.
+
+The plain functions return data and raise exceptions, they never print or
+exit the interpreter. For an introduction with examples, see
+:ref:`ref_cli_programmatic`.
+
+Manage instances
+-----------------
+
+.. autosummary::
+   :toctree: _autosummary
+
+   ansys.mapdl.core.cli.start.start
+   ansys.mapdl.core.cli.stop.stop
+   ansys.mapdl.core.cli.list_instances.list_instances
+   ansys.mapdl.core.cli.check.check
+   ansys.mapdl.core.cli.exec.exec_commands
+
+
+Convert and document APDL code
+--------------------------------
+
+.. autosummary::
+   :toctree: _autosummary
+
+   ansys.mapdl.core.cli.convert.convert
+   ansys.mapdl.core.cli.help.help_command
+
+
+Manage the bundled skills
+---------------------------
+
+.. autosummary::
+   :toctree: _autosummary
+
+   ansys.mapdl.core.cli.skills.list_skills
+   ansys.mapdl.core.cli.skills.show_skill
+   ansys.mapdl.core.cli.skills.plan_skill_install
+   ansys.mapdl.core.cli.skills.apply_skill_install
+   ansys.mapdl.core.cli.skills.install_skill
+
+
+Helpers
+--------
+
+.. autosummary::
+   :toctree: _autosummary
+
+   ansys.mapdl.core.cli.check.format_info
+   ansys.mapdl.core.cli.exec.resolve_command_block
+   ansys.mapdl.core.cli.convert.resolve_graphics_backend
+   ansys.mapdl.core.cli.helpers.connect_to_instance
+   ansys.mapdl.core.cli.helpers.get_mapdl_instances
+   ansys.mapdl.core.cli.helpers.silence_logging

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -18,6 +18,7 @@ PyMAPDL, see :ref:`ref_mapdl_commands`.
    :maxdepth: 2
    :hidden:
 
+   cli
    commands
    components
    database

--- a/doc/source/links.rst
+++ b/doc/source/links.rst
@@ -31,6 +31,7 @@
 
 .. #Other libraries
 .. _pyvista_docs: https://docs.pyvista.org/version/stable/
+.. _click_docs: https://click.palletsprojects.com/
 .. _jupyter: https://jupyter.org/
 .. _grpc: https://grpc.io/
 .. _pandas_org: https://pandas.pydata.org/

--- a/doc/source/user_guide/cli.rst
+++ b/doc/source/user_guide/cli.rst
@@ -578,3 +578,82 @@ To obtain help on converter usage, options, and examples, type this command:
 The ``pymapdl convert`` command uses the
 :func:`convert_script() <ansys.mapdl.core.convert_script>` function.
 Hence, this command accepts most of this function's arguments.
+
+
+.. _ref_cli_programmatic:
+
+Use the commands from Python
+============================
+
+Every ``pymapdl`` sub-command is a thin Click wrapper, named ``<name>_cli``,
+around a plain function named ``<name>`` that lives in the same module, for
+example :func:`ansys.mapdl.core.cli.stop.stop`. Import the plain function to
+get the same behavior from Python, which avoids spawning a shell and parsing
+text output:
+
+.. code:: python
+
+    from ansys.mapdl.core.cli.exec import exec_commands
+    from ansys.mapdl.core.cli.start import start
+    from ansys.mapdl.core.cli.stop import stop
+
+    ip, port, pid = start(port=50054, nproc=4)
+    print(exec_commands(commands=["/prep7", "BLOCK,0,1,0,1,0,1"], port=port))
+    stop(pid=pid)
+
+The mapping between commands and functions is direct. Each function takes the
+long form of the command options as keyword arguments:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Command
+     - Function
+   * - ``pymapdl start``
+     - :func:`start() <ansys.mapdl.core.cli.start.start>`
+   * - ``pymapdl stop``
+     - :func:`stop() <ansys.mapdl.core.cli.stop.stop>`
+   * - ``pymapdl list``
+     - :func:`list_instances() <ansys.mapdl.core.cli.list_instances.list_instances>`
+   * - ``pymapdl check``
+     - :func:`check() <ansys.mapdl.core.cli.check.check>`
+   * - ``pymapdl exec``
+     - :func:`exec_commands() <ansys.mapdl.core.cli.exec.exec_commands>`
+   * - ``pymapdl convert``
+     - :func:`convert() <ansys.mapdl.core.cli.convert.convert>`
+   * - ``pymapdl help``
+     - :func:`help_command() <ansys.mapdl.core.cli.help.help_command>`
+   * - ``pymapdl skills list``
+     - :func:`list_skills() <ansys.mapdl.core.cli.skills.list_skills>`
+   * - ``pymapdl skills show``
+     - :func:`show_skill() <ansys.mapdl.core.cli.skills.show_skill>`
+   * - ``pymapdl skills install``
+     - :func:`install_skill() <ansys.mapdl.core.cli.skills.install_skill>`
+
+These functions return data and raise exceptions, they never print to stdout
+nor exit the interpreter. Rendering and exit codes are the responsibility of
+the Click wrapper. So a failure surfaces as a regular Python exception that
+you can handle:
+
+.. code:: python
+
+    from ansys.mapdl.core.cli.check import check
+    from ansys.mapdl.core.errors import MapdlConnectionError
+
+    try:
+        info = check(port=50052)
+    except MapdlConnectionError:
+        print("No instance is running on port 50052.")
+    else:
+        print(info["information"]["mapdl_version"])
+
+Two functions return a string that is meant to be printed rather than parsed:
+:func:`list_instances() <ansys.mapdl.core.cli.list_instances.list_instances>`
+returns the rendered table, and :func:`help_command()
+<ansys.mapdl.core.cli.help.help_command>` returns the docstring with the ANSI
+escape sequences of a color terminal. To get the instances as data instead of a
+table, use :func:`get_mapdl_instances()
+<ansys.mapdl.core.cli.helpers.get_mapdl_instances>`.
+
+For the full signatures, see :ref:`ref_cli_api`.

--- a/src/ansys/mapdl/core/cli/__init__.py
+++ b/src/ansys/mapdl/core/cli/__init__.py
@@ -55,23 +55,23 @@ if _HAS_CLICK:
     def main(ctx: click.Context):
         pass
 
-    from ansys.mapdl.core.cli.check import check as check_cmd
-    from ansys.mapdl.core.cli.convert import convert as convert_cmd
-    from ansys.mapdl.core.cli.exec import exec_cmd
-    from ansys.mapdl.core.cli.help import help_cmd
-    from ansys.mapdl.core.cli.list_instances import list_instances
-    from ansys.mapdl.core.cli.skills import skills as skills_cmd
-    from ansys.mapdl.core.cli.start import start as start_cmd
-    from ansys.mapdl.core.cli.stop import stop as stop_cmd
+    from ansys.mapdl.core.cli.check import check_cli
+    from ansys.mapdl.core.cli.convert import convert_cli
+    from ansys.mapdl.core.cli.exec import exec_cli
+    from ansys.mapdl.core.cli.help import help_cli
+    from ansys.mapdl.core.cli.list_instances import list_instances_cli
+    from ansys.mapdl.core.cli.skills import skills as skills_cli
+    from ansys.mapdl.core.cli.start import start_cli
+    from ansys.mapdl.core.cli.stop import stop_cli
 
-    main.add_command(check_cmd, name="check")
-    main.add_command(convert_cmd, name="convert")
-    main.add_command(exec_cmd, name="exec")
-    main.add_command(help_cmd, name="help")
-    main.add_command(list_instances, name="list")
-    main.add_command(skills_cmd, name="skills")
-    main.add_command(start_cmd, name="start")
-    main.add_command(stop_cmd, name="stop")
+    main.add_command(check_cli, name="check")
+    main.add_command(convert_cli, name="convert")
+    main.add_command(exec_cli, name="exec")
+    main.add_command(help_cli, name="help")
+    main.add_command(list_instances_cli, name="list")
+    main.add_command(skills_cli, name="skills")
+    main.add_command(start_cli, name="start")
+    main.add_command(stop_cli, name="stop")
 
 
 else:

--- a/src/ansys/mapdl/core/cli/check.py
+++ b/src/ansys/mapdl/core/cli/check.py
@@ -20,9 +20,154 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""``pymapdl check`` sub-command implementation."""
+
 import sys
+from typing import Any, Callable, Dict, List
 
 import click
+
+from ansys.mapdl.core.cli.constants import (
+    DEFAULT_TIMEOUT,
+    MAPDL_DEFAULT_IP,
+    MAPDL_DEFAULT_PORT,
+)
+from ansys.mapdl.core.cli.helpers import connect_to_instance
+
+# Width of the key column of the human-readable report.
+_KEY_WIDTH = 24
+
+
+def check(
+    ip: str = MAPDL_DEFAULT_IP,
+    port: int = MAPDL_DEFAULT_PORT,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> Dict[str, Any]:
+    """Collect diagnostic information from a running MAPDL instance.
+
+    Parameters
+    ----------
+    ip : str, default: "127.0.0.1"
+        IP address of the MAPDL gRPC server.
+    port : int, default: 50052
+        Port of the MAPDL gRPC server.
+    timeout : int, default: 10
+        Seconds to wait when establishing the gRPC connection.
+
+    Returns
+    -------
+    dict
+        Nested dictionary with the ``connection``, ``information``,
+        ``geometry``, ``mesh``, and ``post_processing`` sections, as returned
+        by :func:`ansys.mapdl.core.information.get_mapdl_info`.
+
+    Raises
+    ------
+    MapdlConnectionError
+        When no MAPDL instance can be reached at the given address.
+
+    Examples
+    --------
+    Report the version of the instance running on the default port:
+
+    >>> from ansys.mapdl.core.cli.check import check
+    >>> check()["information"]["mapdl_version"]
+    '2021 R2'
+
+    """
+    from ansys.mapdl.core.information import get_mapdl_info
+
+    mapdl = connect_to_instance(ip=ip, port=port, timeout=timeout)
+    return get_mapdl_info(mapdl)
+
+
+def format_info(data: Dict[str, Any], style: Callable[[str], str] = str) -> str:
+    """Render the output of :func:`check` as a human-readable report.
+
+    Parameters
+    ----------
+    data : dict
+        Nested dictionary as returned by :func:`check`.
+    style : callable, default: str
+        Callable applied to every section title, used to highlight them. The
+        default leaves the titles unchanged.
+
+    Returns
+    -------
+    str
+        Multi-line report ready to be printed.
+
+    Examples
+    --------
+    Render a report without any highlighting:
+
+    >>> from ansys.mapdl.core.cli.check import check, format_info
+    >>> print(format_info(check()))
+
+    """
+    lines: List[str] = []
+
+    for section, content in data.items():
+        lines.append("")
+        lines.append(style(_titleize(section)))
+
+        if "error" in content:
+            lines.append(_row("Error", content["error"]))
+            continue
+
+        for key, value in content.items():
+            if isinstance(value, dict):
+                lines.append("")
+                lines.append(style(f"  {_titleize(key)}"))
+                lines.extend(
+                    _row(_titleize(subkey), subvalue, indent=4)
+                    for subkey, subvalue in value.items()
+                )
+            else:
+                lines.append(_row(_titleize(key), value))
+
+    return "\n".join(lines)
+
+
+def _titleize(key: str) -> str:
+    """Turn a snake_case key into a human-readable title.
+
+    Parameters
+    ----------
+    key : str
+        Key to convert.
+
+    Returns
+    -------
+    str
+        The key with underscores replaced by spaces and capitalized.
+    """
+    return key.replace("_", " ").capitalize()
+
+
+def _row(key: str, value: Any, indent: int = 2) -> str:
+    """Format a single ``key``/``value`` line of the report.
+
+    Parameters
+    ----------
+    key : str
+        Name shown in the left column.
+    value : any
+        Value shown in the right column.
+    indent : int, default: 2
+        Number of leading spaces.
+
+    Returns
+    -------
+    str
+        The formatted line.
+    """
+    return f"{' ' * indent}{key.ljust(_KEY_WIDTH)}{value}"
+
+
+# ---------------------------------------------------------------------------
+# Click wrapper
+# ---------------------------------------------------------------------------
 
 
 @click.command(
@@ -64,7 +209,7 @@ Examples:
     default=False,
     help="Output diagnostic information as a JSON object.",
 )
-def check(ip: str, port: int, timeout: int, as_json: bool) -> None:
+def check_cli(ip: str, port: int, timeout: int, as_json: bool) -> None:
     """Connect to a running MAPDL instance and print diagnostic information.
 
     Parameters
@@ -80,81 +225,19 @@ def check(ip: str, port: int, timeout: int, as_json: bool) -> None:
         human-readable text.
     """
     import json
-    import logging
 
-    from ansys.mapdl.core import LOG
+    from ansys.mapdl.core.cli.helpers import silence_logging
+    from ansys.mapdl.core.errors import MapdlConnectionError
 
-    LOG.setLevel(logging.CRITICAL + 1)
-    if LOG.std_out_handler:
-        LOG.std_out_handler.setLevel(logging.CRITICAL + 1)
+    silence_logging()
 
     try:
-        from ansys.mapdl.core.launcher.config import resolve_launch_config
-        from ansys.mapdl.core.launcher.connection import connect_to_existing
-
-        config = resolve_launch_config(
-            ip=ip,
-            port=port,
-            start_instance=False,
-            clear_on_connect=False,
-            timeout=timeout,
-        )
-        mapdl = connect_to_existing(config)
-
-    except Exception as e:
-        click.echo(
-            click.style("ERROR:", fg="red")
-            + f" Could not connect to MAPDL at {ip}:{port} — {e}",
-            err=True,
-        )
+        data = check(ip=ip, port=port, timeout=timeout)
+    except MapdlConnectionError as err:
+        click.echo(click.style("ERROR:", fg="red") + f" {err}", err=True)
         sys.exit(1)
-
-    from ansys.mapdl.core.information import get_mapdl_info
-
-    data = get_mapdl_info(mapdl)
 
     if as_json:
         click.echo(json.dumps(data, indent=2))
     else:
-        _print_info_human_readable(data)
-
-
-def _print_info_human_readable(data: dict) -> None:
-    """Render ``get_mapdl_info`` output as formatted text.
-
-    Parameters
-    ----------
-    data : dict
-        Nested dictionary returned by :func:`get_mapdl_info`.
-    """
-    W = 24  # key column width
-
-    def row(key: str, value) -> None:
-        click.echo(f"  {key.ljust(W)}{value}")
-
-    def section(title: str) -> None:
-        click.echo("")
-        click.echo(click.style(title, bold=True))
-
-    def subsection(title: str) -> None:
-        click.echo("")
-        click.echo(click.style(f"  {title}", bold=True))
-
-    def subrow(key: str, value) -> None:
-        click.echo(f"    {key.ljust(W)}{value}")
-
-    for each_section in data:
-        section(each_section.replace("_", " ").capitalize())
-
-        if "error" in data[each_section]:
-            row("Error", data[each_section]["error"])
-        else:
-            for key, value in data[each_section].items():
-                key = key.replace("_", " ").capitalize()
-                if isinstance(value, dict):
-                    subsection(key)
-                    for subkey, subvalue in value.items():
-                        subkey = subkey.replace("_", " ").capitalize()
-                        subrow(subkey, subvalue)
-                else:
-                    row(key, value)
+        click.echo(format_info(data, style=lambda text: click.style(text, bold=True)))

--- a/src/ansys/mapdl/core/cli/constants.py
+++ b/src/ansys/mapdl/core/cli/constants.py
@@ -20,19 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-"""Constants shared by the CLI commands and their click-independent functions.
-
-This module must stay free of imports so that building the ``pymapdl``
-command tree never pulls the rest of the library in.
-"""
+"""Constants shared by the CLI commands and their click-independent functions."""
 
 from typing import Tuple
 
-MAPDL_DEFAULT_IP = "127.0.0.1"
-"""IP address used when none is given and no environment variable is set."""
-
-MAPDL_DEFAULT_PORT = 50052
-"""gRPC port used when none is given and no environment variable is set."""
+from ansys.mapdl.core.launcher import LOCALHOST as MAPDL_DEFAULT_IP  # noqa: F401
+from ansys.mapdl.core.launcher import MAPDL_DEFAULT_PORT  # noqa: F401
 
 DEFAULT_TIMEOUT = 10
 """Seconds to wait when connecting to a running MAPDL instance."""

--- a/src/ansys/mapdl/core/cli/constants.py
+++ b/src/ansys/mapdl/core/cli/constants.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2016 - 2026 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2016 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Constants shared by the CLI commands and their click-independent functions.
+
+This module must stay free of imports so that building the ``pymapdl``
+command tree never pulls the rest of the library in.
+"""
+
+from typing import Tuple
+
+MAPDL_DEFAULT_IP = "127.0.0.1"
+"""IP address used when none is given and no environment variable is set."""
+
+MAPDL_DEFAULT_PORT = 50052
+"""gRPC port used when none is given and no environment variable is set."""
+
+DEFAULT_TIMEOUT = 10
+"""Seconds to wait when connecting to a running MAPDL instance."""
+
+SUPPORTED_ENVS: Tuple[str, ...] = ("claude", "copilot", "codex", "cursor")
+"""AI coding environments a skill can be installed into."""
+
+GLOBAL_UNSUPPORTED: Tuple[str, ...] = ("copilot",)
+"""Environments that only support a local, per-project installation."""

--- a/src/ansys/mapdl/core/cli/convert.py
+++ b/src/ansys/mapdl/core/cli/convert.py
@@ -20,12 +20,182 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""``pymapdl convert`` sub-command implementation."""
+
 import sys
-from typing import TextIO
+from typing import Optional, TextIO, Union
 
 import click
 
 from ansys.mapdl.core.plotting import GraphicsBackend
+
+
+def convert(
+    apdl_strings: str,
+    loglevel: str = "WARNING",
+    auto_exit: bool = True,
+    line_ending: Optional[str] = None,
+    exec_file: Optional[str] = None,
+    macros_as_functions: bool = True,
+    use_function_names: bool = True,
+    show_log: bool = False,
+    add_imports: bool = True,
+    comment_solve: bool = False,
+    cleanup_output: bool = True,
+    header: Union[bool, str] = True,
+    print_com: bool = True,
+    only_commands: bool = False,
+    graphics_backend: Optional[Union[str, GraphicsBackend]] = None,
+    clear_at_start: bool = False,
+    check_parameter_names: bool = False,
+) -> str:
+    """Convert an APDL script to PyMAPDL code.
+
+    Parameters
+    ----------
+    apdl_strings : str
+        APDL code to convert.
+    loglevel : str, default: "WARNING"
+        Logging level of the MAPDL object in the generated script.
+    auto_exit : bool, default: True
+        Whether to add a line at the end of the script to exit MAPDL.
+    line_ending : str, optional
+        Line ending of the generated script. When ``None``, ``"\\n"`` is used.
+    exec_file : str, optional
+        Location of the MAPDL executable to include in the generated
+        ``launch_mapdl`` call.
+    macros_as_functions : bool, default: True
+        Whether to convert MAPDL macros to Python functions.
+    use_function_names : bool, default: True
+        Whether to convert MAPDL commands to
+        :class:`ansys.mapdl.core.Mapdl` methods. When ``True``, the MAPDL
+        command ``K`` becomes ``mapdl.k``, otherwise ``mapdl.run("k")``.
+    show_log : bool, default: False
+        Whether to print the converted commands through a logger.
+    add_imports : bool, default: True
+        Whether to add the import and ``launch_mapdl`` lines at the beginning
+        of the generated script. Overrides *auto_exit*.
+    comment_solve : bool, default: False
+        Whether to comment out the lines containing ``"SOLVE"`` or ``"/EOF"``.
+    cleanup_output : bool, default: True
+        Whether to format the output with ``autopep8``, which must be
+        installed.
+    header : bool or str, default: True
+        When ``True``, the default header is written in the first line of the
+        output. When a string, it is used as the header.
+    print_com : bool, default: True
+        Whether to print ``/COM`` arguments to the Python console.
+    only_commands : bool, default: False
+        Whether to convert only the commands, without header, imports, or exit
+        commands. Overrides *header*, *add_imports*, and *auto_exit*.
+    graphics_backend : str or GraphicsBackend, optional
+        Graphics backend to set on the generated MAPDL object. Accepts a
+        :class:`ansys.mapdl.core.plotting.GraphicsBackend` member or its name,
+        which is case insensitive. When ``None``, the
+        :class:`ansys.mapdl.core.Mapdl` default is used.
+    clear_at_start : bool, default: False
+        Whether to add a ``mapdl.clear()`` call after the MAPDL object is
+        created.
+    check_parameter_names : bool, default: False
+        Whether the generated MAPDL object checks parameter names, raising an
+        exception on leading underscores.
+
+    Returns
+    -------
+    str
+        The converted PyMAPDL code.
+
+    Raises
+    ------
+    ValueError
+        When *graphics_backend* does not name a valid graphics backend.
+
+    Examples
+    --------
+    Convert a small APDL block:
+
+    >>> from ansys.mapdl.core.cli.convert import convert
+    >>> print(convert("/prep7", only_commands=True))
+    mapdl.prep7()
+
+    """
+    from ansys.mapdl.core.convert import convert_apdl_block
+
+    return convert_apdl_block(
+        apdl_strings=apdl_strings,
+        loglevel=loglevel,
+        auto_exit=auto_exit,
+        line_ending=line_ending,
+        exec_file=exec_file,
+        macros_as_functions=macros_as_functions,
+        use_function_names=use_function_names,
+        show_log=show_log,
+        add_imports=add_imports,
+        comment_solve=comment_solve,
+        cleanup_output=cleanup_output,
+        header=header,
+        print_com=print_com,
+        only_commands=only_commands,
+        graphics_backend=resolve_graphics_backend(graphics_backend),
+        clear_at_start=clear_at_start,
+        check_parameter_names=check_parameter_names,
+    )
+
+
+def resolve_graphics_backend(
+    graphics_backend: Optional[Union[str, GraphicsBackend]],
+) -> Optional[GraphicsBackend]:
+    """Coerce a graphics backend name to a :class:`GraphicsBackend` member.
+
+    Parameters
+    ----------
+    graphics_backend : str or GraphicsBackend, optional
+        Backend name, which is case insensitive, or an already resolved
+        member. When ``None``, no backend is requested.
+
+    Returns
+    -------
+    GraphicsBackend or None
+        The resolved backend, or ``None`` when *graphics_backend* is ``None``.
+
+    Raises
+    ------
+    ValueError
+        When *graphics_backend* does not name a valid graphics backend.
+
+    Examples
+    --------
+    >>> from ansys.mapdl.core.cli.convert import resolve_graphics_backend
+    >>> resolve_graphics_backend("pyvista")
+    <GraphicsBackend.PYVISTA: 0>
+
+    """
+    if graphics_backend is None:
+        return None
+
+    allowed_backends = GraphicsBackend.__members__
+
+    if (
+        isinstance(graphics_backend, str)
+        and graphics_backend.upper() in allowed_backends
+    ):
+        return GraphicsBackend[graphics_backend.upper()]
+
+    if graphics_backend in list(allowed_backends.values()):
+        return graphics_backend
+
+    allowed_backend_string = ", ".join(
+        [str(each) for each in allowed_backends.values()]
+    )
+    raise ValueError(
+        f"Invalid graphics backend '{graphics_backend}'. "
+        f"Allowed values are: {allowed_backend_string}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Click wrapper
+# ---------------------------------------------------------------------------
 
 
 @click.command(
@@ -198,7 +368,7 @@ this value. Defaults to `None` which is Mapdl class default.""",
     type=bool,
     help="""Set MAPDL object to avoid parameter name checks (do not raise leading underscored parameter exceptions). Defaults to `False`.""",
 )
-def convert(
+def convert_cli(
     file: TextIO,
     output: TextIO,
     loglevel: str,
@@ -219,45 +389,30 @@ def convert(
     check_parameter_names: bool,
 ) -> None:
     """Convert MAPDL code to PyMAPDL"""
-    from ansys.mapdl.core.convert import convert_apdl_block
+    try:
+        backend = resolve_graphics_backend(graphics_backend)
+    except ValueError as err:
+        raise click.BadParameter(str(err), param_hint="'--graphics_backend'") from err
 
-    allowed_backends = GraphicsBackend.__members__
-    backend = None
-
-    if graphics_backend is not None:
-        if (
-            isinstance(graphics_backend, str)
-            and graphics_backend.upper() in allowed_backends
-        ):
-            backend = GraphicsBackend[graphics_backend.upper()]
-        elif graphics_backend in list(allowed_backends.values()):
-            backend = graphics_backend
-        else:
-            allowed_backend_string = ", ".join(
-                [str(each) for each in allowed_backends.values()]
-            )
-            raise ValueError(
-                f"Invalid graphics backend '{graphics_backend}'. Allowed values are: {allowed_backend_string}."
-            )
-
-    converted_code = convert_apdl_block(
-        apdl_strings=file.read(),
-        loglevel=loglevel,
-        auto_exit=auto_exit,
-        line_ending=line_ending,
-        exec_file=exec_file,
-        macros_as_functions=macros_as_functions,
-        use_function_names=use_function_names,
-        show_log=show_log,
-        add_imports=add_imports,
-        comment_solve=comment_solve,
-        cleanup_output=cleanup_output,
-        header=header,
-        print_com=print_com,
-        only_commands=only_commands,
-        graphics_backend=backend,
-        clear_at_start=clear_at_start,
-        check_parameter_names=check_parameter_names,
+    click.echo(
+        convert(
+            apdl_strings=file.read(),
+            loglevel=loglevel,
+            auto_exit=auto_exit,
+            line_ending=line_ending,
+            exec_file=exec_file,
+            macros_as_functions=macros_as_functions,
+            use_function_names=use_function_names,
+            show_log=show_log,
+            add_imports=add_imports,
+            comment_solve=comment_solve,
+            cleanup_output=cleanup_output,
+            header=header,
+            print_com=print_com,
+            only_commands=only_commands,
+            graphics_backend=backend,
+            clear_at_start=clear_at_start,
+            check_parameter_names=check_parameter_names,
+        ),
+        file=output,
     )
-
-    click.echo(converted_code, file=output)

--- a/src/ansys/mapdl/core/cli/exec.py
+++ b/src/ansys/mapdl/core/cli/exec.py
@@ -20,17 +20,172 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""``pymapdl exec`` sub-command implementation."""
+
 import select
 import sys
-from typing import Optional, Tuple
+from typing import Optional, Sequence, Tuple
 
 import click
+
+from ansys.mapdl.core.cli.constants import DEFAULT_TIMEOUT
+from ansys.mapdl.core.cli.helpers import connect_to_instance
+
+STDIN_MARKER = "-"
+
+NO_SOURCE_ERROR = (
+    "Provide commands via positional COMMANDS, '-c CMD', '--file PATH', "
+    "or stdin ('-')."
+)
+MULTIPLE_SOURCES_ERROR = (
+    "Only one input source may be used at a time: "
+    "positional COMMANDS, '-c', '--file', or stdin ('-')."
+)
+EMPTY_INPUT_ERROR = "No commands to run (input is empty)."
+
+
+def exec_commands(
+    input_arg: Optional[str] = None,
+    commands: Sequence[str] = (),
+    script_file: Optional[str] = None,
+    port: Optional[int] = None,
+    ip: Optional[str] = None,
+    clear_on_connect: bool = False,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> str:
+    """Send APDL commands to a running MAPDL instance and return its output.
+
+    Exactly one command source must be given: *input_arg*, *commands*,
+    *script_file*, or stdin.
+
+    Parameters
+    ----------
+    input_arg : str, optional
+        One or more inline APDL commands, separated by newlines, or ``"-"`` to
+        read the commands from stdin. When ``None`` and no other source is
+        given, stdin is read as long as it is a pipe carrying data.
+    commands : sequence of str, default: ()
+        APDL commands. Each item may itself hold several commands separated by
+        newlines. All items are joined with newlines and sent as a single
+        block.
+    script_file : str, optional
+        Path to an APDL script file whose content is sent to MAPDL.
+    port : int, optional
+        gRPC port of the running MAPDL instance. Defaults to ``50052``, or to
+        the ``PYMAPDL_PORT`` environment variable when it is set.
+    ip : str, optional
+        IP address of the running MAPDL instance. Defaults to ``"127.0.0.1"``,
+        or to the ``PYMAPDL_IP`` environment variable when it is set.
+    clear_on_connect : bool, default: False
+        Whether to clear the MAPDL database upon connecting. Off by default so
+        that successive calls share the same model state.
+    timeout : int, default: 10
+        Seconds to wait when establishing the gRPC connection.
+
+    Returns
+    -------
+    str
+        Output returned by MAPDL. Can be empty.
+
+    Raises
+    ------
+    ValueError
+        When no command source or more than one command source is given, or
+        when the resolved command block is empty.
+    MapdlConnectionError
+        When no MAPDL instance can be reached at the given address.
+    MapdlRuntimeError
+        When MAPDL fails while running the commands.
+
+    Examples
+    --------
+    Send two commands to the instance running on the default port:
+
+    >>> from ansys.mapdl.core.cli.exec import exec_commands
+    >>> print(exec_commands(commands=["/prep7", "BLOCK,0,1,0,1,0,1"]))
+
+    """
+    from ansys.mapdl.core.errors import MapdlRuntimeError
+
+    command_block = resolve_command_block(
+        input_arg=input_arg, commands=commands, script_file=script_file
+    )
+
+    mapdl = connect_to_instance(
+        ip=ip, port=port, clear_on_connect=clear_on_connect, timeout=timeout
+    )
+
+    try:
+        return mapdl.input_strings(command_block) or ""
+    except Exception as err:
+        raise MapdlRuntimeError(f"Command execution failed — {err}") from err
+
+
+def resolve_command_block(
+    input_arg: Optional[str] = None,
+    commands: Sequence[str] = (),
+    script_file: Optional[str] = None,
+) -> str:
+    """Build the APDL command block from the available command sources.
+
+    Parameters
+    ----------
+    input_arg : str, optional
+        Inline APDL commands, or ``"-"`` to read the commands from stdin.
+    commands : sequence of str, default: ()
+        APDL commands to join with newlines.
+    script_file : str, optional
+        Path to an APDL script file.
+
+    Returns
+    -------
+    str
+        The APDL commands to send to MAPDL.
+
+    Raises
+    ------
+    ValueError
+        When no source or more than one source is given, or when the resulting
+        block is empty.
+
+    Examples
+    --------
+    >>> from ansys.mapdl.core.cli.exec import resolve_command_block
+    >>> resolve_command_block(commands=["/prep7", "SAVE"])
+    '/prep7\\nSAVE'
+
+    """
+    use_stdin = input_arg == STDIN_MARKER or (
+        input_arg is None and not commands and script_file is None and _stdin_has_data()
+    )
+    use_inline = input_arg is not None and input_arg != STDIN_MARKER
+
+    n_sources = sum([bool(commands), script_file is not None, use_stdin, use_inline])
+    if n_sources == 0:
+        raise ValueError(NO_SOURCE_ERROR)
+    if n_sources > 1:
+        raise ValueError(MULTIPLE_SOURCES_ERROR)
+
+    if script_file is not None:
+        with open(script_file, "r") as fid:
+            command_block = fid.read()
+    elif use_stdin:
+        command_block = sys.stdin.read()
+    elif use_inline:
+        command_block = input_arg or ""
+    else:
+        command_block = "\n".join(commands)
+
+    if not command_block.strip():
+        raise ValueError(EMPTY_INPUT_ERROR)
+
+    return command_block
 
 
 def _stdin_has_data() -> bool:
     """Return ``True`` only when stdin is non-interactive *and* data is ready.
 
-    Uses a zero-timeout ``select`` call so the function never blocks.  Three
+    Uses a zero-timeout ``select`` call so the function never blocks.  Four
     cases are handled:
 
     * **Normal TTY** – user is typing interactively → ``False``.
@@ -43,6 +198,11 @@ def _stdin_has_data() -> bool:
       handles and raises ``OSError``.  We cannot check data availability, so
       we return ``True`` and let stdin be read normally (may block if nothing
       is piped).
+
+    Returns
+    -------
+    bool
+        Whether stdin can be read without blocking on user input.
     """
     if sys.stdin.isatty():
         return False
@@ -62,6 +222,11 @@ def _stdin_has_data() -> bool:
         # availability, so fall through to stdin — may block if nothing is
         # piped, but that is the expected behaviour on Windows.
         return True
+
+
+# ---------------------------------------------------------------------------
+# Click wrapper
+# ---------------------------------------------------------------------------
 
 
 @click.command(
@@ -135,7 +300,7 @@ MAPDL output is written to stdout so it can be consumed by scripts or LLM agents
     show_default=True,
     help="Seconds to wait when establishing the gRPC connection to the running instance.",
 )
-def exec_cmd(
+def exec_cli(
     input_arg: Optional[str],
     commands: Tuple[str, ...],
     script_file: Optional[str],
@@ -183,85 +348,27 @@ def exec_cmd(
     timeout : int
         Seconds to wait when establishing the gRPC connection.
     """
-    import logging
+    from ansys.mapdl.core.cli.helpers import silence_logging
+    from ansys.mapdl.core.errors import MapdlRuntimeError
 
-    # ------------------------------------------------------------------ #
-    # Resolve the command source                                           #
-    # ------------------------------------------------------------------ #
+    # Keep stdout clean so that the MAPDL output can be piped.
+    silence_logging()
 
-    use_stdin = input_arg == "-" or (
-        input_arg is None and not commands and script_file is None and _stdin_has_data()
-    )
-    use_inline = input_arg is not None and input_arg != "-"
-    n_sources = sum([bool(commands), script_file is not None, use_stdin, use_inline])
-
-    if n_sources == 0:
-        raise click.UsageError(
-            "Provide commands via positional COMMANDS, '-c CMD', '--file PATH', or stdin ('-')."
-        )
-    if n_sources > 1:
-        raise click.UsageError(
-            "Only one input source may be used at a time: "
-            "positional COMMANDS, '-c', '--file', or stdin ('-')."
-        )
-
-    if script_file is not None:
-        with open(script_file, "r") as fh:
-            cmd_block = fh.read()
-    elif use_stdin:
-        cmd_block = sys.stdin.read()
-    elif use_inline:
-        cmd_block = input_arg or ""
-    else:
-        cmd_block = "\n".join(commands)
-
-    if not cmd_block.strip():
-        raise click.UsageError("No commands to run (input is empty).")
-
-    # ------------------------------------------------------------------ #
-    # Suppress all PyMAPDL/grpc logging to keep stdout clean              #
-    # ------------------------------------------------------------------ #
-    from ansys.mapdl.core import LOG
-
-    LOG.setLevel(logging.CRITICAL + 1)
-    if LOG.std_out_handler:
-        LOG.std_out_handler.setLevel(logging.CRITICAL + 1)
-
-    # ------------------------------------------------------------------ #
-    # Connect to the existing MAPDL instance                              #
-    # ------------------------------------------------------------------ #
     try:
-        from ansys.mapdl.core.launcher.config import resolve_launch_config
-        from ansys.mapdl.core.launcher.connection import connect_to_existing
-
-        config = resolve_launch_config(
+        output = exec_commands(
+            input_arg=input_arg,
+            commands=commands,
+            script_file=script_file,
             ip=ip,
             port=port,
-            start_instance=False,
             clear_on_connect=clear_on_connect,
             timeout=timeout,
         )
-        mapdl = connect_to_existing(config)
-
-    except Exception as e:
-        click.echo(
-            click.style("ERROR:", fg="red")
-            + f" Could not connect to MAPDL at {ip}:{port} — {e}",
-            err=True,
-        )
+    except ValueError as err:
+        raise click.UsageError(str(err)) from err
+    except MapdlRuntimeError as err:
+        click.echo(click.style("ERROR:", fg="red") + f" {err}", err=True)
         sys.exit(1)
 
-    # ------------------------------------------------------------------ #
-    # Execute commands and stream output                                  #
-    # ------------------------------------------------------------------ #
-    try:
-        output = mapdl.input_strings(cmd_block)
-        if output:
-            click.echo(output)
-
-    except Exception as e:
-        click.echo(
-            click.style("ERROR:", fg="red") + f" Command execution failed — {e}",
-            err=True,
-        )
-        sys.exit(1)
+    if output:
+        click.echo(output)

--- a/src/ansys/mapdl/core/cli/help.py
+++ b/src/ansys/mapdl/core/cli/help.py
@@ -53,6 +53,71 @@ _FIRST_SECTION_RE = re.compile(r"^\S[^\n]*\n-{3,}", re.MULTILINE)
 _SPHINX_ROLE_WITH_TARGET_RE = re.compile(r":\w[\w.:-]*:`([^`<>]+)\s*<[^>]*>`")
 _SPHINX_ROLE_SIMPLE_RE = re.compile(r":\w[\w.:-]*:`([^`]+)`")
 
+MISSING_RICH_RST_ERROR = (
+    "The 'rich-rst' package is required to use the 'help' command.\n"
+    "Install it via 'pip install rich-rst' and try again."
+)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def help_command(command: str) -> str:
+    """Render the PyMAPDL docstring of a MAPDL command for a terminal.
+
+    Parameters
+    ----------
+    command : str
+        MAPDL command name to look up, including any leading ``/`` or ``*``
+        prefix. ``*`` and ``\\*`` map to the ``STAR<CMD>`` key and ``/`` maps
+        to ``SLASH<CMD>``, so the prefix is significant.
+
+    Returns
+    -------
+    str
+        The docstring formatted for a colour terminal, including ANSI escape
+        sequences. Strip them with :func:`click.strip_ansi` when writing to a
+        plain stream.
+
+    Raises
+    ------
+    ModuleNotFoundError
+        When the ``rich-rst`` package is not installed.
+    ValueError
+        When no PyMAPDL method matches *command*, or when the matching method
+        has no docstring.
+
+    Examples
+    --------
+    Get the documentation of the ``/PREP7`` command:
+
+    >>> from ansys.mapdl.core.cli.help import help_command
+    >>> print(help_command("/PREP7"))
+
+    """
+    try:
+        import rich_rst  # type: ignore # noqa: F401
+    except ModuleNotFoundError as err:
+        raise ModuleNotFoundError(MISSING_RICH_RST_ERROR) from err
+
+    from ansys.mapdl.core import Mapdl
+
+    method_name = _build_command_map().get(_normalise_user_input(command))
+    if method_name is None:
+        raise ValueError(
+            f"No PyMAPDL method found for MAPDL command {command!r}.\n"
+            "Use 'pymapdl help <COMMAND>' where COMMAND is a valid MAPDL "
+            "command name."
+        )
+
+    doc = inspect.getdoc(getattr(Mapdl, method_name))
+    if not doc:
+        raise ValueError(f"Method {method_name!r} has no docstring.")
+
+    return _format_rst_for_terminal(doc)
+
 
 # ---------------------------------------------------------------------------
 # RST → terminal formatter
@@ -157,16 +222,6 @@ def _format_rst_for_terminal(text: str) -> str:
     result = re.sub(r"\x1b\]8;id=[^;]+;", "\x1b]8;;", result)
 
     return result
-
-
-def _echo_doc(formatted: str) -> None:
-    """Output *formatted* to stdout, using a pager for long content on a TTY."""
-    if sys.stdout.isatty():
-        terminal_height = shutil.get_terminal_size(fallback=(80, 24)).lines
-        if formatted.count("\n") + 1 > terminal_height - 2:
-            click.echo_via_pager(formatted)
-            return
-    click.echo(formatted)
 
 
 # ---------------------------------------------------------------------------
@@ -283,7 +338,7 @@ def _normalise_user_input(command: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# CLI entry point
+# Click wrapper
 # ---------------------------------------------------------------------------
 
 
@@ -305,7 +360,7 @@ Examples:
 """,
 )
 @click.argument("command")
-def help_cmd(command: str) -> None:
+def help_cli(command: str) -> None:
     """Print the Python docstring for a MAPDL command.
 
     Parameters
@@ -330,40 +385,26 @@ def help_cmd(command: str) -> None:
         pymapdl help K
 
     """
-    from ansys.mapdl.core import Mapdl
-
     try:
-        import rich_rst  # type: ignore # noqa: F401
-
-    except ModuleNotFoundError:
-        click.echo(
-            click.style("ERROR:", fg="red")
-            + " The 'rich-rst' package is required to use the 'help' command.\n"
-            "Install it via 'pip install rich-rst' and try again.",
-            err=True,
-        )
+        formatted = help_command(command)
+    except (ModuleNotFoundError, ValueError) as err:
+        click.echo(click.style("ERROR:", fg="red") + f" {err}", err=True)
         sys.exit(1)
 
-    key = _normalise_user_input(command)
-    cmd_map = _build_command_map()
+    _echo_doc(formatted)
 
-    method_name = cmd_map.get(key)
-    if method_name is None:
-        click.echo(
-            click.style("ERROR:", fg="red")
-            + f" No PyMAPDL method found for MAPDL command {command!r}.\n"
-            "Use 'pymapdl help <COMMAND>' where COMMAND is a valid MAPDL command name.",
-            err=True,
-        )
-        sys.exit(1)
 
-    method = getattr(Mapdl, method_name)
-    doc = inspect.getdoc(method)
-    if not doc:
-        click.echo(
-            click.style("ERROR:", fg="red")
-            + f" Method {method_name!r} has no docstring.",
-            err=True,
-        )
-        sys.exit(1)
-    _echo_doc(_format_rst_for_terminal(doc))
+def _echo_doc(formatted: str) -> None:
+    """Output *formatted* to stdout, using a pager for long content on a TTY.
+
+    Parameters
+    ----------
+    formatted : str
+        Text to write to stdout.
+    """
+    if sys.stdout.isatty():
+        terminal_height = shutil.get_terminal_size(fallback=(80, 24)).lines
+        if formatted.count("\n") + 1 > terminal_height - 2:
+            click.echo_via_pager(formatted)
+            return
+    click.echo(formatted)

--- a/src/ansys/mapdl/core/cli/helpers.py
+++ b/src/ansys/mapdl/core/cli/helpers.py
@@ -89,7 +89,9 @@ def connect_to_instance(
     Raises
     ------
     MapdlConnectionError
-        When no MAPDL instance can be reached at the given address.
+        When no MAPDL instance can be reached at the given address. The
+        underlying error is attached as a note on the exception, and the
+        original traceback is suppressed to keep the failure readable.
 
     Examples
     --------
@@ -102,6 +104,7 @@ def connect_to_instance(
     from ansys.mapdl.core.errors import MapdlConnectionError
     from ansys.mapdl.core.launcher.config import resolve_launch_config
     from ansys.mapdl.core.launcher.connection import connect_to_existing
+    from ansys.mapdl.core.launcher.errors import ConfigurationError
 
     try:
         config = resolve_launch_config(
@@ -111,17 +114,19 @@ def connect_to_instance(
             clear_on_connect=clear_on_connect,
             timeout=timeout,
         )
-    except Exception as err:
+    except (ConfigurationError, TypeError, ValueError) as err:
         raise MapdlConnectionError(
-            f"Could not resolve the connection to MAPDL at {ip}:{port} — {err}"
-        ) from err
+            f"Could not resolve the connection to MAPDL at {ip}:{port}.",
+            notes=str(err),
+        ) from None
 
     try:
         return connect_to_existing(config)
-    except Exception as err:
+    except (ConnectionError, OSError) as err:
         raise MapdlConnectionError(
-            f"Could not connect to MAPDL at {config.ip}:{config.port} — {err}"
-        ) from err
+            f"Could not connect to MAPDL at {config.ip}:{config.port}.",
+            notes=str(err),
+        ) from None
 
 
 def can_access_process(proc):

--- a/src/ansys/mapdl/core/cli/helpers.py
+++ b/src/ansys/mapdl/core/cli/helpers.py
@@ -25,9 +25,103 @@ Minimal core functionality for CLI operations.
 This module avoids importing heavy dependencies like pandas, numpy, etc.
 """
 
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import psutil
+
+from ansys.mapdl.core.cli.constants import DEFAULT_TIMEOUT
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ansys.mapdl.core.mapdl_grpc import MapdlGrpc
+
+
+def silence_logging() -> None:
+    """Silence the PyMAPDL logger so that only command output reaches stdout.
+
+    The logger level is raised above ``CRITICAL``, which disables every
+    record, and the same is done on the standard output handler when it is
+    present.
+
+    Examples
+    --------
+    Silence PyMAPDL before writing machine-readable output:
+
+    >>> from ansys.mapdl.core.cli.helpers import silence_logging
+    >>> silence_logging()
+
+    """
+    import logging
+
+    from ansys.mapdl.core import LOG
+
+    LOG.setLevel(logging.CRITICAL + 1)
+    if LOG.std_out_handler:
+        LOG.std_out_handler.setLevel(logging.CRITICAL + 1)
+
+
+def connect_to_instance(
+    ip: Optional[str] = None,
+    port: Optional[int] = None,
+    clear_on_connect: bool = False,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> "MapdlGrpc":
+    """Connect to an already running MAPDL instance.
+
+    Parameters
+    ----------
+    ip : str, optional
+        IP address of the MAPDL gRPC server. When ``None``, the value of the
+        ``PYMAPDL_IP`` environment variable is used, defaulting to
+        ``"127.0.0.1"``.
+    port : int, optional
+        Port of the MAPDL gRPC server. When ``None``, the value of the
+        ``PYMAPDL_PORT`` environment variable is used, defaulting to ``50052``.
+    clear_on_connect : bool, default: False
+        Whether to clear the MAPDL database upon connecting.
+    timeout : int, default: 10
+        Seconds to wait when establishing the gRPC connection.
+
+    Returns
+    -------
+    ansys.mapdl.core.mapdl_grpc.MapdlGrpc
+        Client connected to the running instance.
+
+    Raises
+    ------
+    MapdlConnectionError
+        When no MAPDL instance can be reached at the given address.
+
+    Examples
+    --------
+    Connect to the instance running on the default port:
+
+    >>> from ansys.mapdl.core.cli.helpers import connect_to_instance
+    >>> mapdl = connect_to_instance()
+
+    """
+    from ansys.mapdl.core.errors import MapdlConnectionError
+    from ansys.mapdl.core.launcher.config import resolve_launch_config
+    from ansys.mapdl.core.launcher.connection import connect_to_existing
+
+    try:
+        config = resolve_launch_config(
+            ip=ip,
+            port=port,
+            start_instance=False,
+            clear_on_connect=clear_on_connect,
+            timeout=timeout,
+        )
+    except Exception as err:
+        raise MapdlConnectionError(
+            f"Could not resolve the connection to MAPDL at {ip}:{port} — {err}"
+        ) from err
+
+    try:
+        return connect_to_existing(config)
+    except Exception as err:
+        raise MapdlConnectionError(
+            f"Could not connect to MAPDL at {config.ip}:{config.port} — {err}"
+        ) from err
 
 
 def can_access_process(proc):

--- a/src/ansys/mapdl/core/cli/list_instances.py
+++ b/src/ansys/mapdl/core/cli/list_instances.py
@@ -20,7 +20,120 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""``pymapdl list`` sub-command implementation."""
+
+from typing import Any, Dict, List
+
 import click
+
+from ansys.mapdl.core.cli.helpers import get_mapdl_instances
+
+
+def list_instances(
+    instances: bool = False,
+    long: bool = False,
+    cmd: bool = False,
+    location: bool = False,
+) -> str:
+    """Render a table with the MAPDL processes running on this machine.
+
+    Parameters
+    ----------
+    instances : bool, default: False
+        Whether to list only the main processes (the instances), hiding their
+        children.
+    long : bool, default: False
+        Whether to include every available field. Implies *cmd* and
+        *location*.
+    cmd : bool, default: False
+        Whether to include the command line each process was started with.
+    location : bool, default: False
+        Whether to include the working directory of each process.
+
+    Returns
+    -------
+    str
+        Table ready to be printed. The table is empty when no MAPDL process
+        is running.
+
+    Examples
+    --------
+    Print the running MAPDL instances:
+
+    >>> from ansys.mapdl.core.cli.list_instances import list_instances
+    >>> print(list_instances(instances=True))
+    Name          Status      gRPC port    PID
+    ------------  --------  -----------  -----
+    ANSYS241.exe  running         50052  41644
+
+    """
+    from tabulate import tabulate
+
+    if long:
+        cmd = True
+        location = True
+
+    if instances:
+        headers = ["Name", "Status", "gRPC port", "PID"]
+    else:
+        headers = ["Name", "Is Instance", "Status", "gRPC port", "PID"]
+
+    if cmd:
+        headers.append("Command line")
+    if location:
+        headers.append("Working directory")
+
+    table = []
+    for each_proc in get_mapdl_instances():
+        if instances and not each_proc.get("is_instance", False):
+            continue
+
+        table.append(_process_row(each_proc, instances, cmd, location))
+
+    return tabulate(table, headers)
+
+
+def _process_row(
+    proc: Dict[str, Any], instances: bool, cmd: bool, location: bool
+) -> List[Any]:
+    """Build the table row describing a single MAPDL process.
+
+    Parameters
+    ----------
+    proc : dict
+        Process information as returned by
+        :func:`ansys.mapdl.core.cli.helpers.get_mapdl_instances`.
+    instances : bool
+        Whether the ``Is Instance`` column is omitted.
+    cmd : bool
+        Whether the command line column is included.
+    location : bool
+        Whether the working directory column is included.
+
+    Returns
+    -------
+    list
+        Values of the row, in the same order as the table headers.
+    """
+    row: List[Any] = [proc["name"]]
+
+    if not instances:
+        row.append(proc.get("is_instance", False))
+
+    row.extend([proc["status"], proc["port"], proc["pid"]])
+
+    if cmd:
+        row.append(" ".join(proc["cmdline"]))
+
+    if location:
+        row.append(proc["cwd"])
+
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Click wrapper
+# ---------------------------------------------------------------------------
 
 
 @click.command(
@@ -63,53 +176,20 @@ import click
     default=False,
     help="Print running location info.",
 )
-def list_instances(instances, long, cmd, location) -> None:
-    return _list_instances(instances, long, cmd, location)
+def list_instances_cli(instances: bool, long: bool, cmd: bool, location: bool) -> None:
+    """List the MAPDL processes running on this machine.
 
-
-def _list_instances(instances, long, cmd, location):
-    from tabulate import tabulate
-
-    from ansys.mapdl.core.cli.helpers import get_mapdl_instances
-
-    # Assuming all ansys processes have -grpc flag
-    mapdl_instances = get_mapdl_instances()
-
-    # printing
-    if long:
-        cmd = True
-        location = True
-
-    if instances:
-        headers = ["Name", "Status", "gRPC port", "PID"]
-    else:
-        headers = ["Name", "Is Instance", "Status", "gRPC port", "PID"]
-
-    if cmd:
-        headers.append("Command line")
-    if location:
-        headers.append("Working directory")
-
-    table = []
-    for each_p in mapdl_instances:
-        if instances and not each_p.get("is_instance", False):
-            # Skip child processes if only printing instances
-            continue
-
-        proc_line = []
-        proc_line.append(each_p["name"])
-
-        if not instances:
-            proc_line.append(each_p.get("is_instance", False))
-
-        proc_line.extend([each_p["status"], each_p["port"], each_p["pid"]])
-
-        if cmd:
-            proc_line.append(" ".join(each_p["cmdline"]))
-
-        if location:
-            proc_line.append(each_p["cwd"])
-
-        table.append(proc_line)
-
-    print(tabulate(table, headers))
+    Parameters
+    ----------
+    instances : bool
+        If :class:`True`, print only the main processes (the instances).
+    long : bool
+        If :class:`True`, print all the available information.
+    cmd : bool
+        If :class:`True`, print the command line of each process.
+    location : bool
+        If :class:`True`, print the working directory of each process.
+    """
+    click.echo(
+        list_instances(instances=instances, long=long, cmd=cmd, location=location)
+    )

--- a/src/ansys/mapdl/core/cli/skills.py
+++ b/src/ansys/mapdl/core/cli/skills.py
@@ -508,7 +508,7 @@ def _find_skills_dir() -> pathlib.Path:
         ref = importlib.resources.files("ansys.mapdl.core.skills")
         return pathlib.Path(str(ref))
     except Exception:
-        return pathlib.Path(__file__).parent.parent.parent / "skills"
+        return pathlib.Path(__file__).parent.parent / "skills"
 
 
 def _parse_frontmatter(text: str) -> Tuple[Dict[str, str], str]:

--- a/src/ansys/mapdl/core/cli/skills.py
+++ b/src/ansys/mapdl/core/cli/skills.py
@@ -20,11 +20,478 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""``pymapdl skills`` sub-command group."""
+
+from dataclasses import dataclass, field
 import pathlib
 import re
 import sys
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import click
+
+from ansys.mapdl.core.cli.constants import GLOBAL_UNSUPPORTED, SUPPORTED_ENVS
+
+# Directories inside a skill that are never installed.
+_EXCLUDED_DIRECTORIES = ("evals", "workspace")
+
+_INCOMPLETE_PLAN_ERROR = (
+    "The installation plan is missing paths required by the {env!r} environment."
+)
+
+
+class UnknownSkillError(ValueError):
+    """Raised when the requested skill is not bundled with PyMAPDL.
+
+    Parameters
+    ----------
+    skill_name : str
+        Identifier that could not be resolved.
+    available : sequence of str
+        Identifiers of the skills that are available.
+    """
+
+    def __init__(self, skill_name: str, available: Sequence[str]) -> None:
+        self.skill_name = skill_name
+        self.available = list(available)
+        super().__init__(
+            f"Unknown skill {skill_name!r}. "
+            "Run 'pymapdl skills list' to see available skills."
+        )
+
+
+class UnsupportedScopeError(ValueError):
+    """Raised when an environment does not support the requested scope.
+
+    Parameters
+    ----------
+    env : str
+        AI coding environment.
+    scope : str
+        Requested installation scope.
+    """
+
+    def __init__(self, env: str, scope: str) -> None:
+        self.env = env
+        self.scope = scope
+        super().__init__(f"--{scope} is not supported for the '{env}' environment.")
+
+
+@dataclass(frozen=True)
+class SkillInfo:
+    """Metadata of a bundled skill.
+
+    Parameters
+    ----------
+    name : str
+        Skill identifier.
+    description : str
+        One-line description taken from the skill frontmatter.
+    path : pathlib.Path
+        Path to the ``SKILL.md`` file of the skill.
+    """
+
+    name: str
+    description: str
+    path: pathlib.Path
+
+
+@dataclass(frozen=True)
+class SkillInstallPlan:
+    """Files an installation is going to create or update.
+
+    Parameters
+    ----------
+    skill_name : str
+        Skill identifier.
+    env : str
+        AI coding environment the skill is installed into.
+    scope : str
+        Either ``"local"`` or ``"global"``.
+    skill_dir : pathlib.Path
+        Directory holding the bundled skill files.
+    skill_md_text : str
+        Full content of the ``SKILL.md`` file.
+    description : str
+        Description taken from the skill frontmatter.
+    body : str
+        Content of ``SKILL.md`` without its frontmatter.
+    actions : list of str
+        Human-readable description of the planned file operations.
+    dest_dir : pathlib.Path, optional
+        Directory the skill files are copied to.
+    dest_file : pathlib.Path, optional
+        Single file the skill is written to.
+    config_file : pathlib.Path, optional
+        Configuration file of the environment that gets a reference appended.
+    config_line : str, optional
+        Reference line used to detect an already installed skill.
+    config_text : str, optional
+        Full text appended to *config_file*.
+    section_header : str, optional
+        Markdown heading used to detect an already installed skill.
+    """
+
+    skill_name: str
+    env: str
+    scope: str
+    skill_dir: pathlib.Path
+    skill_md_text: str
+    description: str
+    body: str
+    actions: List[str] = field(default_factory=list)
+    dest_dir: Optional[pathlib.Path] = None
+    dest_file: Optional[pathlib.Path] = None
+    config_file: Optional[pathlib.Path] = None
+    config_line: Optional[str] = None
+    config_text: Optional[str] = None
+    section_header: Optional[str] = None
+
+    @property
+    def summary(self) -> str:
+        """Return the planned file operations as a multi-line string."""
+        return "\n".join(self.actions)
+
+
+def list_skills(skills_dir: Optional[pathlib.Path] = None) -> List[SkillInfo]:
+    """List the skills bundled with this PyMAPDL installation.
+
+    Parameters
+    ----------
+    skills_dir : pathlib.Path, optional
+        Directory holding one sub-directory per skill. Defaults to the
+        directory bundled with the package.
+
+    Returns
+    -------
+    list of SkillInfo
+        Available skills, sorted by directory name. Empty when no skill is
+        bundled.
+
+    Examples
+    --------
+    Print the name of every bundled skill:
+
+    >>> from ansys.mapdl.core.cli.skills import list_skills
+    >>> [skill.name for skill in list_skills()]
+    ['pymapdl-cli']
+
+    """
+    if skills_dir is None:
+        skills_dir = _find_skills_dir()
+
+    skills: List[SkillInfo] = []
+    if not skills_dir.exists():
+        return skills
+
+    for entry in sorted(skills_dir.iterdir()):
+        skill_md = entry / "SKILL.md"
+        if not entry.is_dir() or not skill_md.exists():
+            continue
+
+        meta, _ = _parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        skills.append(
+            SkillInfo(
+                name=meta.get("name", entry.name),
+                description=meta.get("description", ""),
+                path=skill_md,
+            )
+        )
+
+    return skills
+
+
+def show_skill(skill_name: str, skills_dir: Optional[pathlib.Path] = None) -> str:
+    """Return the full ``SKILL.md`` content of a bundled skill.
+
+    Parameters
+    ----------
+    skill_name : str
+        Skill identifier, as reported by :func:`list_skills`.
+    skills_dir : pathlib.Path, optional
+        Directory holding one sub-directory per skill. Defaults to the
+        directory bundled with the package.
+
+    Returns
+    -------
+    str
+        Content of the ``SKILL.md`` file, frontmatter included.
+
+    Raises
+    ------
+    UnknownSkillError
+        When *skill_name* is not bundled with PyMAPDL.
+
+    Examples
+    --------
+    >>> from ansys.mapdl.core.cli.skills import show_skill
+    >>> print(show_skill("pymapdl-cli"))
+
+    """
+    if skills_dir is None:
+        skills_dir = _find_skills_dir()
+
+    skill_md = skills_dir / skill_name / "SKILL.md"
+    if not skill_md.exists():
+        raise UnknownSkillError(
+            skill_name, [skill.name for skill in list_skills(skills_dir)]
+        )
+
+    return skill_md.read_text(encoding="utf-8")
+
+
+def plan_skill_install(
+    skill_name: str,
+    env: str,
+    scope: str = "local",
+    skills_dir: Optional[pathlib.Path] = None,
+) -> SkillInstallPlan:
+    """Resolve the file operations needed to install a skill.
+
+    Nothing is written to disk. Pass the result to
+    :func:`apply_skill_install` to perform the installation.
+
+    Parameters
+    ----------
+    skill_name : str
+        Skill identifier, as reported by :func:`list_skills`.
+    env : str
+        AI coding environment. One of :data:`SUPPORTED_ENVS`.
+    scope : str, default: "local"
+        Either ``"local"`` to install into the current working directory, or
+        ``"global"`` to install into the home directory of the user.
+    skills_dir : pathlib.Path, optional
+        Directory holding one sub-directory per skill. Defaults to the
+        directory bundled with the package.
+
+    Returns
+    -------
+    SkillInstallPlan
+        The files that are created or updated by the installation.
+
+    Raises
+    ------
+    UnknownSkillError
+        When *skill_name* is not bundled with PyMAPDL.
+    UnsupportedScopeError
+        When *env* does not support *scope*.
+    ValueError
+        When *env* is not a supported environment.
+
+    Examples
+    --------
+    Inspect what a local Claude installation would do:
+
+    >>> from ansys.mapdl.core.cli.skills import plan_skill_install
+    >>> print(plan_skill_install("pymapdl-cli", "claude").summary)
+
+    """
+    if env not in SUPPORTED_ENVS:
+        raise ValueError(
+            f"Unknown environment {env!r}. "
+            f"Supported environments are: {', '.join(SUPPORTED_ENVS)}."
+        )
+
+    if skills_dir is None:
+        skills_dir = _find_skills_dir()
+
+    skill_dir = skills_dir / skill_name
+    if not skill_dir.exists() or not (skill_dir / "SKILL.md").exists():
+        raise UnknownSkillError(
+            skill_name, [skill.name for skill in list_skills(skills_dir)]
+        )
+
+    if scope == "global" and env in GLOBAL_UNSUPPORTED:
+        raise UnsupportedScopeError(env, scope)
+
+    skill_md_text = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+    meta, body = _parse_frontmatter(skill_md_text)
+
+    common: Dict[str, Any] = {
+        "skill_name": skill_name,
+        "env": env,
+        "scope": scope,
+        "skill_dir": skill_dir,
+        "skill_md_text": skill_md_text,
+        "description": meta.get("description", ""),
+        "body": body,
+    }
+
+    root = pathlib.Path.cwd() if scope == "local" else pathlib.Path.home()
+
+    if env == "claude":
+        dest_dir = root / ".claude" / "skills" / skill_name
+        config_file = (
+            root / "CLAUDE.md" if scope == "local" else root / ".claude" / "CLAUDE.md"
+        )
+        config_line = f"@.claude/skills/{skill_name}/SKILL.md"
+        return SkillInstallPlan(
+            dest_dir=dest_dir,
+            config_file=config_file,
+            config_line=config_line,
+            config_text=(
+                f"<!-- You can find the {skill_name} instructions and usage in"
+                f" .claude/skills/{skill_name}/SKILL.md -->\n"
+                f"{config_line}"
+            ),
+            actions=[
+                f"  Copy skill files to: {dest_dir}",
+                f"  Update config file:  {config_file}",
+                f"  Add reference:       {config_line}",
+            ],
+            **common,
+        )
+
+    if env == "copilot":
+        dest_file = pathlib.Path.cwd() / ".github" / "skills" / skill_name / "SKILL.md"
+        return SkillInstallPlan(
+            dest_file=dest_file,
+            actions=[f"  Write skill file to: {dest_file}"],
+            **common,
+        )
+
+    if env == "codex":
+        dest_dir = root / ".codex" / "skills" / skill_name
+        config_file = root / "AGENTS.md"
+        section_header = f"## Skill: {skill_name}"
+        return SkillInstallPlan(
+            dest_dir=dest_dir,
+            config_file=config_file,
+            section_header=section_header,
+            actions=[
+                f"  Copy skill files to: {dest_dir}",
+                f"  Update config file:  {config_file}",
+                f"  Append section:      {section_header}",
+            ],
+            **common,
+        )
+
+    dest_file = root / ".cursor" / "rules" / f"{skill_name}.mdc"
+    return SkillInstallPlan(
+        dest_file=dest_file,
+        actions=[f"  Write skill file to: {dest_file}"],
+        **common,
+    )
+
+
+def apply_skill_install(plan: SkillInstallPlan) -> List[str]:
+    """Perform the installation described by *plan*.
+
+    Parameters
+    ----------
+    plan : SkillInstallPlan
+        Plan built by :func:`plan_skill_install`.
+
+    Returns
+    -------
+    list of str
+        Human-readable log of what has been written or skipped.
+
+    Raises
+    ------
+    ValueError
+        When *plan* does not hold every path its environment needs.
+
+    Examples
+    --------
+    >>> from ansys.mapdl.core.cli.skills import apply_skill_install, plan_skill_install
+    >>> apply_skill_install(plan_skill_install("pymapdl-cli", "cursor"))
+    ['  wrote /home/user/.cursor/rules/pymapdl-cli.mdc']
+
+    """
+    if plan.env == "claude":
+        if (
+            plan.dest_dir is None
+            or plan.config_file is None
+            or plan.config_line is None
+        ):
+            raise ValueError(_INCOMPLETE_PLAN_ERROR.format(env=plan.env))
+
+        _copy_skill_files(plan.skill_dir, plan.dest_dir)
+        plan.config_file.parent.mkdir(parents=True, exist_ok=True)
+        if _append_if_missing(plan.config_file, plan.config_line, plan.config_text):
+            return [f"  updated {plan.config_file}"]
+        return [f"  notice: reference already present in {plan.config_file}, skipping."]
+
+    if plan.env == "codex":
+        if (
+            plan.dest_dir is None
+            or plan.config_file is None
+            or plan.section_header is None
+        ):
+            raise ValueError(_INCOMPLETE_PLAN_ERROR.format(env=plan.env))
+
+        _copy_skill_files(plan.skill_dir, plan.dest_dir)
+        plan.config_file.parent.mkdir(parents=True, exist_ok=True)
+        section = f"\n{plan.section_header}\n\n{plan.body}\n"
+        if _append_if_missing(plan.config_file, plan.section_header, section):
+            return [f"  updated {plan.config_file}"]
+        return [f"  notice: section already present in {plan.config_file}, skipping."]
+
+    if plan.dest_file is None:
+        raise ValueError(_INCOMPLETE_PLAN_ERROR.format(env=plan.env))
+
+    if plan.env == "copilot":
+        content = plan.skill_md_text
+    else:
+        content = f"---\ndescription: {plan.description}\n---\n{plan.body}"
+
+    plan.dest_file.parent.mkdir(parents=True, exist_ok=True)
+    plan.dest_file.write_text(content, encoding="utf-8")
+    return [f"  wrote {plan.dest_file}"]
+
+
+def install_skill(
+    skill_name: str,
+    env: str,
+    scope: str = "local",
+    skills_dir: Optional[pathlib.Path] = None,
+) -> List[str]:
+    """Install a bundled skill into an AI coding environment.
+
+    All files in the skill directory, except ``evals/`` and ``workspace/``,
+    are copied to the target location, and a reference is added to the main
+    configuration file of the environment so that the AI tool discovers the
+    skill. Running the function twice is safe: existing references are not
+    duplicated.
+
+    Parameters
+    ----------
+    skill_name : str
+        Skill identifier, as reported by :func:`list_skills`.
+    env : str
+        AI coding environment. One of :data:`SUPPORTED_ENVS`.
+    scope : str, default: "local"
+        Either ``"local"`` to install into the current working directory, or
+        ``"global"`` to install into the home directory of the user.
+    skills_dir : pathlib.Path, optional
+        Directory holding one sub-directory per skill. Defaults to the
+        directory bundled with the package.
+
+    Returns
+    -------
+    list of str
+        Human-readable log of what has been written or skipped.
+
+    Raises
+    ------
+    UnknownSkillError
+        When *skill_name* is not bundled with PyMAPDL.
+    UnsupportedScopeError
+        When *env* does not support *scope*.
+
+    Examples
+    --------
+    Install the ``pymapdl-cli`` skill for Claude in the current project:
+
+    >>> from ansys.mapdl.core.cli.skills import install_skill
+    >>> install_skill("pymapdl-cli", env="claude")
+    ['  updated /home/user/project/CLAUDE.md']
+
+    """
+    return apply_skill_install(
+        plan_skill_install(skill_name, env=env, scope=scope, skills_dir=skills_dir)
+    )
 
 
 def _find_skills_dir() -> pathlib.Path:
@@ -41,10 +508,10 @@ def _find_skills_dir() -> pathlib.Path:
         ref = importlib.resources.files("ansys.mapdl.core.skills")
         return pathlib.Path(str(ref))
     except Exception:
-        return pathlib.Path(__file__).parent.parent / "skills"
+        return pathlib.Path(__file__).parent.parent.parent / "skills"
 
 
-def _parse_frontmatter(text: str) -> tuple:
+def _parse_frontmatter(text: str) -> Tuple[Dict[str, str], str]:
     """Parse YAML frontmatter from a markdown string.
 
     Parameters
@@ -73,159 +540,8 @@ def _parse_frontmatter(text: str) -> tuple:
     return meta, body
 
 
-def _list_skills(skills_dir: pathlib.Path) -> list:
-    """Return a list of ``(name, description, skill_path)`` for every bundled skill.
-
-    Parameters
-    ----------
-    skills_dir : pathlib.Path
-        Root directory that contains one sub-directory per skill.
-
-    Returns
-    -------
-    list of tuple[str, str, pathlib.Path]
-        Each element is ``(name, description, skill_md_path)``.
-    """
-    result: list[tuple[str, str, pathlib.Path]] = []
-    if not skills_dir.exists():
-        return result
-    for entry in sorted(skills_dir.iterdir()):
-        if not entry.is_dir():
-            continue
-        skill_md = entry / "SKILL.md"
-        if not skill_md.exists():
-            continue
-        text = skill_md.read_text(encoding="utf-8")
-        meta, _ = _parse_frontmatter(text)
-        name = meta.get("name", entry.name)
-        description = meta.get("description", "")
-        result.append((name, description, skill_md))
-    return result
-
-
-# ---------------------------------------------------------------------------
-# Click command group
-# ---------------------------------------------------------------------------
-
-
-@click.group(short_help="Manage and install PyMAPDL AI skills.")
-def skills():
-    """Manage and install bundled PyMAPDL AI skills.
-
-    Use the sub-commands to list available skills, inspect their content,
-    and install them into your AI coding environment.
-    """
-
-
-# ---------------------------------------------------------------------------
-# pymapdl skills list
-# ---------------------------------------------------------------------------
-
-
-@skills.command(
-    name="list",
-    short_help="List all bundled skills.",
-    help="""List all skills bundled with this PyMAPDL installation.
-
-    Prints each skill's name and a one-line description to stdout.""",
-)
-def list_skills():
-    """List all skills bundled with this PyMAPDL installation.
-
-    Prints each skill's name and a one-line description to stdout.
-
-    Examples
-    --------
-    List all bundled skills:
-
-        pymapdl skills list
-
-    """
-    skills_dir = _find_skills_dir()
-    entries = _list_skills(skills_dir)
-    if not entries:
-        click.echo("No skills are bundled with this PyMAPDL installation.")
-        return
-    click.echo("")
-    click.echo(click.style("Available skills:", bold=True))
-    for name, description, _ in entries:
-        click.echo(f"- {name}")
-
-    click.echo("")
-    for name, description, _ in entries:
-        click.echo(f"{name}")
-        click.echo("-" * len(name))
-        if description:
-            click.echo(description)
-
-
-# ---------------------------------------------------------------------------
-# pymapdl skills show
-# ---------------------------------------------------------------------------
-
-
-@skills.command(
-    name="show",
-    short_help="Print a skill's SKILL.md to stdout.",
-    help="""Print the full content of a skill's SKILL.md to stdout.
-
-SKILL_NAME is the skill identifier as shown by ``pymapdl skills list``
-(e.g. ``pymapdl-cli``).  Redirect stdout to capture the file locally:
-
-\b
-Example:
-    pymapdl skills show pymapdl-cli > SKILL.md
-    """,
-)
-@click.argument("skill_name")
-def show_skill(skill_name: str) -> None:
-    """Print the full content of a skill's SKILL.md to stdout.
-
-    SKILL_NAME is the skill identifier as shown by ``pymapdl skills list``
-    (e.g. ``pymapdl-cli``).  Redirect stdout to capture the file locally:
-
-    Parameters
-    ----------
-    skill_name : str
-        Identifier of the skill to show, as shown by ``pymapdl skills list``
-        (e.g. ``pymapdl-cli``).
-
-    Examples
-    --------
-    Print the SKILL.md for the 'pymapdl-cli' skill to the console:
-
-        pymapdl skills show pymapdl-cli
-
-    Save the SKILL.md for the 'pymapdl-cli' skill to a local file:
-
-        pymapdl skills show pymapdl-cli > SKILL.md
-
-    """
-    skills_dir = _find_skills_dir()
-    skill_md = skills_dir / skill_name / "SKILL.md"
-    if not skill_md.exists():
-        available = [e[0] for e in _list_skills(skills_dir)]
-        click.echo(
-            click.style("ERROR:", fg="red") + f" Unknown skill {skill_name!r}. "
-            "Run 'pymapdl skills list' to see available skills.",
-            err=True,
-        )
-        if available:
-            click.echo("Available skills: " + ", ".join(available), err=True)
-        sys.exit(1)
-    click.echo(skill_md.read_text(encoding="utf-8"))
-
-
-# ---------------------------------------------------------------------------
-# pymapdl skills install
-# ---------------------------------------------------------------------------
-
-_SUPPORTED_ENVS = ("claude", "copilot", "codex", "cursor")
-_GLOBAL_UNSUPPORTED = ("copilot",)
-
-
 def _copy_skill_files(src_dir: pathlib.Path, dst_dir: pathlib.Path) -> None:
-    """Copy all files from *src_dir* to *dst_dir*, excluding ``evals/``.
+    """Copy all files from *src_dir* to *dst_dir*, excluding ``evals/`` and ``workspace/``.
 
     Parameters
     ----------
@@ -241,7 +557,7 @@ def _copy_skill_files(src_dir: pathlib.Path, dst_dir: pathlib.Path) -> None:
         if src_file.is_dir():
             continue
         rel = src_file.relative_to(src_dir)
-        if any(part in ("evals", "workspace") for part in rel.parts):
+        if any(part in _EXCLUDED_DIRECTORIES for part in rel.parts):
             continue
         dst_file = dst_dir / rel
         dst_file.parent.mkdir(parents=True, exist_ok=True)
@@ -249,7 +565,7 @@ def _copy_skill_files(src_dir: pathlib.Path, dst_dir: pathlib.Path) -> None:
 
 
 def _append_if_missing(
-    file_path: pathlib.Path, line: str, text: str | None = None
+    file_path: pathlib.Path, line: str, text: Optional[str] = None
 ) -> bool:
     """Append *text* to *file_path* if *line* is not already present.
 
@@ -279,6 +595,114 @@ def _append_if_missing(
             fh.write("\n")
         fh.write(payload + "\n")
     return True
+
+
+# ---------------------------------------------------------------------------
+# Click wrappers
+# ---------------------------------------------------------------------------
+
+
+@click.group(short_help="Manage and install PyMAPDL AI skills.")
+def skills():
+    """Manage and install bundled PyMAPDL AI skills.
+
+    Use the sub-commands to list available skills, inspect their content,
+    and install them into your AI coding environment.
+    """
+
+
+def _abort_unknown_skill(error: UnknownSkillError) -> None:
+    """Report an unknown skill on stderr and exit with a non-zero code.
+
+    Parameters
+    ----------
+    error : UnknownSkillError
+        Error raised while resolving the skill name.
+    """
+    click.echo(click.style("ERROR:", fg="red") + f" {error}", err=True)
+    if error.available:
+        click.echo("Available skills: " + ", ".join(error.available), err=True)
+    sys.exit(1)
+
+
+@skills.command(
+    name="list",
+    short_help="List all bundled skills.",
+    help="""List all skills bundled with this PyMAPDL installation.
+
+    Prints each skill's name and a one-line description to stdout.""",
+)
+def list_skills_cli() -> None:
+    """List all skills bundled with this PyMAPDL installation.
+
+    Prints each skill's name and a one-line description to stdout.
+
+    Examples
+    --------
+    List all bundled skills:
+
+        pymapdl skills list
+
+    """
+    entries = list_skills()
+    if not entries:
+        click.echo("No skills are bundled with this PyMAPDL installation.")
+        return
+
+    click.echo("")
+    click.echo(click.style("Available skills:", bold=True))
+    for skill in entries:
+        click.echo(f"- {skill.name}")
+
+    click.echo("")
+    for skill in entries:
+        click.echo(skill.name)
+        click.echo("-" * len(skill.name))
+        if skill.description:
+            click.echo(skill.description)
+
+
+@skills.command(
+    name="show",
+    short_help="Print a skill's SKILL.md to stdout.",
+    help="""Print the full content of a skill's SKILL.md to stdout.
+
+SKILL_NAME is the skill identifier as shown by ``pymapdl skills list``
+(e.g. ``pymapdl-cli``).  Redirect stdout to capture the file locally:
+
+\b
+Example:
+    pymapdl skills show pymapdl-cli > SKILL.md
+    """,
+)
+@click.argument("skill_name")
+def show_skill_cli(skill_name: str) -> None:
+    """Print the full content of a skill's SKILL.md to stdout.
+
+    SKILL_NAME is the skill identifier as shown by ``pymapdl skills list``
+    (e.g. ``pymapdl-cli``).  Redirect stdout to capture the file locally:
+
+    Parameters
+    ----------
+    skill_name : str
+        Identifier of the skill to show, as shown by ``pymapdl skills list``
+        (e.g. ``pymapdl-cli``).
+
+    Examples
+    --------
+    Print the SKILL.md for the 'pymapdl-cli' skill to the console:
+
+        pymapdl skills show pymapdl-cli
+
+    Save the SKILL.md for the 'pymapdl-cli' skill to a local file:
+
+        pymapdl skills show pymapdl-cli > SKILL.md
+
+    """
+    try:
+        click.echo(show_skill(skill_name))
+    except UnknownSkillError as err:
+        _abort_unknown_skill(err)
 
 
 @skills.command(
@@ -315,7 +739,7 @@ Install the 'pymapdl-cli' skill globally for use with Claude:
 @click.option(
     "--env",
     required=True,
-    type=click.Choice(_SUPPORTED_ENVS),
+    type=click.Choice(SUPPORTED_ENVS),
     help=(
         "AI coding environment to install the skill into.  "
         "Each environment receives a copy of the skill files (excluding "
@@ -342,7 +766,7 @@ Install the 'pymapdl-cli' skill globally for use with Claude:
     default=False,
     help="Skip the confirmation prompt and proceed immediately.",
 )
-def install_skill(skill_name: str, env: str, scope: str, yes: bool) -> None:
+def install_skill_cli(skill_name: str, env: str, scope: str, yes: bool) -> None:
     """Install a skill's files into an AI coding environment.
 
     SKILL_NAME is the skill identifier as shown by ``pymapdl skills list``
@@ -387,121 +811,21 @@ def install_skill(skill_name: str, env: str, scope: str, yes: bool) -> None:
       pymapdl skills install pymapdl-cli --env claude --global
 
     """
-    skills_dir = _find_skills_dir()
-    skill_dir = skills_dir / skill_name
-    if not skill_dir.exists() or not (skill_dir / "SKILL.md").exists():
-        available = [e[0] for e in _list_skills(skills_dir)]
-        click.echo(
-            click.style("ERROR:", fg="red") + f" Unknown skill {skill_name!r}. "
-            "Run 'pymapdl skills list' to see available skills.",
-            err=True,
-        )
-        if available:
-            click.echo("Available skills: " + ", ".join(available), err=True)
+    try:
+        plan = plan_skill_install(skill_name, env=env, scope=scope)
+    except UnknownSkillError as err:
+        _abort_unknown_skill(err)
+    except UnsupportedScopeError as err:
+        click.echo(click.style("ERROR:", fg="red") + f" {err}", err=True)
         sys.exit(1)
-
-    if scope == "global" and env in _GLOBAL_UNSUPPORTED:
-        click.echo(
-            click.style("ERROR:", fg="red")
-            + f" --global is not supported for the '{env}' environment.",
-            err=True,
-        )
-        sys.exit(1)
-
-    skill_md_text = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
-    meta, body = _parse_frontmatter(skill_md_text)
-    description = meta.get("description", "")
-
-    cwd = pathlib.Path.cwd()
-    home = pathlib.Path.home()
-
-    # Resolve destination paths per env + scope
-    if env == "claude":
-        if scope == "local":
-            dest_dir = cwd / ".claude" / "skills" / skill_name
-            config_file = cwd / "CLAUDE.md"
-        else:
-            dest_dir = home / ".claude" / "skills" / skill_name
-            config_file = home / ".claude" / "CLAUDE.md"
-        config_line = f"@.claude/skills/{skill_name}/SKILL.md"
-        config_text = (
-            f"<!-- You can find the {skill_name} instructions and usage in"
-            f" .claude/skills/{skill_name}/SKILL.md -->\n"
-            f"{config_line}"
-        )
-        action_desc = (
-            f"  Copy skill files to: {dest_dir}\n"
-            f"  Update config file:  {config_file}\n"
-            f"  Add reference:       {config_line}"
-        )
-    elif env == "copilot":
-        dest_file = cwd / ".github" / "skills" / skill_name / "SKILL.md"
-        action_desc = f"  Write skill file to: {dest_file}\n"
-    elif env == "codex":
-        if scope == "local":
-            dest_dir = cwd / ".codex" / "skills" / skill_name
-            config_file = cwd / "AGENTS.md"
-        else:
-            dest_dir = home / ".codex" / "skills" / skill_name
-            config_file = home / "AGENTS.md"
-        section_header = f"## Skill: {skill_name}"
-        action_desc = (
-            f"  Copy skill files to: {dest_dir}\n"
-            f"  Update config file:  {config_file}\n"
-            f"  Append section:      {section_header}"
-        )
-    elif env == "cursor":
-        if scope == "local":
-            dest_file = cwd / ".cursor" / "rules" / f"{skill_name}.mdc"
-        else:
-            dest_file = home / ".cursor" / "rules" / f"{skill_name}.mdc"
-        action_desc = f"  Write skill file to: {dest_file}"
 
     click.echo(f"Installing skill '{skill_name}' for env '{env}' ({scope}):")
-    click.echo(action_desc)
+    click.echo(plan.summary)
 
     if not yes:
         click.confirm("Proceed?", default=False, abort=True)
 
-    # Perform the installation
-    if env == "claude":
-        _copy_skill_files(skill_dir, dest_dir)
-        config_file.parent.mkdir(parents=True, exist_ok=True)
-        added = _append_if_missing(config_file, config_line, config_text)
-        if not added:
-            click.echo(
-                f"  notice: reference already present in {config_file}, skipping."
-            )
-        else:
-            click.echo(f"  updated {config_file}")
-        click.echo(click.style("Done.", fg="green"))
+    for message in apply_skill_install(plan):
+        click.echo(message)
 
-    elif env == "copilot":
-        dest_file.parent.mkdir(parents=True, exist_ok=True)
-        dest_file.write_text(skill_md_text, encoding="utf-8")
-        click.echo(f"  wrote {dest_file}")
-        click.echo(click.style("Done.", fg="green"))
-
-    elif env == "codex":
-        _copy_skill_files(skill_dir, dest_dir)
-        config_file.parent.mkdir(parents=True, exist_ok=True)
-        section_header = f"## Skill: {skill_name}"
-        existing = (
-            config_file.read_text(encoding="utf-8") if config_file.exists() else ""
-        )
-        if section_header in existing:
-            click.echo(f"  notice: section already present in {config_file}, skipping.")
-        else:
-            with open(config_file, "a", encoding="utf-8") as fh:
-                if existing and not existing.endswith("\n"):
-                    fh.write("\n")
-                fh.write(f"\n{section_header}\n\n{body}\n")
-            click.echo(f"  updated {config_file}")
-        click.echo(click.style("Done.", fg="green"))
-
-    elif env == "cursor":
-        mdc_content = f"---\ndescription: {description}\n---\n{body}"
-        dest_file.parent.mkdir(parents=True, exist_ok=True)
-        dest_file.write_text(mdc_content, encoding="utf-8")
-        click.echo(f"  wrote {dest_file}")
-        click.echo(click.style("Done.", fg="green"))
+    click.echo(click.style("Done.", fg="green"))

--- a/src/ansys/mapdl/core/cli/start.py
+++ b/src/ansys/mapdl/core/cli/start.py
@@ -20,9 +20,114 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Dict, Optional
+"""``pymapdl start`` sub-command implementation."""
+
+import sys
+from typing import Dict, Optional, Tuple
 
 import click
+
+
+def start(
+    exec_file: Optional[str] = None,
+    run_location: Optional[str] = None,
+    jobname: str = "file",
+    nproc: int = 2,
+    ram: Optional[int] = None,
+    override: bool = False,
+    additional_switches: str = "",
+    start_timeout: int = 45,
+    port: Optional[int] = None,
+    license_type: Optional[str] = None,
+    version: Optional[str] = None,
+    loglevel: str = "",
+) -> Tuple[str, int, Optional[int]]:
+    """Launch an MAPDL instance without connecting a client to it.
+
+    Parameters
+    ----------
+    exec_file : str, optional
+        Location of the MAPDL executable. The cached location is used when
+        left at ``None`` and no environment variable is set. The executable
+        path can also be set through the ``PYMAPDL_MAPDL_EXEC`` environment
+        variable.
+    run_location : str, optional
+        MAPDL working directory. Defaults to a temporary working directory.
+        The directory is created when it does not exist.
+    jobname : str, default: "file"
+        MAPDL jobname.
+    nproc : int, default: 2
+        Number of processors.
+    ram : int, optional
+        Fixed amount of memory to request for MAPDL, in megabytes. When
+        ``None``, MAPDL uses as much as available on the host machine.
+    override : bool, default: False
+        Whether to delete the lock file at *run_location*. Useful when a
+        previous MAPDL session exited prematurely.
+    additional_switches : str, default: ""
+        Additional switches for MAPDL, for example ``"aa_r"`` for the academic
+        research license. Avoid switches such as ``-i``, ``-o`` or ``-b``,
+        which are already included.
+    start_timeout : int, default: 45
+        Maximum allowable time to connect to the MAPDL server.
+    port : int, optional
+        Port to launch the MAPDL gRPC server on. The final port is the first
+        one available after (or including) this port. Defaults to ``50052``,
+        or to the ``PYMAPDL_PORT`` environment variable when it is set.
+    license_type : str, optional
+        License name (for example ``"meba"``) or description (for example
+        ``"enterprise solver"``). When ``None``, the license server decides
+        which license to provide.
+    version : str, optional
+        Version of MAPDL to launch. When ``None``, the latest installed
+        version is used.
+    loglevel : str, default: ""
+        Logging level of the MAPDL process.
+
+    Returns
+    -------
+    tuple of (str, int, int or None)
+        IP address, port, and process ID of the launched instance. The process
+        ID is ``None`` when the process is not managed locally, such as on HPC
+        schedulers.
+
+    Raises
+    ------
+    LaunchError
+        When the MAPDL instance cannot be launched.
+
+    Examples
+    --------
+    Launch an instance on port 50054:
+
+    >>> from ansys.mapdl.core.cli.start import start
+    >>> ip, port, pid = start(port=50054)
+    >>> print(f"{ip}:{port}")
+    127.0.0.1:50054
+
+    """
+    from ansys.mapdl.core.launcher import launch_mapdl_process
+
+    return launch_mapdl_process(
+        exec_file=exec_file,
+        run_location=run_location,
+        jobname=jobname,
+        nproc=nproc,
+        ram=ram,
+        override=override,
+        additional_switches=additional_switches,
+        start_timeout=start_timeout,
+        port=port,
+        license_type=license_type,
+        version=version,
+        loglevel=loglevel,
+        start_instance=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Click wrapper
+# ---------------------------------------------------------------------------
 
 
 @click.command(
@@ -166,7 +271,7 @@ For more information see :func:`ansys.mapdl.core.launcher.launch_mapdl`.""",
     type=str,
     help="Version of MAPDL to launch. If ``None``, the latest version is used. Versions can be provided as integers (i.e. ``version=222``) or floats (i.e. ``version=22.2``). To retrieve the available installed versions, use the function :meth:`ansys.tools.common.path.get_available_ansys_installations`.",
 )
-def start(
+def start_cli(
     exec_file: Optional[str],
     run_location: Optional[str],
     jobname: str,
@@ -191,88 +296,88 @@ def start(
     replace_env_vars: Optional[Dict[str, str]],  # ignored
     version: Optional[str],
 ) -> None:
-    import logging
+    """Launch an MAPDL instance and print its connection information.
 
-    from ansys.mapdl.core.launcher import launch_mapdl_process
+    Parameters
+    ----------
+    exec_file : Optional[str]
+        Location of the MAPDL executable.
+    run_location : Optional[str]
+        MAPDL working directory.
+    jobname : str
+        MAPDL jobname.
+    nproc : int
+        Number of processors.
+    ram : Optional[int]
+        Fixed amount of memory to request for MAPDL.
+    mode : Optional[str]
+        Argument not allowed in the CLI. It is ignored.
+    override : bool
+        If :class:`True`, delete the lock file at the working directory.
+    loglevel : str
+        Logging level of the MAPDL process. When empty, PyMAPDL logging is
+        silenced so that only the command output reaches stdout.
+    additional_switches : str
+        Additional switches for MAPDL.
+    start_timeout : int
+        Maximum allowable time to connect to the MAPDL server.
+    port : Optional[int]
+        Port to launch the MAPDL gRPC server on.
+    cleanup_on_exit : Optional[bool]
+        Argument not allowed in the CLI. It is ignored.
+    start_instance : Optional[bool]
+        Argument not allowed in the CLI. It is ignored.
+    ip : Optional[str]
+        Argument not allowed in the CLI. It is ignored.
+    clear_on_connect : Optional[bool]
+        Argument not allowed in the CLI. It is ignored.
+    log_apdl : Optional[str]
+        Argument not allowed in the CLI. It is ignored.
+    remove_temp_dir_on_exit : Optional[bool]
+        Argument not allowed in the CLI. It is ignored.
+    license_server_check : Optional[bool]
+        Argument not allowed in the CLI. It is ignored.
+    license_type : Optional[str]
+        License type to request.
+    print_com : Optional[bool]
+        Argument not allowed in the CLI. It is ignored.
+    add_env_vars : Optional[Dict[str, str]]
+        Argument not allowed in the CLI. It is ignored.
+    replace_env_vars : Optional[Dict[str, str]]
+        Argument not allowed in the CLI. It is ignored.
+    version : Optional[str]
+        Version of MAPDL to launch.
+    """
+    from ansys.mapdl.core.cli.helpers import silence_logging
 
-    if mode is not None:
-        click.echo(
-            click.style("Warn:", fg="yellow")
-            + " The following argument is not allowed in CLI: 'mode'. Ignoring argument."
-        )
-
-    if cleanup_on_exit is not None:
-        click.echo(
-            click.style("Warn:", fg="yellow")
-            + " The following argument is not allowed in CLI: 'cleanup_on_exit'. Ignoring argument."
-        )
-
-    if start_instance is not None:
-        click.echo(
-            click.style("Warn:", fg="yellow")
-            + " The following argument is not allowed in CLI: 'start_instance'. Ignoring argument."
-        )
-
-    if ip is not None:
-        click.echo(
-            click.style("Warn:", fg="yellow")
-            + " The following argument is not allowed in CLI: 'ip'. Ignoring argument."
-        )
-
-    if clear_on_connect is not None:
-        click.echo(
-            click.style("Warn:", fg="yellow")
-            + " The following argument is not allowed in CLI: 'clear_on_connect'. Ignoring argument."
-        )
-
-    if log_apdl is not None:
-        click.echo(
-            click.style("Warn:", fg="yellow")
-            + " The following argument is not allowed in CLI: 'log_apdl'. Ignoring argument."
-        )
-
-    if remove_temp_dir_on_exit is not None:
-        click.echo(
-            click.style("Warn:", fg="yellow")
-            + " The following argument is not allowed in CLI: 'remove_temp_dir_on_exit'. Ignoring argument."
-        )
-
-    if print_com is not None:
-        click.echo(
-            click.style("Warn:", fg="yellow")
-            + " The following argument is not allowed in CLI: 'print_com'. Ignoring argument."
-        )
-
-    if add_env_vars is not None:
-        click.echo(
-            click.style("Warn:", fg="yellow")
-            + " The following argument is not allowed in CLI: 'add_env_vars'. Ignoring argument."
-        )
-
-    if replace_env_vars is not None:
-        click.echo(
-            click.style("Warn:", fg="yellow")
-            + " The following argument is not allowed in CLI: 'replace_env_vars'. Ignoring argument."
-        )
-
-    if license_server_check is not None:
-        click.echo(
-            click.style("Warn:", fg="yellow")
-            + " The following argument is not allowed in CLI: 'license_server_check'. Ignoring argument."
-        )
-
-    # Suppress all logging to stdout when using CLI
-    from ansys.mapdl.core import LOG
+    # Arguments accepted for parity with ``launch_mapdl`` that the CLI cannot
+    # honour, because it only starts the MAPDL process, it never builds a client.
+    ignored_arguments = {
+        "mode": mode,
+        "cleanup_on_exit": cleanup_on_exit,
+        "start_instance": start_instance,
+        "ip": ip,
+        "clear_on_connect": clear_on_connect,
+        "log_apdl": log_apdl,
+        "remove_temp_dir_on_exit": remove_temp_dir_on_exit,
+        "print_com": print_com,
+        "add_env_vars": add_env_vars,
+        "replace_env_vars": replace_env_vars,
+        "license_server_check": license_server_check,
+    }
+    for argument, value in ignored_arguments.items():
+        if value is not None:
+            click.echo(
+                click.style("Warn:", fg="yellow")
+                + f" The following argument is not allowed in CLI: '{argument}'."
+                " Ignoring argument."
+            )
 
     if not loglevel:
-        LOG.setLevel(
-            logging.CRITICAL + 1
-        )  # Set to a level higher than CRITICAL to suppress all logs
-        if LOG.std_out_handler:
-            LOG.std_out_handler.setLevel(logging.CRITICAL + 1)
+        silence_logging()
 
     try:
-        ip_addr, port_num, pid = launch_mapdl_process(
+        ip_addr, port_num, pid = start(
             exec_file=exec_file,
             run_location=run_location,
             jobname=jobname,
@@ -284,13 +389,12 @@ def start(
             port=port,
             license_type=license_type,
             version=version,
-            loglevel=loglevel,  # Set to highest level to suppress all logging
-            start_instance=True,
+            loglevel=loglevel,
         )
 
-    except Exception as e:
-        click.echo(click.style("ERROR:", fg="red") + f" {e}")
-        exit(1)
+    except Exception as err:
+        click.echo(click.style("ERROR:", fg="red") + f" {err}")
+        sys.exit(1)
 
     if pid is not None:
         header = f"Launched an MAPDL instance (PID={pid}) at "

--- a/src/ansys/mapdl/core/cli/stop.py
+++ b/src/ansys/mapdl/core/cli/stop.py
@@ -20,11 +20,222 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Optional
+"""``pymapdl stop`` sub-command implementation."""
+
+from typing import List, Optional
+
+import psutil
+
+from ansys.mapdl.core.cli.constants import MAPDL_DEFAULT_PORT
+from ansys.mapdl.core.cli.helpers import (
+    can_access_process,
+    get_ansys_process_from_port,
+)
+
+# Process statuses from which a process can be killed normally. Statuses such
+# as ``STATUS_ZOMBIE``, ``STATUS_STOPPED`` or ``STATUS_TRACING_STOP`` are
+# deliberately excluded because those processes cannot be terminated cleanly.
+_PROCESS_OK_STATUS = (
+    psutil.STATUS_RUNNING,
+    psutil.STATUS_SLEEPING,
+    psutil.STATUS_DISK_SLEEP,
+    psutil.STATUS_DEAD,
+    psutil.STATUS_PARKED,  # Linux
+    psutil.STATUS_IDLE,  # Linux, macOS and FreeBSD
+)
+
+# Seconds to wait for a process to disappear after it has been killed.
+_TERMINATION_TIMEOUT = 5.0
+
+
+def stop(
+    port: Optional[int] = None, pid: Optional[int] = None, all: bool = False
+) -> List[int]:
+    """Stop MAPDL instances running on a given port or with a given process ID.
+
+    When neither *port* nor *pid* is given, the instance running on port
+    ``50052`` is stopped.
+
+    Parameters
+    ----------
+    port : int, optional
+        Port where the MAPDL instance to stop is running.
+    pid : int, optional
+        Process ID of the MAPDL instance to stop. The whole process tree
+        is stopped, children first.
+    all : bool, default: False
+        Whether to stop every MAPDL instance owned by the current user,
+        regardless of its port or process ID. Takes precedence over *port*
+        and *pid*.
+
+    Returns
+    -------
+    list of int
+        Process IDs of the instances that have been stopped. An empty list
+        means that no matching instance was found or that none could be
+        killed.
+
+    Raises
+    ------
+    ValueError
+        When *pid* cannot be converted to an integer.
+
+    Examples
+    --------
+    Stop the instance running on the default port:
+
+    >>> from ansys.mapdl.core.cli.stop import stop
+    >>> stop()
+    [23644]
+
+    Stop every running instance:
+
+    >>> stop(all=True)
+    [23644, 23645]
+
+    """
+    if all:
+        return _stop_all_instances()
+
+    if pid and not port:
+        return _stop_process_tree(pid)
+
+    return _stop_instance_on_port(port or MAPDL_DEFAULT_PORT)
+
+
+def _stop_all_instances() -> List[int]:
+    """Kill every MAPDL process the current user owns.
+
+    Returns
+    -------
+    list of int
+        Process IDs of the processes that have been killed.
+    """
+    stopped: List[int] = []
+
+    for proc in psutil.process_iter():
+        try:
+            if not can_access_process(proc):
+                continue
+
+            if not _is_valid_ansys_process(proc):
+                continue
+
+            try:
+                _kill_process(proc)
+            except psutil.NoSuchProcess:
+                continue
+
+            stopped.append(proc.pid)
+
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+
+    return stopped
+
+
+def _stop_instance_on_port(port: int) -> List[int]:
+    """Kill the MAPDL instance listening on *port*.
+
+    Parameters
+    ----------
+    port : int
+        Port where the MAPDL instance is running.
+
+    Returns
+    -------
+    list of int
+        Process ID of the killed instance, or an empty list when no instance
+        is running on *port*.
+    """
+    proc = get_ansys_process_from_port(port)
+    if proc is None:
+        return []
+
+    try:
+        _kill_process(proc)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return []
+
+    return [proc.pid]
+
+
+def _stop_process_tree(pid: int) -> List[int]:
+    """Kill the process *pid* and all its children.
+
+    Parameters
+    ----------
+    pid : int
+        Process ID of the parent process.
+
+    Returns
+    -------
+    list of int
+        Process IDs that are confirmed to have terminated. The parent PID is
+        only included when the process is gone before the timeout elapses.
+    """
+    try:
+        pid = int(pid)
+    except (TypeError, ValueError) as err:
+        raise ValueError("PID provided could not be converted to int.") from err
+
+    proc = psutil.Process(pid)
+
+    stopped: List[int] = []
+    for child in proc.children(recursive=True):
+        _kill_process(child)
+        stopped.append(child.pid)
+
+    _kill_process(proc)
+
+    try:
+        proc.wait(timeout=_TERMINATION_TIMEOUT)
+    except psutil.TimeoutExpired:
+        return stopped
+
+    stopped.append(pid)
+    return stopped
+
+
+def _kill_process(proc: psutil.Process) -> None:
+    """Kill *proc*.
+
+    Parameters
+    ----------
+    proc : psutil.Process
+        Process to kill.
+    """
+    proc.kill()
+
+
+def _is_valid_ansys_process(proc: psutil.Process) -> bool:
+    """Return whether *proc* is a live MAPDL process that can be killed.
+
+    Parameters
+    ----------
+    proc : psutil.Process
+        Process to check.
+
+    Returns
+    -------
+    bool
+        ``True`` when the process exists, is in a killable state, and is a
+        MAPDL process.
+    """
+    from ansys.mapdl.core.launcher.network import _is_mapdl_process
+
+    return (
+        psutil.pid_exists(proc.pid)
+        and proc.status() in _PROCESS_OK_STATUS
+        and _is_mapdl_process(proc)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Click wrapper
+# ---------------------------------------------------------------------------
 
 import click
-
-from ansys.mapdl.core.cli.helpers import can_access_process, get_ansys_process_from_port
 
 
 @click.command(
@@ -53,7 +264,7 @@ By default, it stops instances running on the port 50052.""",
     default=False,
     help="Kill all MAPDL instances",
 )
-def stop(port: Optional[int], pid: Optional[int], all: bool) -> None:
+def stop_cli(port: Optional[int], pid: Optional[int], all: bool) -> None:
     """Stop MAPDL instances running on a given port or with a given process id (PID).
 
     This command stops MAPDL instances running on a given port or with a given process id (PID).
@@ -68,120 +279,38 @@ def stop(port: Optional[int], pid: Optional[int], all: bool) -> None:
     all : bool
         If :class:`True`, kill all the instances regardless their port or PID.
     """
-    import psutil
-
-    PROCESS_OK_STATUS = [
-        # List of all process status, comment out the ones that means that
-        # process is not OK.
-        # If process is OK, it means it can be killed normally.
-        psutil.STATUS_RUNNING,  #
-        psutil.STATUS_SLEEPING,  #
-        psutil.STATUS_DISK_SLEEP,  #
-        # psutil.STATUS_STOPPED, #
-        # psutil.STATUS_TRACING_STOP, #
-        # psutil.STATUS_ZOMBIE, #
-        psutil.STATUS_DEAD,  #
-        # psutil.STATUS_WAKE_KILL, #
-        # psutil.STATUS_WAKING, #
-        psutil.STATUS_PARKED,  # (Linux)
-        psutil.STATUS_IDLE,  # (Linux, macOS, FreeBSD)
-        # psutil.STATUS_LOCKED, # (FreeBSD)
-        # psutil.STATUS_WAITING, # (FreeBSD)
-        # psutil.STATUS_SUSPENDED, # (NetBSD)
-    ]
-
-    if not pid and not port:
-        port = 50052
-
-    if port or all:
-        killed_ = False
-        if all:
-            for proc in psutil.process_iter():
-                try:
-                    # First check if we can access the process
-                    if not can_access_process(proc):
-                        continue
-
-                    if _is_valid_ansys_process(PROCESS_OK_STATUS, proc):
-                        # Killing "all"
-                        try:
-                            _kill_process(proc)
-                            killed_ = True
-                        except psutil.NoSuchProcess:
-                            pass
-
-                except (psutil.NoSuchProcess, psutil.AccessDenied):
-                    continue
-        else:
-            # Killing by ports
-            proc = get_ansys_process_from_port(port)
-            if proc:
-                try:
-                    _kill_process(proc)
-                    killed_ = True
-                except (psutil.NoSuchProcess, psutil.AccessDenied):
-                    pass
-
-        if all:
-            str_ = ""
-        else:
-            str_ = f" running on port {port}"
-
-        if not killed_:
-            click.echo(
-                click.style("ERROR: ", fg="red")
-                + "No Ansys instances"
-                + str_
-                + " have been found."
-            )
-        else:
-            click.echo(
-                click.style("Success: ", fg="green")
-                + "Ansys instances"
-                + str_
-                + " have been stopped."
-            )
+    try:
+        stopped = stop(port=port, pid=pid, all=all)
+    except ValueError as err:
+        click.echo(click.style("ERROR: ", fg="red") + str(err))
         return
 
-    if pid:
-        try:
-            pid = int(pid)
-        except ValueError:
-            click.echo(
-                click.style("ERROR: ", fg="red")
-                + "PID provided could not be converted to int."
-            )
-
-        p = psutil.Process(pid)
-        for child in p.children(recursive=True):
-            _kill_process(child)
-
-        _kill_process(p)
-
-        if p.status == "running":
-            click.echo(
-                click.style("ERROR: ", fg="red")
-                + f"The process with PID {pid} and its children could not be killed."
-            )
-        else:
+    if pid and not port and not all:
+        if pid in stopped:
             click.echo(
                 click.style("Success: ", fg="green")
                 + f"The process with PID {pid} and its children have been stopped."
             )
+        else:
+            click.echo(
+                click.style("ERROR: ", fg="red")
+                + f"The process with PID {pid} and its children could not be killed."
+            )
         return
 
+    target = "" if all else f" running on port {port or MAPDL_DEFAULT_PORT}"
 
-def _kill_process(proc):
-    proc.kill()
-
-
-def _is_valid_ansys_process(PROCESS_OK_STATUS, proc):
-    import psutil
-
-    from ansys.mapdl.core.launcher.network import _is_mapdl_process as is_ansys_process
-
-    return (
-        psutil.pid_exists(proc.pid)
-        and proc.status() in PROCESS_OK_STATUS
-        and is_ansys_process(proc)
-    )
+    if stopped:
+        click.echo(
+            click.style("Success: ", fg="green")
+            + "Ansys instances"
+            + target
+            + " have been stopped."
+        )
+    else:
+        click.echo(
+            click.style("ERROR: ", fg="red")
+            + "No Ansys instances"
+            + target
+            + " have been found."
+        )

--- a/src/ansys/mapdl/core/cli/stop.py
+++ b/src/ansys/mapdl/core/cli/stop.py
@@ -163,6 +163,11 @@ def _stop_instance_on_port(port: int) -> List[int]:
 def _stop_process_tree(pid: int) -> List[int]:
     """Kill the process *pid* and all its children.
 
+    Any :class:`psutil.NoSuchProcess` or :class:`psutil.AccessDenied` raised
+    while looking up, killing, or waiting on a process is treated the same
+    way as elsewhere in this module: the process is skipped rather than the
+    exception being propagated.
+
     Parameters
     ----------
     pid : int
@@ -173,25 +178,49 @@ def _stop_process_tree(pid: int) -> List[int]:
     list of int
         Process IDs that are confirmed to have terminated. The parent PID is
         only included when the process is gone before the timeout elapses.
+        An empty list means that the process could not be found or that
+        nothing could be killed.
+
+    Raises
+    ------
+    ValueError
+        When *pid* cannot be converted to an integer.
     """
     try:
         pid = int(pid)
     except (TypeError, ValueError) as err:
         raise ValueError("PID provided could not be converted to int.") from err
 
-    proc = psutil.Process(pid)
+    try:
+        proc = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        return []
 
     stopped: List[int] = []
-    for child in proc.children(recursive=True):
-        _kill_process(child)
+
+    try:
+        children = proc.children(recursive=True)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        children = []
+
+    for child in children:
+        try:
+            _kill_process(child)
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
         stopped.append(child.pid)
 
-    _kill_process(proc)
+    try:
+        _kill_process(proc)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return stopped
 
     try:
         proc.wait(timeout=_TERMINATION_TIMEOUT)
     except psutil.TimeoutExpired:
         return stopped
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        pass
 
     stopped.append(pid)
     return stopped

--- a/src/ansys/mapdl/core/launcher/connection.py
+++ b/src/ansys/mapdl/core/launcher/connection.py
@@ -267,7 +267,7 @@ def close_all_local_instances(port_range: range | None = None) -> None:
     from ansys.mapdl.core.cli.stop import stop
 
     if port_range is None:
-        stop(port=None, pid=None, all=True)
+        stop(all=True)
     else:
         for port in port_range:
-            stop(port=port, pid=None, all=False)
+            stop(port=port)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -271,7 +271,10 @@ def test_pymapdl_stop_permission_handling(run_cli):
     with (
         patch("psutil.process_iter", return_value=test_processes),
         patch("psutil.pid_exists", return_value=True),
-        patch("ansys.mapdl.core.cli.stop._kill_process", side_effect=mock_kill_process),
+        patch(
+            "ansys.mapdl.core.cli.stop._kill_process",
+            side_effect=mock_kill_process,
+        ),
     ):
 
         # Test 1: stop --all should not crash and only kill current user's ANSYS processes
@@ -327,7 +330,10 @@ def test_pymapdl_stop_with_username_containing_domain(run_cli):
         patch("getpass.getuser", return_value=current_user),
         patch("psutil.process_iter", return_value=[mock_process]),
         patch("psutil.pid_exists", return_value=True),
-        patch("ansys.mapdl.core.cli.stop._kill_process", side_effect=mock_kill_process),
+        patch(
+            "ansys.mapdl.core.cli.stop._kill_process",
+            side_effect=mock_kill_process,
+        ),
     ):
         killed_processes.clear()
         output = run_cli("stop --all")
@@ -2026,27 +2032,28 @@ def test_stop_port_kill_raises(run_cli):
 
 @requires("click")
 def test_stop_pid_invalid():
-    """Test stop callback with non-integer PID hits the ValueError branch (lines 149-150)."""
+    """Test the stop callback reports a PID that cannot be converted to int."""
     import click
     from click.testing import CliRunner
 
-    from ansys.mapdl.core.cli.stop import stop as stop_cmd
-
-    mock_proc = MagicMock(spec=psutil.Process)
-    mock_proc.children.return_value = []
+    from ansys.mapdl.core.cli.stop import stop_cli
 
     @click.command()
     def invoke_with_invalid_pid():
         """Wrapper that calls stop callback with a non-integer pid string."""
-        stop_cmd.callback(port=None, pid="not-an-int", all=False)
+        stop_cli.callback(port=None, pid="not-an-int", all=False)
 
     runner = CliRunner()
-    with (
-        patch("psutil.Process", return_value=mock_proc),
-        patch("ansys.mapdl.core.cli.stop._kill_process"),
-    ):
-        result = runner.invoke(invoke_with_invalid_pid, [])
+    result = runner.invoke(invoke_with_invalid_pid, [])
     assert "pid provided could not be converted to int" in result.output.lower()
+
+
+def test_stop_func_pid_invalid():
+    """``stop`` raises ValueError when the PID cannot be converted to int."""
+    from ansys.mapdl.core.cli.stop import stop
+
+    with pytest.raises(ValueError, match="could not be converted to int"):
+        stop(pid="not-an-int")
 
 
 @requires("click")
@@ -2076,12 +2083,12 @@ def test_stop_pid_kills_children(run_cli):
 
 @requires("click")
 def test_stop_pid_kill_failed(run_cli):
-    """Test stop --pid reports error when p.status == \'running\' after kill (line 162)."""
+    """Test stop --pid reports an error when the process outlives the kill."""
     pid = 12345
     mock_proc = MagicMock(spec=psutil.Process)
     mock_proc.children.return_value = []
-    # Simulate kill failure: p.status attribute equals the string "running"
-    mock_proc.status = "running"
+    # The process is still around once the termination timeout elapses.
+    mock_proc.wait.side_effect = psutil.TimeoutExpired(5)
 
     with (
         patch("psutil.Process", return_value=mock_proc),

--- a/tests/test_cli_funcs.py
+++ b/tests/test_cli_funcs.py
@@ -561,3 +561,71 @@ def test_connect_to_instance_wraps_configuration_failures():
     ):
         with pytest.raises(MapdlConnectionError, match="Could not resolve"):
             connect_to_instance(port=-1)
+
+
+def test_connect_to_instance_attaches_the_original_error_as_a_note():
+    """The low-level error is kept as a note instead of being appended inline."""
+    from ansys.mapdl.core.cli.helpers import connect_to_instance
+
+    with patch(
+        "ansys.mapdl.core.launcher.connection.connect_to_existing",
+        side_effect=ConnectionError("refused"),
+    ):
+        with pytest.raises(MapdlConnectionError) as excinfo:
+            connect_to_instance(ip="127.0.0.1", port=50052)
+
+    assert excinfo.value.notes == "refused"
+
+
+def test_connect_to_instance_suppresses_the_original_traceback():
+    """The re-raised error hides the low-level traceback, showing only its message."""
+    from ansys.mapdl.core.cli.helpers import connect_to_instance
+
+    with patch(
+        "ansys.mapdl.core.launcher.connection.connect_to_existing",
+        side_effect=ConnectionError("refused"),
+    ):
+        with pytest.raises(MapdlConnectionError) as excinfo:
+            connect_to_instance(ip="127.0.0.1", port=50052)
+
+    assert excinfo.value.__cause__ is None
+    assert excinfo.value.__suppress_context__ is True
+
+
+@pytest.mark.parametrize("error", [KeyError("boom"), AttributeError("boom")])
+def test_connect_to_instance_does_not_mask_unexpected_configuration_errors(error):
+    """Errors unrelated to configuration resolution are not disguised as connection errors."""
+    from ansys.mapdl.core.cli.helpers import connect_to_instance
+
+    with patch(
+        "ansys.mapdl.core.launcher.config.resolve_launch_config", side_effect=error
+    ):
+        with pytest.raises(type(error)):
+            connect_to_instance()
+
+
+@pytest.mark.parametrize("error", [KeyError("boom"), RuntimeError("boom")])
+def test_connect_to_instance_does_not_mask_unexpected_connection_errors(error):
+    """Errors unrelated to the connection attempt are not disguised as connection errors."""
+    from ansys.mapdl.core.cli.helpers import connect_to_instance
+
+    with patch(
+        "ansys.mapdl.core.launcher.connection.connect_to_existing", side_effect=error
+    ):
+        with pytest.raises(type(error)):
+            connect_to_instance()
+
+
+def test_connect_to_instance_does_not_double_wrap_mapdl_connection_errors():
+    """A MapdlConnectionError raised by the client itself is not wrapped again."""
+    from ansys.mapdl.core.cli.helpers import connect_to_instance
+
+    original = MapdlConnectionError("gRPC handshake failed")
+    with patch(
+        "ansys.mapdl.core.launcher.connection.connect_to_existing",
+        side_effect=original,
+    ):
+        with pytest.raises(MapdlConnectionError) as excinfo:
+            connect_to_instance()
+
+    assert excinfo.value is original

--- a/tests/test_cli_funcs.py
+++ b/tests/test_cli_funcs.py
@@ -1,0 +1,563 @@
+# Copyright (C) 2016 - 2026 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2016 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for the plain functions behind the ``pymapdl`` CLI commands.
+
+Each ``pymapdl`` sub-command is a thin Click wrapper (``<name>_cli``) around a
+plain function (``<name>``) that lives in the same module, for example
+:func:`ansys.mapdl.core.cli.stop.stop`. These tests exercise the plain
+functions directly, without going through Click.
+"""
+
+import getpass
+import pathlib
+from unittest.mock import MagicMock, patch
+
+import psutil
+import pytest
+
+from ansys.mapdl.core.cli.check import check, format_info
+from ansys.mapdl.core.cli.convert import convert, resolve_graphics_backend
+from ansys.mapdl.core.cli.exec import exec_commands, resolve_command_block
+from ansys.mapdl.core.cli.help import help_command
+from ansys.mapdl.core.cli.list_instances import list_instances
+from ansys.mapdl.core.cli.skills import (
+    UnknownSkillError,
+    UnsupportedScopeError,
+    install_skill,
+    list_skills,
+    plan_skill_install,
+    show_skill,
+)
+from ansys.mapdl.core.cli.start import start
+from ansys.mapdl.core.cli.stop import stop
+from ansys.mapdl.core.errors import MapdlConnectionError, MapdlRuntimeError
+from ansys.mapdl.core.plotting import GraphicsBackend
+
+MOCK_SKILL_CONTENT = """\
+---
+name: pymapdl-cli
+description: Test skill description.
+---
+
+# Test Skill
+
+Test content here.
+"""
+
+
+def _make_mock_skills_dir(tmp_path: pathlib.Path) -> pathlib.Path:
+    """Create a minimal fake skills directory."""
+    skill_dir = tmp_path / "pymapdl-cli"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(MOCK_SKILL_CONTENT, encoding="utf-8")
+    return tmp_path
+
+
+def _make_mapdl_process(pid: int, port: int = 50052, name: str = "ansys251"):
+    """Return a mock MAPDL process owned by the current user."""
+    proc = MagicMock(spec=psutil.Process)
+    proc.pid = pid
+    proc.name.return_value = name
+    proc.info = {"name": name}
+    proc.status.return_value = psutil.STATUS_RUNNING
+    proc.username.return_value = getpass.getuser()
+    proc.cmdline.return_value = ["ansys251", "-grpc", "-port", str(port)]
+    proc.children.return_value = []
+    proc.cwd.return_value = "/cwd/of/ansys251"
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# Plain functions are not Click commands
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "func", [check, convert, exec_commands, help_command, list_instances, start, stop]
+)
+def test_plain_functions_are_not_click_commands(func):
+    """The plain function is a regular callable, not a ``click.Command``."""
+    assert not hasattr(func, "callback"), f"{func.__name__} must not be a Click command"
+    assert not hasattr(func, "main"), f"{func.__name__} must not be a Click command"
+
+
+# ---------------------------------------------------------------------------
+# stop
+# ---------------------------------------------------------------------------
+
+
+def test_stop_defaults_to_the_default_port():
+    """Without arguments, the instance on port 50052 is targeted."""
+    from ansys.mapdl.core.cli.constants import MAPDL_DEFAULT_PORT
+
+    with patch("ansys.mapdl.core.cli.stop.get_ansys_process_from_port") as mock_get:
+        mock_get.return_value = None
+        assert stop() == []
+
+    mock_get.assert_called_once_with(MAPDL_DEFAULT_PORT)
+
+
+def test_stop_returns_the_killed_pid():
+    """The PID of the instance stopped by port is returned."""
+    proc = _make_mapdl_process(pid=4321)
+
+    with (
+        patch(
+            "ansys.mapdl.core.cli.stop.get_ansys_process_from_port",
+            return_value=proc,
+        ),
+        patch("ansys.mapdl.core.cli.stop._kill_process") as mock_kill,
+    ):
+        assert stop(port=50053) == [4321]
+
+    mock_kill.assert_called_once_with(proc)
+
+
+def test_stop_all_returns_every_killed_pid():
+    """``all=True`` stops every MAPDL process owned by the current user."""
+    procs = [_make_mapdl_process(pid=1), _make_mapdl_process(pid=2)]
+
+    with (
+        patch("psutil.process_iter", return_value=procs),
+        patch("psutil.pid_exists", return_value=True),
+        patch("ansys.mapdl.core.cli.stop._kill_process"),
+    ):
+        assert stop(all=True) == [1, 2]
+
+
+def test_stop_all_takes_precedence_over_port():
+    """``all=True`` wins over an explicit port."""
+    with (
+        patch("psutil.process_iter", return_value=[]),
+        patch("ansys.mapdl.core.cli.stop.get_ansys_process_from_port") as mock_get,
+    ):
+        assert stop(port=50055, all=True) == []
+
+    mock_get.assert_not_called()
+
+
+def test_stop_by_pid_kills_children_first():
+    """Children are killed before the parent process."""
+    child = MagicMock(spec=psutil.Process)
+    child.pid = 99
+    parent = MagicMock(spec=psutil.Process)
+    parent.children.return_value = [child]
+
+    killed = []
+
+    with (
+        patch("psutil.Process", return_value=parent),
+        patch(
+            "ansys.mapdl.core.cli.stop._kill_process",
+            side_effect=lambda proc: killed.append(proc),
+        ),
+    ):
+        stopped = stop(pid=12345)
+
+    assert killed == [child, parent]
+    assert stopped == [99, 12345]
+
+
+def test_stop_by_pid_omits_a_surviving_process():
+    """A process that outlives the kill is not reported as stopped."""
+    parent = MagicMock(spec=psutil.Process)
+    parent.children.return_value = []
+    parent.wait.side_effect = psutil.TimeoutExpired(5)
+
+    with (
+        patch("psutil.Process", return_value=parent),
+        patch("ansys.mapdl.core.cli.stop._kill_process"),
+    ):
+        assert stop(pid=12345) == []
+
+
+# ---------------------------------------------------------------------------
+# list_instances
+# ---------------------------------------------------------------------------
+
+
+def test_list_instances_returns_a_table():
+    """The table holds one row per running instance."""
+    with patch("psutil.process_iter", return_value=[_make_mapdl_process(pid=777)]):
+        table = list_instances()
+
+    assert "gRPC port" in table
+    assert "777" in table
+    assert "Command line" not in table
+
+
+def test_list_instances_long_adds_every_column():
+    """``long=True`` implies both the command line and the working directory."""
+    with patch("psutil.process_iter", return_value=[_make_mapdl_process(pid=777)]):
+        table = list_instances(long=True)
+
+    assert "Command line" in table
+    assert "Working directory" in table
+    assert "/cwd/of/ansys251" in table
+
+
+def test_list_instances_only_instances():
+    """``instances=True`` hides the child processes and the extra column."""
+    proc = _make_mapdl_process(pid=777)
+    proc.children.return_value = []
+
+    with patch("psutil.process_iter", return_value=[proc]):
+        table = list_instances(instances=True)
+
+    assert "Is Instance" not in table
+    assert "777" not in table
+
+
+# ---------------------------------------------------------------------------
+# convert
+# ---------------------------------------------------------------------------
+
+
+def test_convert_returns_python_code():
+    """APDL commands are converted to PyMAPDL calls."""
+    assert convert("/prep7", only_commands=True).strip() == "mapdl.prep7()"
+
+
+@pytest.mark.parametrize("backend", ["pyvista", "PYVISTA", "pyVISTa"])
+def test_resolve_graphics_backend_accepts_any_case(backend):
+    """Backend names are case insensitive."""
+    assert resolve_graphics_backend(backend) is GraphicsBackend.PYVISTA
+
+
+def test_resolve_graphics_backend_passes_members_through():
+    """An already resolved member is returned unchanged."""
+    assert resolve_graphics_backend(GraphicsBackend.MAPDL) is GraphicsBackend.MAPDL
+
+
+def test_resolve_graphics_backend_rejects_unknown_names():
+    """An unknown backend name raises ValueError."""
+    with pytest.raises(ValueError, match="Invalid graphics backend"):
+        resolve_graphics_backend("no_exists")
+
+
+def test_resolve_graphics_backend_none():
+    """``None`` means the MAPDL default is kept."""
+    assert resolve_graphics_backend(None) is None
+
+
+# ---------------------------------------------------------------------------
+# start
+# ---------------------------------------------------------------------------
+
+
+def test_start_always_launches_a_new_instance():
+    """``start`` forces ``start_instance=True`` and returns the address."""
+    with patch("ansys.mapdl.core.launcher.launch_mapdl_process") as mock_launch:
+        mock_launch.return_value = ("127.0.0.1", 50054, 4242)
+
+        assert start(port=50054, nproc=8) == ("127.0.0.1", 50054, 4242)
+
+    kwargs = mock_launch.call_args.kwargs
+    assert kwargs["start_instance"] is True
+    assert kwargs["port"] == 50054
+    assert kwargs["nproc"] == 8
+
+
+# ---------------------------------------------------------------------------
+# check
+# ---------------------------------------------------------------------------
+
+
+def test_check_returns_the_information_dictionary():
+    """``check`` connects and returns the diagnostic dictionary."""
+    info = {"connection": {"ip": "127.0.0.1", "port": 50052}}
+
+    with (
+        patch("ansys.mapdl.core.cli.check.connect_to_instance") as mock_connect,
+        patch("ansys.mapdl.core.information.get_mapdl_info", return_value=info),
+    ):
+        assert check(port=50052) == info
+
+    assert mock_connect.call_args.kwargs["port"] == 50052
+
+
+def test_check_propagates_connection_errors():
+    """A connection failure surfaces as MapdlConnectionError."""
+    with patch(
+        "ansys.mapdl.core.cli.check.connect_to_instance",
+        side_effect=MapdlConnectionError("refused"),
+    ):
+        with pytest.raises(MapdlConnectionError):
+            check()
+
+
+def test_format_info_renders_sections_and_subsections():
+    """Nested dictionaries become indented subsections."""
+    report = format_info(
+        {
+            "connection": {"ip": "127.0.0.1", "is_local": True},
+            "information": {"units": {"length": "meter"}},
+        }
+    )
+    lines = report.splitlines()
+
+    assert "Connection" in lines
+    assert "  Units" in lines
+
+    ip_line = next(line for line in lines if line.strip().startswith("Ip"))
+    assert ip_line.startswith("  ") and ip_line.endswith("127.0.0.1")
+
+    length_line = next(line for line in lines if line.strip().startswith("Length"))
+    assert length_line.startswith("    ") and length_line.endswith("meter")
+
+
+def test_format_info_reports_section_errors():
+    """A section holding an error only shows that error."""
+    report = format_info({"mesh": {"error": "not available"}})
+
+    assert "Error" in report
+    assert "not available" in report
+
+
+def test_format_info_applies_the_style_callback():
+    """Section titles go through the style callable."""
+    report = format_info({"mesh": {"n_node": 4}}, style=lambda text: f"<{text}>")
+
+    assert "<Mesh>" in report
+
+
+# ---------------------------------------------------------------------------
+# exec_commands
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_command_block_joins_commands():
+    """Several commands are joined with newlines."""
+    assert resolve_command_block(commands=["/prep7", "SAVE"]) == "/prep7\nSAVE"
+
+
+def test_resolve_command_block_reads_a_script(tmp_path):
+    """The content of a script file is used as is."""
+    script = tmp_path / "script.inp"
+    script.write_text("/prep7\nSAVE\n")
+
+    assert "SAVE" in resolve_command_block(script_file=str(script))
+
+
+def test_resolve_command_block_rejects_several_sources(tmp_path):
+    """Only one command source may be given at a time."""
+    script = tmp_path / "script.inp"
+    script.write_text("/prep7\n")
+
+    with pytest.raises(ValueError, match="Only one input source"):
+        resolve_command_block(commands=["/prep7"], script_file=str(script))
+
+
+def test_resolve_command_block_rejects_no_source():
+    """At least one command source is required."""
+    with patch("ansys.mapdl.core.cli.exec._stdin_has_data", return_value=False):
+        with pytest.raises(ValueError, match="Provide commands"):
+            resolve_command_block()
+
+
+def test_resolve_command_block_rejects_empty_input():
+    """Blank commands are rejected."""
+    with pytest.raises(ValueError, match="input is empty"):
+        resolve_command_block(commands=["   "])
+
+
+def test_exec_commands_returns_the_mapdl_output():
+    """The MAPDL output of the command block is returned."""
+    mapdl = MagicMock()
+    mapdl.input_strings.return_value = "output"
+
+    with patch("ansys.mapdl.core.cli.exec.connect_to_instance", return_value=mapdl):
+        assert exec_commands(commands=["/prep7"]) == "output"
+
+    mapdl.input_strings.assert_called_once_with("/prep7")
+
+
+def test_exec_commands_wraps_execution_errors():
+    """An MAPDL failure is reported as MapdlRuntimeError."""
+    mapdl = MagicMock()
+    mapdl.input_strings.side_effect = RuntimeError("bad command")
+
+    with patch("ansys.mapdl.core.cli.exec.connect_to_instance", return_value=mapdl):
+        with pytest.raises(MapdlRuntimeError, match="Command execution failed"):
+            exec_commands(commands=["/prep7"])
+
+
+# ---------------------------------------------------------------------------
+# help_command
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("command", ["/PREP7", "K", "*ABBR", r"\*ABBR"])
+def test_help_command_returns_a_docstring(command):
+    """Known MAPDL commands resolve to a rendered docstring."""
+    pytest.importorskip("rich_rst")
+
+    assert help_command(command).strip()
+
+
+def test_help_command_rejects_unknown_commands():
+    """An unknown MAPDL command raises ValueError."""
+    pytest.importorskip("rich_rst")
+
+    with pytest.raises(ValueError, match="No PyMAPDL method found"):
+        help_command("UNKNOWNCMD999")
+
+
+def test_help_command_prefix_is_significant():
+    """``PREP7`` without the slash is not a command name."""
+    pytest.importorskip("rich_rst")
+
+    with pytest.raises(ValueError, match="No PyMAPDL method found"):
+        help_command("PREP7")
+
+
+# ---------------------------------------------------------------------------
+# skills
+# ---------------------------------------------------------------------------
+
+
+def test_list_skills_reads_the_frontmatter(tmp_path):
+    """Name and description come from the skill frontmatter."""
+    skills = list_skills(_make_mock_skills_dir(tmp_path))
+
+    assert [skill.name for skill in skills] == ["pymapdl-cli"]
+    assert skills[0].description == "Test skill description."
+
+
+def test_list_skills_missing_directory(tmp_path):
+    """A missing skills directory yields no skill."""
+    assert list_skills(tmp_path / "does-not-exist") == []
+
+
+def test_show_skill_returns_the_file_content(tmp_path):
+    """The full ``SKILL.md`` is returned, frontmatter included."""
+    content = show_skill("pymapdl-cli", _make_mock_skills_dir(tmp_path))
+
+    assert "# Test Skill" in content
+    assert "name: pymapdl-cli" in content
+
+
+def test_show_skill_unknown(tmp_path):
+    """An unknown skill raises UnknownSkillError listing the alternatives."""
+    with pytest.raises(UnknownSkillError) as excinfo:
+        show_skill("nope", _make_mock_skills_dir(tmp_path))
+
+    assert excinfo.value.available == ["pymapdl-cli"]
+
+
+def test_plan_skill_install_does_not_touch_the_disk(tmp_path, monkeypatch):
+    """Planning only reports the file operations."""
+    monkeypatch.chdir(tmp_path)
+    skills_dir = _make_mock_skills_dir(tmp_path / "skills")
+
+    plan = plan_skill_install("pymapdl-cli", env="claude", skills_dir=skills_dir)
+
+    assert plan.dest_dir == tmp_path / ".claude" / "skills" / "pymapdl-cli"
+    assert plan.config_file == tmp_path / "CLAUDE.md"
+    assert "Copy skill files to" in plan.summary
+    assert not (tmp_path / ".claude").exists()
+
+
+def test_plan_skill_install_rejects_unknown_env(tmp_path):
+    """An unsupported environment raises ValueError."""
+    with pytest.raises(ValueError, match="Unknown environment"):
+        plan_skill_install(
+            "pymapdl-cli", env="notepad", skills_dir=_make_mock_skills_dir(tmp_path)
+        )
+
+
+def test_plan_skill_install_rejects_global_for_copilot(tmp_path):
+    """Copilot only supports a local installation."""
+    with pytest.raises(UnsupportedScopeError):
+        plan_skill_install(
+            "pymapdl-cli",
+            env="copilot",
+            scope="global",
+            skills_dir=_make_mock_skills_dir(tmp_path),
+        )
+
+
+def test_install_skill_writes_the_files(tmp_path, monkeypatch):
+    """A local Claude installation copies the skill and updates CLAUDE.md."""
+    monkeypatch.chdir(tmp_path)
+    skills_dir = _make_mock_skills_dir(tmp_path / "skills")
+
+    messages = install_skill("pymapdl-cli", env="claude", skills_dir=skills_dir)
+
+    assert (tmp_path / ".claude" / "skills" / "pymapdl-cli" / "SKILL.md").exists()
+    claude_md = (tmp_path / "CLAUDE.md").read_text()
+    assert "@.claude/skills/pymapdl-cli/SKILL.md" in claude_md
+    assert any("updated" in message for message in messages)
+
+
+def test_install_skill_is_idempotent(tmp_path, monkeypatch):
+    """Installing twice does not duplicate the reference."""
+    monkeypatch.chdir(tmp_path)
+    skills_dir = _make_mock_skills_dir(tmp_path / "skills")
+
+    install_skill("pymapdl-cli", env="claude", skills_dir=skills_dir)
+    messages = install_skill("pymapdl-cli", env="claude", skills_dir=skills_dir)
+
+    claude_md = (tmp_path / "CLAUDE.md").read_text()
+    assert claude_md.count("@.claude/skills/pymapdl-cli/SKILL.md") == 1
+    assert any("already present" in message for message in messages)
+
+
+def test_install_skill_cursor_writes_a_rule(tmp_path, monkeypatch):
+    """The cursor environment gets a single ``.mdc`` rule file."""
+    monkeypatch.chdir(tmp_path)
+    skills_dir = _make_mock_skills_dir(tmp_path / "skills")
+
+    install_skill("pymapdl-cli", env="cursor", skills_dir=skills_dir)
+
+    rule = tmp_path / ".cursor" / "rules" / "pymapdl-cli.mdc"
+    assert "description: Test skill description." in rule.read_text()
+
+
+# ---------------------------------------------------------------------------
+# connect_to_instance
+# ---------------------------------------------------------------------------
+
+
+def test_connect_to_instance_wraps_connection_failures():
+    """Failures while connecting are reported as MapdlConnectionError."""
+    from ansys.mapdl.core.cli.helpers import connect_to_instance
+
+    with patch(
+        "ansys.mapdl.core.launcher.connection.connect_to_existing",
+        side_effect=ConnectionError("refused"),
+    ):
+        with pytest.raises(MapdlConnectionError, match="Could not connect to MAPDL"):
+            connect_to_instance(ip="127.0.0.1", port=50052)
+
+
+def test_connect_to_instance_wraps_configuration_failures():
+    """Failures while resolving the configuration are reported too."""
+    from ansys.mapdl.core.cli.helpers import connect_to_instance
+
+    with patch(
+        "ansys.mapdl.core.launcher.config.resolve_launch_config",
+        side_effect=ValueError("bad port"),
+    ):
+        with pytest.raises(MapdlConnectionError, match="Could not resolve"):
+            connect_to_instance(port=-1)

--- a/tests/test_cli_funcs.py
+++ b/tests/test_cli_funcs.py
@@ -52,6 +52,7 @@ from ansys.mapdl.core.cli.start import start
 from ansys.mapdl.core.cli.stop import stop
 from ansys.mapdl.core.errors import MapdlConnectionError, MapdlRuntimeError
 from ansys.mapdl.core.plotting import GraphicsBackend
+from conftest import requires
 
 MOCK_SKILL_CONTENT = """\
 ---
@@ -266,6 +267,7 @@ def test_stop_by_pid_treats_disappearance_during_wait_as_stopped(exc):
 # ---------------------------------------------------------------------------
 
 
+@requires("tabulate")
 def test_list_instances_returns_a_table():
     """The table holds one row per running instance."""
     with patch("psutil.process_iter", return_value=[_make_mapdl_process(pid=777)]):
@@ -276,6 +278,7 @@ def test_list_instances_returns_a_table():
     assert "Command line" not in table
 
 
+@requires("tabulate")
 def test_list_instances_long_adds_every_column():
     """``long=True`` implies both the command line and the working directory."""
     with patch("psutil.process_iter", return_value=[_make_mapdl_process(pid=777)]):
@@ -286,6 +289,7 @@ def test_list_instances_long_adds_every_column():
     assert "/cwd/of/ansys251" in table
 
 
+@requires("tabulate")
 def test_list_instances_only_instances():
     """``instances=True`` hides the child processes and the extra column."""
     proc = _make_mapdl_process(pid=777)

--- a/tests/test_cli_funcs.py
+++ b/tests/test_cli_funcs.py
@@ -191,6 +191,76 @@ def test_stop_by_pid_omits_a_surviving_process():
         assert stop(pid=12345) == []
 
 
+def test_stop_by_pid_missing_process_returns_empty_list():
+    """A PID that no longer exists does not raise, it just reports nothing stopped."""
+    with patch("psutil.Process", side_effect=psutil.NoSuchProcess(12345)):
+        assert stop(pid=12345) == []
+
+
+def test_stop_by_pid_handles_unreachable_children():
+    """A child that disappears/cannot be inspected while listing does not raise."""
+    parent = MagicMock(spec=psutil.Process)
+    parent.children.side_effect = psutil.NoSuchProcess(12345)
+
+    with (
+        patch("psutil.Process", return_value=parent),
+        patch("ansys.mapdl.core.cli.stop._kill_process") as mock_kill,
+    ):
+        assert stop(pid=12345) == [12345]
+
+    mock_kill.assert_called_once_with(parent)
+
+
+@pytest.mark.parametrize("exc", [psutil.NoSuchProcess(99), psutil.AccessDenied(99)])
+def test_stop_by_pid_skips_a_child_that_cannot_be_killed(exc):
+    """A child that vanishes or is inaccessible while being killed is skipped, not raised."""
+    child = MagicMock(spec=psutil.Process)
+    child.pid = 99
+    parent = MagicMock(spec=psutil.Process)
+    parent.children.return_value = [child]
+
+    def _kill_side_effect(proc):
+        if proc is child:
+            raise exc
+
+    with (
+        patch("psutil.Process", return_value=parent),
+        patch("ansys.mapdl.core.cli.stop._kill_process", side_effect=_kill_side_effect),
+    ):
+        assert stop(pid=12345) == [12345]
+
+
+@pytest.mark.parametrize(
+    "exc", [psutil.NoSuchProcess(12345), psutil.AccessDenied(12345)]
+)
+def test_stop_by_pid_does_not_raise_when_parent_kill_fails(exc):
+    """A parent that vanishes or is inaccessible while being killed does not raise."""
+    parent = MagicMock(spec=psutil.Process)
+    parent.children.return_value = []
+
+    with (
+        patch("psutil.Process", return_value=parent),
+        patch("ansys.mapdl.core.cli.stop._kill_process", side_effect=exc),
+    ):
+        assert stop(pid=12345) == []
+
+
+@pytest.mark.parametrize(
+    "exc", [psutil.NoSuchProcess(12345), psutil.AccessDenied(12345)]
+)
+def test_stop_by_pid_treats_disappearance_during_wait_as_stopped(exc):
+    """If the process is already gone by the time wait() is called, it is reported stopped."""
+    parent = MagicMock(spec=psutil.Process)
+    parent.children.return_value = []
+    parent.wait.side_effect = exc
+
+    with (
+        patch("psutil.Process", return_value=parent),
+        patch("ansys.mapdl.core.cli.stop._kill_process"),
+    ):
+        assert stop(pid=12345) == [12345]
+
+
 # ---------------------------------------------------------------------------
 # list_instances
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_skills.py
+++ b/tests/test_cli_skills.py
@@ -28,7 +28,7 @@ from unittest.mock import patch
 from click.testing import CliRunner
 import pytest
 
-from ansys.mapdl.core.cli.skills import _parse_frontmatter, skills
+from ansys.mapdl.core.cli.skills import _find_skills_dir, _parse_frontmatter, skills
 
 MOCK_SKILL_CONTENT = """\
 ---
@@ -67,6 +67,32 @@ def test_parse_frontmatter_no_frontmatter():
     meta, body = _parse_frontmatter(text)
     assert meta == {}
     assert body == text
+
+
+# ---------------------------------------------------------------------------
+# _find_skills_dir unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_find_skills_dir_via_importlib_resources_points_to_bundled_skills():
+    """The primary lookup resolves to the real, existing skills directory."""
+    skills_dir = _find_skills_dir()
+
+    assert skills_dir.name == "skills"
+    assert skills_dir.parent.name == "core"
+    assert skills_dir.exists()
+    assert (skills_dir / "pymapdl-cli" / "SKILL.md").exists()
+
+
+def test_find_skills_dir_fallback_points_to_the_same_directory():
+    """The ``importlib.resources`` failure fallback resolves to the real skills directory."""
+    with patch("importlib.resources.files", side_effect=ModuleNotFoundError):
+        skills_dir = _find_skills_dir()
+
+    assert skills_dir.name == "skills"
+    assert skills_dir.parent.name == "core"
+    assert skills_dir.exists()
+    assert (skills_dir / "pymapdl-cli" / "SKILL.md").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_launcher/test_connection.py
+++ b/tests/test_launcher/test_connection.py
@@ -1044,19 +1044,15 @@ class TestCloseAllLocalInstances:
         with patch(self._STOP_TARGET) as mock_stop:
             close_all_local_instances()
 
-        mock_stop.assert_called_once_with(port=None, pid=None, all=True)
+        mock_stop.assert_called_once_with(all=True)
 
     def test_port_range_calls_stop_per_port(self):
-        """With a port_range, stop is called once per port with all=False."""
+        """With a port_range, stop is called once per port."""
         ports = range(50052, 50055)
         with patch(self._STOP_TARGET) as mock_stop:
             close_all_local_instances(port_range=ports)
 
         assert mock_stop.call_count == len(ports)
-        for i, port in enumerate(ports):
-            mock_stop.call_args_list[i].assert_called_with(
-                port=port, pid=None, all=False
-            )
 
     def test_port_range_passes_correct_ports(self):
         """Each port in the range is forwarded to stop."""
@@ -1073,7 +1069,7 @@ class TestCloseAllLocalInstances:
             close_all_local_instances(port_range=range(50052, 50056))
 
         for call in mock_stop.call_args_list:
-            assert call.kwargs["all"] is False
+            assert not call.kwargs.get("all", False)
 
     def test_empty_port_range_never_calls_stop(self):
         """An empty range means stop is never invoked."""
@@ -1082,10 +1078,12 @@ class TestCloseAllLocalInstances:
 
         mock_stop.assert_not_called()
 
-    def test_stop_imported_from_correct_module(self):
-        """stop is imported from ansys.mapdl.core.cli.stop, not the cli package."""
-        with patch(self._STOP_TARGET) as mock_stop:
-            close_all_local_instances()
+    def test_stop_is_callable_without_click(self):
+        """The stop used internally is the plain function, not the Click command."""
+        from ansys.mapdl.core.cli.stop import stop
 
-        # The mock target confirms the import path used internally.
-        mock_stop.assert_called_once()
+        assert not hasattr(stop, "callback"), "stop must not be a Click command"
+
+        with patch("ansys.mapdl.core.cli.stop._stop_all_instances") as mock_all:
+            mock_all.return_value = [123]
+            assert stop(all=True) == [123]


### PR DESCRIPTION
## Summary

- Implements https://github.com/ansys/pymapdl/issues/4298: every `pymapdl` CLI sub-command is now a thin [Click](https://click.palletsprojects.com/) wrapper (`<name>_cli`) around a plain, click-independent function (`<name>`) that lives in the same submodule (for example `stop_cli()` on top of `stop()` in `ansys.mapdl.core.cli.stop`).
- The plain functions return data and raise regular exceptions; they never call `click.echo`, `sys.exit`, or `click.UsageError`, so they can be imported and reused from Python without spawning a shell or depending on Click's argument-parsing/output machinery.
- Helpers shared across commands (`connect_to_instance`, `silence_logging`, `get_mapdl_instances`, ...) stay in `ansys.mapdl.core.cli.helpers`; shared defaults live in `ansys.mapdl.core.cli.constants`. Command-specific private helpers keep the `_` prefix and stay in their command's module.
- Fixed a latent bug in `close_all_local_instances` (`launcher/connection.py`), which was calling the Click command object instead of the plain `stop` function.
- Added `doc/source/api/cli.rst` and a new "Use the commands from Python" section in `doc/source/user_guide/cli.rst` documenting the programmatic API and the command-to-function mapping.
- Added `tests/test_cli_funcs.py` with dedicated coverage for the plain functions (mocking, exception handling, argument resolution) across all commands.

## Test plan

- [x] `uv run pytest tests/test_cli.py tests/test_cli_skills.py tests/test_cli_funcs.py tests/test_launcher/test_connection.py tests/test_skill_pymapdl_cli.py` — 336 passed, 2 skipped (Windows/minimal-install only)
- [x] `uv run pre-commit run --all-files` passes
- [x] Manual smoke test of `pymapdl --help`, `pymapdl skills --help`, and `pymapdl convert` from the CLI entry point

Made with [Cursor](https://cursor.com)