### PR TITLE
perf: lazily import MapdlTheme and drop a dead-weight pandas import

### DIFF
--- a/doc/changelog.d/4749.miscellaneous.md
+++ b/doc/changelog.d/4749.miscellaneous.md
@@ -1,0 +1,1 @@
+Lazily import MapdlTheme and drop a dead-weight pandas import

--- a/src/ansys/mapdl/core/commands.py
+++ b/src/ansys/mapdl/core/commands.py
@@ -22,13 +22,13 @@
 
 from functools import wraps
 import re
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 
 from ansys.mapdl.core import _HAS_PANDAS
 
-if _HAS_PANDAS:
+if TYPE_CHECKING:
     import pandas
 
 from ._commands import (

--- a/src/ansys/mapdl/core/plotting/__init__.py
+++ b/src/ansys/mapdl/core/plotting/__init__.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 from enum import Enum
+from typing import Any
 
 from ansys.mapdl.core import _HAS_VISUALIZER
 from ansys.mapdl.core.plotting.consts import (
@@ -44,5 +45,18 @@ class GraphicsBackend(Enum):
     MAPDL = "mapdl"
 
 
-if _HAS_VISUALIZER:
-    from ansys.mapdl.core.plotting.theme import MapdlTheme  # noqa: F401
+def __getattr__(name: str) -> Any:
+    """Lazily import :class:`MapdlTheme <ansys.mapdl.core.plotting.theme.MapdlTheme>`.
+
+    ``MapdlTheme`` pulls in PyVista, Matplotlib, and pandas, which are slow to
+    import and are only needed by code that actually plots something. Most of
+    ``ansys.mapdl.core`` only needs :class:`GraphicsBackend` from this module,
+    so ``MapdlTheme`` is imported on first access instead of at module load
+    time, following :pep:`562`.
+    """
+    if name == "MapdlTheme" and _HAS_VISUALIZER:
+        from ansys.mapdl.core.plotting.theme import MapdlTheme
+
+        return MapdlTheme
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/ansys/mapdl/core/plotting/__init__.py
+++ b/src/ansys/mapdl/core/plotting/__init__.py
@@ -48,7 +48,7 @@ class GraphicsBackend(Enum):
 def __getattr__(name: str) -> Any:
     """Lazily import :class:`MapdlTheme <ansys.mapdl.core.plotting.theme.MapdlTheme>`.
 
-    ``MapdlTheme`` pulls in PyVista, Matplotlib, and pandas, which are slow to
+    ``MapdlTheme`` pulls in PyVista, Matplotlib, and ``cycler``, which are slow to
     import and are only needed by code that actually plots something. Most of
     ``ansys.mapdl.core`` only needs :class:`GraphicsBackend` from this module,
     so ``MapdlTheme`` is imported on first access instead of at module load

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -64,3 +64,16 @@ def test_get_ansys_color_cycle():
     assert len(get_ansys_color_cycle(10)) == 10
     assert len(get_ansys_color_cycle(100)) == 100
     assert np.unique(get_ansys_color_cycle(100), axis=0).shape[0] == 9
+
+
+def test_plotting_lazy_import_mapdl_theme():
+    import ansys.mapdl.core.plotting as plotting
+
+    assert plotting.MapdlTheme is MapdlTheme
+
+
+def test_plotting_getattr_invalid_attribute():
+    import ansys.mapdl.core.plotting as plotting
+
+    with pytest.raises(AttributeError):
+        plotting.non_existing_attribute


### PR DESCRIPTION
## Summary

- Importing `ansys.mapdl.core` eagerly imported `ansys.mapdl.core.plotting`, which unconditionally imported `theme.py` just to re-export `MapdlTheme`. `theme.py` pulls in PyVista, Matplotlib, and `cycler`, even though the far more common need (from `misc.py`, `convert.py`, and therefore the whole package) is just the plain `GraphicsBackend` enum defined in the same module. `MapdlTheme` is now a lazy, [PEP 562](https://peps.python.org/pep-0562/) module attribute, imported only on first access. `from ansys.mapdl.core.plotting import MapdlTheme` keeps working exactly as before.
- `commands.py` separately imported `pandas` at module scope, even though the only two places that build a `DataFrame` already do their own guarded, lazy `import pandas` right where it's used. The dead top-level import is now under `TYPE_CHECKING`, so `mypy` still validates the `"pandas.DataFrame"` return-type hints without paying the import cost at runtime.
- Together, this cuts `import ansys.mapdl.core` from ~1.5s to ~0.17s and `pymapdl --help` from ~1.4s to ~0.29s (measured with `--all-extras` installed), with no behavior change.

## Test plan

- [x] `uv run pre-commit run --files src/ansys/mapdl/core/commands.py src/ansys/mapdl/core/plotting/__init__.py` passes (mypy, black, isort, flake8, numpydoc-validation, etc.)
- [x] Verified `MapdlTheme`, `GraphicsBackend`, and `CommandListingOutput.to_dataframe()` still work correctly at runtime
- [x] Verified plotting-adjacent modules (`mapdl_geometry.py`, `plotting/visualizer.py`, `post.py`, `mapdl_extended.py`, `mapdl_core.py`) still import without error
- [x] Full `tests/test_cli.py`, `tests/test_cli_funcs.py`, `tests/test_cli_skills.py` suites pass (264 passed)
- [x] `tests/test_convert.py` passes (89 passed); `tests/test_misc.py` passes except for two pre-existing tests that require a live MAPDL instance (unrelated to this change)
- [x] Benchmarked `import ansys.mapdl.core` and `pymapdl --help` before/after against the commit this branch is based on, using matched dependency sets (`--all-extras`)

Made with [Cursor](https://cursor.com)