### PR TITLE
feat: identify SIGKILL as a likely OOM cause in gRPC UNAVAILABLE errors

### DIFF
--- a/doc/changelog.d/4750.added.md
+++ b/doc/changelog.d/4750.added.md
@@ -1,0 +1,1 @@
+Identify SIGKILL as a likely OOM cause in gRPC UNAVAILABLE errors

--- a/src/ansys/mapdl/core/errors.py
+++ b/src/ansys/mapdl/core/errors.py
@@ -33,8 +33,9 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 if TYPE_CHECKING:
     from ansys.mapdl.core.mapdl_grpc import MapdlGrpc
 
-from ansys.mapdl.core import LOG as logger
 import grpc
+
+from ansys.mapdl.core import LOG as logger
 
 SIGINT_TRACKER: List[bool] = []
 

--- a/src/ansys/mapdl/core/errors.py
+++ b/src/ansys/mapdl/core/errors.py
@@ -33,9 +33,8 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 if TYPE_CHECKING:
     from ansys.mapdl.core.mapdl_grpc import MapdlGrpc
 
-import grpc
-
 from ansys.mapdl.core import LOG as logger
+import grpc
 
 SIGINT_TRACKER: List[bool] = []
 
@@ -507,12 +506,7 @@ def protect_grpc(func: Callable) -> Callable:
 
                 if error.code() == grpc.StatusCode.UNAVAILABLE:
                     # Very likely the MAPDL server has died.
-                    suggestion = (
-                        "  MAPDL *might* have died because it executed a not-allowed command or ran out of memory.\n"
-                        "  Check the MAPDL command output for more details.\n"
-                        "  Open an issue on GitHub if you need assistance: "
-                        "https://github.com/ansys/pymapdl/issues"
-                    )
+                    suggestion = _build_unavailable_suggestion(mapdl)
 
                 # Generic error
                 handle_generic_grpc_error(error, func, args, kwargs, reason, suggestion)
@@ -532,6 +526,67 @@ def protect_grpc(func: Callable) -> Callable:
         return out
 
     return wrapper
+
+
+def _build_unavailable_suggestion(mapdl: "MapdlGrpc") -> str:
+    """Build the user-facing suggestion for a ``UNAVAILABLE`` gRPC error.
+
+    Parameters
+    ----------
+    mapdl : MapdlGrpc
+        The MAPDL instance whose underlying process just became unreachable.
+
+    Returns
+    -------
+    str
+        A suggestion message. When the locally tracked MAPDL subprocess was
+        terminated by ``SIGKILL``, the message calls that out explicitly and
+        points to the OS Out-Of-Memory (OOM) killer as the most common cause.
+        Otherwise, it falls back to the generic "might have died" message.
+
+    Notes
+    -----
+    The exit signal can only be retrieved when PyMAPDL is the parent process
+    of the local MAPDL subprocess (see
+    :meth:`MapdlGrpc._get_process_exit_signal
+    <ansys.mapdl.core.mapdl_grpc.MapdlGrpc._get_process_exit_signal>`). For
+    remote or previously-running instances, this falls back to the generic
+    message.
+    """
+    exit_signal = None
+    get_exit_signal = getattr(mapdl, "_get_process_exit_signal", None)
+    if callable(get_exit_signal):
+        exit_signal = get_exit_signal()
+
+    if exit_signal == signal.SIGKILL:
+        return (
+            "  MAPDL process was terminated with SIGKILL (signal 9).\n"
+            "  This is commonly caused by the operating system's Out-Of-Memory (OOM) killer forcibly terminating the process,\n"
+            "  but it can also happen if MAPDL was killed manually or by a job scheduler/resource limit.\n"
+            "  Check 'dmesg' / 'journalctl -k' (Linux) or your job scheduler logs for confirmation, and consider reducing\n"
+            "  model size, increasing available memory, or requesting more memory from your job scheduler.\n"
+            "  Open an issue on GitHub if you need assistance: "
+            "https://github.com/ansys/pymapdl/issues"
+        )
+
+    if exit_signal is not None:
+        try:
+            signal_name = signal.Signals(exit_signal).name
+        except ValueError:
+            signal_name = str(exit_signal)
+        return (
+            f"  MAPDL process was terminated by signal {exit_signal} ({signal_name}).\n"
+            "  Check the MAPDL command output or system logs for more details.\n"
+            "  Open an issue on GitHub if you need assistance: "
+            "https://github.com/ansys/pymapdl/issues"
+        )
+
+    return (
+        "  MAPDL *might* have died because it executed a not-allowed command or ran out of memory.\n"
+        "  Check the MAPDL command output for more details.\n"
+        "  Open an issue on GitHub if you need assistance: "
+        "https://github.com/ansys/pymapdl/issues"
+    )
 
 
 def retrieve_mapdl_from_args(args: tuple[Any, ...]) -> "MapdlGrpc":

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -53,12 +53,11 @@ from warnings import warn
 import weakref
 
 from ansys.tools.common.versioning import version_string_as_tuple
+import grpc
 from grpc._channel import _InactiveRpcError, _MultiThreadedRendezvous
+import numpy as np
 from numpy.typing import NDArray
 import psutil
-
-import grpc
-import numpy as np
 
 MSG_IMPORT = """There was a problem importing the ANSYS MAPDL API module `ansys-api-mapdl`.
 Please make sure you have the latest updated version using:

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -53,11 +53,12 @@ from warnings import warn
 import weakref
 
 from ansys.tools.common.versioning import version_string_as_tuple
-import grpc
 from grpc._channel import _InactiveRpcError, _MultiThreadedRendezvous
-import numpy as np
 from numpy.typing import NDArray
 import psutil
+
+import grpc
+import numpy as np
 
 MSG_IMPORT = """There was a problem importing the ANSYS MAPDL API module `ansys-api-mapdl`.
 Please make sure you have the latest updated version using:
@@ -1226,6 +1227,48 @@ class MapdlGrpc(MapdlBase):
             True if the MAPDL process is alive, False otherwise.
         """
         return self._is_alive_subprocess()
+
+    def _get_process_exit_signal(self) -> Optional[int]:
+        """Return the POSIX signal number that terminated the MAPDL process.
+
+        Returns
+        -------
+        int or None
+            The signal number (for example ``9`` for ``SIGKILL``) if the
+            locally tracked subprocess was terminated by a signal. Returns
+            ``None`` if the process is still running, exited normally (a
+            non-negative return code), or if no local process handle is
+            available (for example, when connected to a remote or
+            already-running MAPDL instance, where PyMAPDL is not the parent
+            process and cannot retrieve its exit status).
+
+        Notes
+        -----
+        This relies on ``subprocess.Popen.poll()``, which only reports a
+        negative return code (``-signal_number``) on POSIX platforms when the
+        child was terminated by a signal. It is ``None`` on Windows, where
+        signal-based termination is not exposed the same way.
+
+        A ``SIGKILL`` (9) result is a strong indicator that the process was
+        forcibly terminated by the operating system, most commonly the Linux
+        Out-Of-Memory (OOM) killer, though it can also result from a manual
+        ``kill -9`` or a job scheduler enforcing a resource limit.
+
+        Examples
+        --------
+        >>> mapdl._get_process_exit_signal()
+        9
+        """
+        process = self._mapdl_process
+        if process is None or not hasattr(process, "poll"):
+            return None
+
+        returncode = process.poll()
+        if returncode is None or returncode >= 0:
+            # Still running, or exited normally/with a non-signal error code.
+            return None
+
+        return -returncode
 
     def _post_mortem_checks(self, process=None):
         """Check possible reasons for not having a successful connection."""

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -30,6 +30,7 @@ from ansys.mapdl.core.errors import (
     MapdlExitedError,
     MapdlInvalidRoutineError,
     MapdlRuntimeError,
+    _build_unavailable_suggestion,
     protect_from,
     protect_grpc,
 )
@@ -226,3 +227,56 @@ def test_protect_grpc_reraises_unrelated_value_error():
         raising(mock_mapdl)
 
     assert mock_mapdl._exited is False
+
+
+class TestBuildUnavailableSuggestion:
+    """Tests for _build_unavailable_suggestion."""
+
+    def test_sigkill_points_to_oom(self):
+        """A SIGKILL (9) exit signal produces the OOM-specific suggestion."""
+        mock_mapdl = MagicMock(spec=MapdlGrpc)
+        mock_mapdl._get_process_exit_signal.return_value = 9
+
+        suggestion = _build_unavailable_suggestion(mock_mapdl)
+
+        assert "SIGKILL" in suggestion
+        assert "Out-Of-Memory" in suggestion
+        assert "dmesg" in suggestion
+
+    def test_other_signal_is_named(self):
+        """A non-SIGKILL exit signal is reported by name, without the OOM claim."""
+        mock_mapdl = MagicMock(spec=MapdlGrpc)
+        mock_mapdl._get_process_exit_signal.return_value = 11  # SIGSEGV
+
+        suggestion = _build_unavailable_suggestion(mock_mapdl)
+
+        assert "signal 11" in suggestion
+        assert "SIGSEGV" in suggestion
+        assert "Out-Of-Memory" not in suggestion
+
+    def test_unknown_signal_number_falls_back_to_number(self):
+        """An out-of-range signal number is shown as-is instead of a name."""
+        mock_mapdl = MagicMock(spec=MapdlGrpc)
+        mock_mapdl._get_process_exit_signal.return_value = 999
+
+        suggestion = _build_unavailable_suggestion(mock_mapdl)
+
+        assert "signal 999 (999)" in suggestion
+
+    def test_no_exit_signal_falls_back_to_generic_message(self):
+        """When the exit signal cannot be determined, use the generic message."""
+        mock_mapdl = MagicMock(spec=MapdlGrpc)
+        mock_mapdl._get_process_exit_signal.return_value = None
+
+        suggestion = _build_unavailable_suggestion(mock_mapdl)
+
+        assert "might* have died" in suggestion
+
+    def test_missing_helper_falls_back_to_generic_message(self):
+        """MAPDL objects without the helper (e.g. older mocks) still work."""
+        mock_mapdl = MagicMock()
+        del mock_mapdl._get_process_exit_signal
+
+        suggestion = _build_unavailable_suggestion(mock_mapdl)
+
+        assert "might* have died" in suggestion

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -372,6 +372,53 @@ class TestKillProcess:
         assert call_log == ["start", "end", "start", "end"]
 
 
+class TestGetProcessExitSignal:
+    """Tests for MapdlGrpc._get_process_exit_signal."""
+
+    def test_no_process_handle(self):
+        """Returns None when no process handle is stored."""
+        mock = _make_mock_mapdl()
+        mock._mapdl_process = None
+
+        assert MapdlGrpc._get_process_exit_signal(mock) is None
+
+    def test_handle_without_poll(self):
+        """Returns None when the handle has no 'poll' method (e.g. a bare
+        psutil.Process from a remote/heuristic match)."""
+        mock = _make_mock_mapdl()
+        mock._mapdl_process = object()
+
+        assert MapdlGrpc._get_process_exit_signal(mock) is None
+
+    def test_process_still_running(self):
+        """Returns None when poll() reports the process is still alive."""
+        mock = _make_mock_mapdl()
+        mock._mapdl_process = _make_mock_process(poll_return=None)
+
+        assert MapdlGrpc._get_process_exit_signal(mock) is None
+
+    def test_process_exited_normally(self):
+        """Returns None for a non-negative (non-signal) return code."""
+        mock = _make_mock_mapdl()
+        mock._mapdl_process = _make_mock_process(poll_return=0)
+
+        assert MapdlGrpc._get_process_exit_signal(mock) is None
+
+    def test_process_killed_by_sigkill(self):
+        """Returns 9 (SIGKILL) when poll() reports -9."""
+        mock = _make_mock_mapdl()
+        mock._mapdl_process = _make_mock_process(poll_return=-9)
+
+        assert MapdlGrpc._get_process_exit_signal(mock) == 9
+
+    def test_process_killed_by_other_signal(self):
+        """Returns the signal number for any other negative return code."""
+        mock = _make_mock_mapdl()
+        mock._mapdl_process = _make_mock_process(poll_return=-11)  # SIGSEGV
+
+        assert MapdlGrpc._get_process_exit_signal(mock) == 11
+
+
 class TestRunExitedGuard:
     """The liveness guards live in ``_run``, ahead of ``self._busy = True``."""
 


### PR DESCRIPTION
## Description

When the gRPC channel to MAPDL becomes `UNAVAILABLE` (the server process has died), PyMAPDL previously always raised a generic suggestion:

> MAPDL *might* have died because it executed a not-allowed command or ran out of memory.

This PR adds `MapdlGrpc._get_process_exit_signal()`, which reads the locally tracked subprocess's exit status (available whenever PyMAPDL launched and is the parent of the MAPDL process) to determine whether it was terminated by a POSIX signal:

- If the signal is **SIGKILL (9)**, the error message now explicitly calls this out as consistent with the operating system's **Out-Of-Memory (OOM) killer**, and points the user to `dmesg`/`journalctl -k` (Linux) or their job scheduler logs for confirmation.
- If it's some other signal (for example `SIGSEGV`), it is named explicitly.
- If the exit signal cannot be determined (remote/already-running instance, Windows, or the process is still alive), the original generic message is kept as a fallback.

## Motivation

Investigated via a debug log where a long-running multi-solve workflow died mid-`SOLVE` with a gRPC `UNAVAILABLE`/`Connection refused` error and no MAPDL-side diagnostics — a classic signature of the process being SIGKILL'd by the OS OOM killer. This change makes that diagnosis explicit in the error message instead of leaving users to guess.

## Testing

- Added `TestGetProcessExitSignal` in `tests/test_mapdl_grpc.py` covering: no process handle, handle without `poll()`, still running, normal exit, SIGKILL, and other signals.
- Added `TestBuildUnavailableSuggestion` in `tests/test_errors.py` covering: SIGKILL → OOM suggestion, other named signals, unknown signal numbers, no signal info (fallback), and missing helper (fallback).
- `uv run pre-commit run --all-files` passes on the changed files.
- No changes to `_commands/`; fully backward compatible (only enriches an existing error message).
