### PR TITLE
refactor: remove unneeded threading in mesh_grpc cache updates

### DIFF
--- a/doc/changelog.d/4753.miscellaneous.md
+++ b/doc/changelog.d/4753.miscellaneous.md
@@ -1,0 +1,1 @@
+Remove unneeded threading in mesh_grpc cache updates

--- a/src/ansys/mapdl/core/mesh_grpc.py
+++ b/src/ansys/mapdl/core/mesh_grpc.py
@@ -34,7 +34,7 @@ import numpy as np
 
 from ansys.mapdl.core.common_grpc import DEFAULT_CHUNKSIZE, parse_chunks
 from ansys.mapdl.core.mapdl_grpc import MapdlGrpc
-from ansys.mapdl.core.misc import requires_package, supress_logging, threaded
+from ansys.mapdl.core.misc import requires_package, supress_logging
 
 TMP_NODE_CM = "__NODE__"
 
@@ -79,9 +79,10 @@ class MeshGrpc:
 
         self._freeze_model = False
         self._ignore_cache_reset = False
-        # MAPDL serves one request at a time. Some mesh cache updates run in
-        # separate threads, but this lock serializes the gRPC requests issued by
-        # MeshGrpc (only one mesh-related request is in flight at a time).
+
+        # MAPDL serves one request at a time, so this lock serializes the
+        # gRPC requests issued by MeshGrpc (only one mesh-related request is
+        # in flight at a time).
         self._thread_lock_grpc = threading.Lock()
         self._reset_cache()
 
@@ -162,7 +163,7 @@ class MeshGrpc:
         return self._ignore_cache_reset_context(self)
 
     def _update_cache(self):
-        """Threaded local cache update.
+        """Local cache update.
 
         Used when needing all the geometry entries from MAPDL.
         """
@@ -175,17 +176,11 @@ class MeshGrpc:
 
                 # '_update_cache_elem' runs first and alone: it is not
                 # guarded by '_thread_lock_grpc' and must finish before the
-                # threads below start, otherwise it could race with them.
+                # calls below start, otherwise it could race with them.
                 self._update_cache_elem()
-
-                threads = [
-                    self._update_cache_element_desc(),
-                    self._update_cache_nnum(),
-                    self._update_node_coord(),
-                ]
-
-                for thread in threads:
-                    thread.join()
+                self._update_cache_element_desc()
+                self._update_cache_nnum()
+                self._update_node_coord()
 
                 # somehow requesting path seems to help windows avoid an
                 # outright segfault prior to running CMSEL
@@ -197,7 +192,6 @@ class MeshGrpc:
         else:
             self.logger.debug("Ignoring cache reset.")
 
-    @threaded
     def _update_cache_nnum(self):
         with self._thread_lock_grpc:
             if self._cache_nnum is None:
@@ -212,14 +206,13 @@ class MeshGrpc:
     @property
     def _nnum(self):
         """Return node number cache"""
-        self._update_cache_nnum().join()
+        self._update_cache_nnum()
         return self._cache_nnum
 
     @_nnum.setter
     def _nnum(self, value):
         self._cache_nnum = value
 
-    @threaded
     def _update_cache_element_desc(self):
         with self._thread_lock_grpc:
             if self._cache_element_desc is None:
@@ -229,7 +222,7 @@ class MeshGrpc:
     @property
     def _ekey(self):
         """Element key description"""
-        self._update_cache_element_desc().join()
+        self._update_cache_element_desc()
 
         # convert to ekey format
         if self._cache_element_desc:
@@ -239,7 +232,6 @@ class MeshGrpc:
             return np.vstack(ekey).astype(np.int32)
         return np.array([])
 
-    @threaded
     def _update_node_coord(self):
         with self._thread_lock_grpc:
             if self._node_coord is None:
@@ -505,7 +497,7 @@ class MeshGrpc:
     @property
     def key_option(self):
         """Key options of selected element types."""
-        self._update_cache_element_desc().join()
+        self._update_cache_element_desc()
 
         key_opt = {}
         for einfo in self._cache_element_desc:
@@ -533,7 +525,7 @@ class MeshGrpc:
                [0.75 0.5  4.  ]
                [0.75 0.5  4.5 ]]
         """
-        self._update_node_coord().join()
+        self._update_node_coord()
         if self._node_coord is None:
             return np.empty(0)
         return self._node_coord

--- a/tests/test_mesh_grpc.py
+++ b/tests/test_mesh_grpc.py
@@ -23,6 +23,8 @@
 """Test mesh"""
 
 import os
+import threading
+from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
@@ -33,6 +35,9 @@ if has_dependency("pyvista"):
     import pyvista as pv
 
 from ansys.mapdl.core import examples
+from ansys.mapdl.core.errors import MapdlConnectionError
+from ansys.mapdl.core.mapdl_grpc import MapdlGrpc
+from ansys.mapdl.core.mesh_grpc import MeshGrpc
 
 
 def test_empty_model(mapdl, cleared):
@@ -385,3 +390,60 @@ def test_ignore_cache_reset_context(mapdl, cleared, initial_state):
 
     assert mesh._ignore_cache_reset == initial_state
     mesh._ignore_cache_reset = previous_state
+
+
+def _make_mock_mesh():
+    """Return a 'MeshGrpc' wired to a mocked MAPDL instance."""
+    mesh = MeshGrpc.__new__(MeshGrpc)
+    mock_mapdl = MagicMock(spec=MapdlGrpc)
+    mesh._mapdl_weakref = lambda: mock_mapdl
+    mesh._ignore_cache_reset = False
+    mesh._chunk_size = None
+    mesh._thread_lock_grpc = threading.Lock()
+    mesh.logger = MagicMock()
+    return mesh, mock_mapdl
+
+
+class TestUpdateCacheIsSerial:
+    """MAPDL serves one request at a time, so the cache update must not overlap
+    its requests: doing so has crashed the server with a segmentation
+    violation."""
+
+    UPDATERS = (
+        "_update_cache_elem",
+        "_update_cache_element_desc",
+        "_update_cache_nnum",
+        "_update_node_coord",
+    )
+
+    def test_updates_run_one_after_another_in_the_calling_thread(self):
+        mesh, _ = _make_mock_mesh()
+        order = []
+        threads = []
+
+        def record(name):
+            def update():
+                order.append(name)
+                threads.append(threading.current_thread())
+
+            return update
+
+        for name in self.UPDATERS:
+            setattr(mesh, name, record(name))
+
+        mesh._update_cache()
+
+        assert order == list(self.UPDATERS)
+        assert threads == [threading.current_thread()] * len(self.UPDATERS)
+
+    def test_a_failing_update_propagates(self):
+        """A request which fails must surface instead of leaving an empty cache."""
+        mesh, _ = _make_mock_mesh()
+        for name in self.UPDATERS:
+            setattr(mesh, name, MagicMock())
+        mesh._update_cache_nnum.side_effect = MapdlConnectionError("MAPDL died")
+
+        with pytest.raises(MapdlConnectionError, match="MAPDL died"):
+            mesh._update_cache()
+
+        mesh._update_node_coord.assert_not_called()


### PR DESCRIPTION
## Description

Extracts the `mesh_grpc.py` threading cleanup from #4735 into its own PR, as requested in #4752.

`_update_cache_nnum`, `_update_cache_element_desc`, and `_update_node_coord` all serialize through the shared `_thread_lock_grpc` lock (introduced in #4738). Since every one of these methods now serializes through the same lock, spawning a thread and immediately `.join()`-ing it provided no real parallelism, only overhead.

Changes:
- Remove `@threaded` from `_update_cache_nnum`, `_update_cache_element_desc`, `_update_node_coord`.
- Call them synchronously.
- Drop the now-unneeded `.join()` calls at their call sites (`_update_cache`, `_nnum`, `_ekey`, `key_option`, `nodes`).
- Add `TestUpdateCacheIsSerial` in `tests/test_mesh_grpc.py` verifying the updates run serially in the calling thread and that a failing update propagates.

This does **not** bring over the `rpc_timeout`/`PYMAPDL_RPC_TIMEOUT` deadline changes from #4735 — those are being handled separately per the discussion on #4739/#4751.

## Issue linked

Closes #4752
