### PR TITLE
fix: join PIPE-drainer threads and suppress GC-shutdown logging in __del__ early-exit path

### DIFF
--- a/doc/changelog.d/4754.fixed.md
+++ b/doc/changelog.d/4754.fixed.md
@@ -1,0 +1,1 @@
+Join PIPE-drainer threads and suppress GC-shutdown logging in __del__ early-exit path

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -2175,7 +2175,7 @@ class MapdlGrpc(MapdlBase):
         finally:
             self._exiting = False
 
-    def _disconnect_but_leave_mapdl_running(self) -> None:
+    def _disconnect_but_leave_mapdl_running(self, exiting: bool = False) -> None:
         """Close the client side of the connection, leaving MAPDL running.
 
         Closing a gRPC channel is a purely client-side operation: it cancels
@@ -2187,6 +2187,17 @@ class MapdlGrpc(MapdlBase):
         The instance is marked as exited because the channel is gone. Use
         :meth:`reconnect_to_mapdl` to build a fresh channel and resume driving
         the same MAPDL session.
+
+        Parameters
+        ----------
+        exiting : bool, optional
+            Whether this is being called from best-effort, garbage-collection
+            driven teardown (:meth:`__del__`) rather than the deterministic
+            :meth:`exit` path. If ``True``, this suppresses this method's own
+            debug logging, and is forwarded to :meth:`_close_grpc_channel` and
+            :meth:`_join_pipe_drainer_threads` to suppress theirs, since
+            logging is unreliable during interpreter shutdown. The default is
+            ``False``.
 
         Returns
         -------
@@ -2202,14 +2213,16 @@ class MapdlGrpc(MapdlBase):
         False
         """
         try:
-            self._close_grpc_channel()
+            self._close_grpc_channel(exiting=exiting)
         except Exception as e:
-            self._log.debug("Error closing gRPC channel: %s", e)
+            if not exiting:
+                self._log.debug("Error closing gRPC channel: %s", e)
 
         try:
-            self._join_pipe_drainer_threads()
+            self._join_pipe_drainer_threads(exiting=exiting)
         except Exception as e:
-            self._log.debug("Error joining pipe-drainer threads: %s", e)
+            if not exiting:
+                self._log.debug("Error joining pipe-drainer threads: %s", e)
 
         self._exited = True
 
@@ -2310,6 +2323,13 @@ class MapdlGrpc(MapdlBase):
 
         path = path or getattr(self, "_path", None)
 
+        # ``cleanup_loggers`` is False only when called from ``__del__``, so
+        # it doubles here as a proxy for "this is best-effort, GC-driven
+        # teardown, where logging may be unreliable" (see the ``exiting``
+        # parameters of ``_join_pipe_drainer_threads`` and
+        # ``_close_grpc_channel``).
+        exiting = not cleanup_loggers
+
         # 1. Kill MAPDL process + remove lock file
         try:
             self._exit_mapdl(path)
@@ -2319,15 +2339,17 @@ class MapdlGrpc(MapdlBase):
         # 2. Ensure PIPE-drainer threads (stdout/stderr/startup) are joined so
         # that background reader threads do not leak after teardown.
         try:
-            self._join_pipe_drainer_threads()
+            self._join_pipe_drainer_threads(exiting=exiting)
         except Exception as e:
-            self._log.debug("Error joining pipe-drainer threads: %s", e)
+            if not exiting:
+                self._log.debug("Error joining pipe-drainer threads: %s", e)
 
         # 3. Close gRPC channel
         try:
-            self._close_grpc_channel()
+            self._close_grpc_channel(exiting=exiting)
         except Exception as e:
-            self._log.debug("Error closing gRPC channel: %s", e)
+            if not exiting:
+                self._log.debug("Error closing gRPC channel: %s", e)
 
         # 4. Remove UDS socket file
         try:
@@ -2566,7 +2588,7 @@ class MapdlGrpc(MapdlBase):
                 "continuing without waiting further."
             )
 
-    def _join_pipe_drainer_threads(self) -> None:
+    def _join_pipe_drainer_threads(self, exiting: bool = False) -> None:
         """Join all PIPE-drainer threads, giving each up to 2 seconds.
 
         Waits for ``_stdout_thread``, ``_stderr_thread``, and
@@ -2574,6 +2596,15 @@ class MapdlGrpc(MapdlBase):
         any thread that does not exit within the timeout.  Every attribute
         access is ``getattr``-guarded so this is safe to call on a partially
         constructed instance.
+
+        Parameters
+        ----------
+        exiting : bool, optional
+            Whether this is being called from best-effort, garbage-collection
+            driven teardown (:meth:`__del__`). If ``True``, suppresses the
+            debug log emitted when a thread does not exit in time, since
+            logging is unreliable during interpreter shutdown. The default is
+            ``False``.
 
         Returns
         -------
@@ -2583,7 +2614,7 @@ class MapdlGrpc(MapdlBase):
             t = getattr(self, attr, None)
             if t is not None and t.is_alive():
                 t.join(timeout=2)
-                if t.is_alive():
+                if t.is_alive() and not exiting:
                     self._log.debug(f"Thread {attr} did not exit in time")
 
     def _kill_process(self) -> None:
@@ -4873,10 +4904,12 @@ class MapdlGrpc(MapdlBase):
         ``cleanup_on_exit=False``, did not launch MAPDL itself
         (``_start_instance=False``), or was never actually launched, the full
         teardown in :meth:`_release_resources` is skipped (it would either be
-        a no-op or kill a server this instance does not own). Even then, the
-        gRPC channel is still closed and the instance is marked as exited,
-        because the channel is a purely client-side resource whose
-        ``_poll_connectivity`` daemon thread outlives this object otherwise.
+        a no-op or kill a server this instance does not own). Even then,
+        :meth:`_disconnect_but_leave_mapdl_running` still closes the gRPC
+        channel, joins the PIPE-drainer threads, and marks the instance as
+        exited, because those are purely client-side resources (the
+        ``_poll_connectivity`` daemon thread and the stdout/stderr/startup
+        reader threads) that outlive this object otherwise.
         """
         # Check early exit conditions.
         if (
@@ -4888,7 +4921,7 @@ class MapdlGrpc(MapdlBase):
 
             try:
                 self._exiting = True
-                self._close_grpc_channel()
+                self._disconnect_but_leave_mapdl_running(exiting=True)
             except (
                 Exception
             ):  # nosec B110 - best-effort cleanup during GC; logging is unreliable here

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -3276,6 +3276,46 @@ def test_release_resources_calls_cleanup_loggers():
 
 
 @stack(*PATCH_MAPDL_START)
+def test_release_resources_suppresses_logging_when_called_like_del():
+    """``_release_resources(cleanup_loggers=False)`` must not log on failure.
+
+    Regression test for https://github.com/ansys/pymapdl/issues/4728: when
+    called the way ``__del__`` calls it (``cleanup_loggers=False``), failures
+    while joining PIPE-drainer threads or closing the gRPC channel must not
+    be logged, since logging can be unreliable during interpreter shutdown.
+    """
+    from unittest.mock import MagicMock
+
+    start_parm = {
+        "ip": "123.45.67.99",
+        "local": False,
+        "set_no_abort": False,
+        "launched": True,
+        "start_instance": True,
+        "transport_mode": "insecure",
+    }
+
+    mapdl = pymapdl.Mapdl(disable_run_at_connect=False, **start_parm)
+    mapdl._channel = MagicMock()  # replace stub with real mock
+
+    with (
+        patch.object(mapdl, "_exit_mapdl"),
+        patch.object(mapdl, "_cleanup_loggers"),
+        patch.object(
+            mapdl, "_join_pipe_drainer_threads", side_effect=RuntimeError("boom")
+        ),
+        patch.object(mapdl, "_close_grpc_channel", side_effect=RuntimeError("boom")),
+        patch.object(mapdl, "_log") as mock_log,
+    ):
+        mapdl._release_resources(cleanup_loggers=False)
+
+    mock_log.debug.assert_not_called()
+    assert mapdl._exited
+
+    mapdl.__del__ = lambda: None  # prevent double cleanup on GC
+
+
+@stack(*PATCH_MAPDL_START)
 def test_del_honours_cleanup_on_exit_false():
     """When cleanup_on_exit=False, __del__ must not call _release_resources."""
     start_parm = {
@@ -3295,6 +3335,43 @@ def test_del_honours_cleanup_on_exit_false():
         mapdl.__del__()
 
     mock_release.assert_not_called()
+
+    mapdl._cleanup = True
+    mapdl.__del__ = lambda: None  # prevent cleanup on GC
+
+
+@stack(*PATCH_MAPDL_START)
+def test_del_early_exit_joins_pipe_drainer_threads():
+    """``__del__``'s early-exit branch must not leak PIPE-drainer threads.
+
+    Regression test for https://github.com/ansys/pymapdl/issues/4728: when
+    the full teardown in ``_release_resources`` is skipped (for example
+    ``cleanup_on_exit=False``), the stdout/stderr/startup PIPE-drainer
+    threads must still be joined, not just the gRPC channel closed.
+    """
+    start_parm = {
+        "ip": "123.45.67.99",
+        "local": True,
+        "set_no_abort": False,
+        "launched": True,
+        "start_instance": True,
+        "transport_mode": "insecure",
+    }
+
+    mapdl = pymapdl.Mapdl(disable_run_at_connect=False, **start_parm)
+    mapdl._cleanup = False  # mirrors cleanup_on_exit=False, hits the early exit
+
+    with (
+        patch.object(type(mapdl), "_release_resources") as mock_release,
+        patch.object(mapdl, "_close_grpc_channel") as mock_close_channel,
+        patch.object(mapdl, "_join_pipe_drainer_threads") as mock_join_threads,
+    ):
+        mapdl.__del__()
+
+    mock_release.assert_not_called()
+    mock_close_channel.assert_called_once_with(exiting=True)
+    mock_join_threads.assert_called_once_with(exiting=True)
+    assert mapdl._exited is True
 
     mapdl._cleanup = True
     mapdl.__del__ = lambda: None  # prevent cleanup on GC

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -3247,6 +3247,46 @@ def test_release_resources_closes_channel():
 
 
 @stack(*PATCH_MAPDL_START)
+def test_release_resources_logs_on_deterministic_exit_path():
+    """``_release_resources(cleanup_loggers=True)`` must log defensively.
+
+    Complements ``test_release_resources_suppresses_logging_when_called_like_del``:
+    on the deterministic ``exit()`` path (``cleanup_loggers=True``), failures
+    while joining PIPE-drainer threads or closing the gRPC channel must still
+    be logged, since logging is reliable there.
+    """
+    from unittest.mock import MagicMock
+
+    start_parm = {
+        "ip": "123.45.67.99",
+        "local": False,
+        "set_no_abort": False,
+        "launched": True,
+        "start_instance": True,
+        "transport_mode": "insecure",
+    }
+
+    mapdl = pymapdl.Mapdl(disable_run_at_connect=False, **start_parm)
+    mapdl._channel = MagicMock()  # replace stub with real mock
+
+    with (
+        patch.object(mapdl, "_exit_mapdl"),
+        patch.object(mapdl, "_cleanup_loggers"),
+        patch.object(
+            mapdl, "_join_pipe_drainer_threads", side_effect=RuntimeError("boom")
+        ),
+        patch.object(mapdl, "_close_grpc_channel", side_effect=RuntimeError("boom")),
+        patch.object(mapdl, "_log") as mock_log,
+    ):
+        mapdl._release_resources(cleanup_loggers=True)
+
+    assert mock_log.debug.call_count == 2
+    assert mapdl._exited
+
+    mapdl.__del__ = lambda: None  # prevent double cleanup on GC
+
+
+@stack(*PATCH_MAPDL_START)
 def test_release_resources_calls_cleanup_loggers():
     """_release_resources() must wire _cleanup_loggers()."""
     from unittest.mock import MagicMock

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -316,6 +316,19 @@ class TestJoinPipeDrainerThreads:
 
         mock._log.debug.assert_called()
 
+    def test_exiting_suppresses_logging_when_thread_does_not_exit(self):
+        """``exiting=True`` suppresses the "did not exit in time" debug log."""
+        mock = _make_mock_mapdl()
+        t = MagicMock(spec=threading.Thread)
+        t.is_alive.side_effect = [True, True]  # alive before AND after join
+        t.name = "_stdout_thread"
+        mock._stdout_thread = t
+
+        MapdlGrpc._join_pipe_drainer_threads(mock, exiting=True)
+
+        t.join.assert_called_once_with(timeout=2)
+        mock._log.debug.assert_not_called()
+
 
 class TestKillProcess:
     """Tests for MapdlGrpc._kill_process (orchestrator)."""
@@ -575,6 +588,31 @@ class TestCloseGrpcChannel:
 
         MapdlGrpc._close_grpc_channel(mock)  # must not raise
 
+        channel.close.assert_called_once()
+
+    def test_exiting_suppresses_close_error_logging(self):
+        """``exiting=True`` suppresses debug logging, even on close() failure."""
+        mock = _make_mock_mapdl()
+        channel = Mock()
+        channel.close.side_effect = RuntimeError("channel already gone")
+        mock._channel = channel
+
+        MapdlGrpc._close_grpc_channel(mock, exiting=True)  # must not raise
+
+        mock._log.debug.assert_not_called()
+        assert mock._channel is None
+
+    def test_exiting_suppresses_unsubscribe_error_logging(self):
+        """``exiting=True`` also suppresses logging of unsubscribe() failures."""
+        mock = _make_mock_mapdl()
+        channel = Mock()
+        channel.unsubscribe.side_effect = RuntimeError("not subscribed")
+        mock._channel = channel
+        mock._connectivity_callback = lambda connectivity: None  # noqa: E731
+
+        MapdlGrpc._close_grpc_channel(mock, exiting=True)  # must not raise
+
+        mock._log.debug.assert_not_called()
         channel.close.assert_called_once()
 
 
@@ -976,6 +1014,34 @@ class TestDisconnectButLeaveMapdlRunning:
         MapdlGrpc._disconnect_but_leave_mapdl_running(mock)
 
         mock._join_pipe_drainer_threads.assert_called_once()
+        assert mock._exited is True
+
+    def test_exiting_is_forwarded_to_channel_close_and_thread_join(self):
+        """``exiting=True`` is forwarded to both helper calls.
+
+        Regression test for https://github.com/ansys/pymapdl/issues/4728:
+        ``__del__``'s early-exit branch relies on this forwarding to suppress
+        logging that is unreliable during interpreter shutdown.
+        """
+        mock = _make_mock_mapdl()
+        mock._exited = False
+
+        MapdlGrpc._disconnect_but_leave_mapdl_running(mock, exiting=True)
+
+        mock._close_grpc_channel.assert_called_once_with(exiting=True)
+        mock._join_pipe_drainer_threads.assert_called_once_with(exiting=True)
+        assert mock._exited is True
+
+    def test_exiting_suppresses_own_error_logging(self):
+        """``exiting=True`` suppresses this method's own debug logging."""
+        mock = _make_mock_mapdl()
+        mock._exited = False
+        mock._close_grpc_channel.side_effect = RuntimeError("boom")
+        mock._join_pipe_drainer_threads.side_effect = RuntimeError("boom too")
+
+        MapdlGrpc._disconnect_but_leave_mapdl_running(mock, exiting=True)
+
+        mock._log.debug.assert_not_called()
         assert mock._exited is True
 
     def test_already_exited_still_releases_the_client_side(self):

--- a/tests/test_mapdl_grpc.py
+++ b/tests/test_mapdl_grpc.py
@@ -1016,6 +1016,23 @@ class TestDisconnectButLeaveMapdlRunning:
         mock._join_pipe_drainer_threads.assert_called_once()
         assert mock._exited is True
 
+    def test_a_failing_join_is_logged_on_the_deterministic_path(self):
+        """A failure joining the PIPE-drainer threads is logged when exiting=False.
+
+        Complements ``test_a_failing_close_does_not_prevent_the_join``, which
+        only exercises the channel-close failure branch: this covers the
+        analogous failure branch for ``_join_pipe_drainer_threads``.
+        """
+        mock = _make_mock_mapdl()
+        mock._exited = False
+        mock._join_pipe_drainer_threads.side_effect = RuntimeError("boom")
+
+        MapdlGrpc._disconnect_but_leave_mapdl_running(mock)
+
+        mock._close_grpc_channel.assert_called_once()
+        mock._log.debug.assert_called_once()
+        assert mock._exited is True
+
     def test_exiting_is_forwarded_to_channel_close_and_thread_join(self):
         """``exiting=True`` is forwarded to both helper calls.
 


### PR DESCRIPTION
## Summary

Closes #4728.

`MapdlGrpc.__del__`'s early-exit branch (hit when the instance is already exited, was launched with `cleanup_on_exit=False`, has `_start_instance=False`, or was never `_launched`) used to hand-roll `_close_grpc_channel()` plus `_exited = True` instead of reusing `_disconnect_but_leave_mapdl_running()`, the method `exit()` already uses on the equivalent "leave MAPDL running" paths. As a result, the `_stdout_thread`, `_stderr_thread`, and `_startup_stdout_thread` PIPE-drainer threads were never joined on that path and could leak.

Separately, `_close_grpc_channel(exiting: bool = False)` already had a knob to suppress its own debug logging (logging can be unreliable while the interpreter is tearing down module globals during `__del__`), but no call site ever passed `exiting=True`, so it had no effect.

## Changes

- `__del__`'s early-exit branch now calls `self._disconnect_but_leave_mapdl_running(exiting=True)`, so the channel and all three PIPE-drainer threads are released together, reusing the same tested implementation `exit()` uses.
- Threaded the `exiting` parameter through:
  - `_disconnect_but_leave_mapdl_running(self, exiting: bool = False)` - forwards it to `_close_grpc_channel` and `_join_pipe_drainer_threads`, and suppresses its own debug logging when `True`.
  - `_join_pipe_drainer_threads(self, exiting: bool = False)` - suppresses the "thread did not exit in time" debug log when `True`.
  - `_release_resources()` steps 2 and 3 - pass `exiting=not cleanup_loggers`, since `cleanup_loggers=False` already identifies the GC-driven `__del__` caller vs the deterministic `exit()` caller.
- This makes logging behavior consistent: the deterministic `exit()` path always logs defensively (unchanged behavior), while every GC-driven `__del__` path (both the early-exit branch and the full `_release_resources` teardown) never logs, since `self._log` itself may be unreliable during interpreter shutdown.
- Added regression tests in `tests/test_mapdl_grpc.py` and `tests/test_mapdl.py` covering:
  - `__del__`'s early-exit branch joins the PIPE-drainer threads (not just closing the channel).
  - `exiting=True` suppresses logging at each layer (`_close_grpc_channel`, `_join_pipe_drainer_threads`, `_disconnect_but_leave_mapdl_running`, `_release_resources`).

## Testing

- `uv run pytest tests/test_mapdl_grpc.py -k "not test_get_lock and not test_get_fallback_string"` - 78 passed (the two excluded tests require a live MAPDL connection, unrelated to this change).
- `uv run pytest tests/test_mapdl.py -k "test_del or test_release_resources"` - 6 passed.
- `uv run pre-commit run --files src/ansys/mapdl/core/mapdl_grpc.py tests/test_mapdl_grpc.py tests/test_mapdl.py` - all hooks passed.

## Notes

No changes to `src/ansys/mapdl/core/_commands/`, no backward-incompatible changes (new parameters default to the previous behavior). No changelog fragment added by hand, per repository convention (CI/CD generates it on PR open).
