### PR TITLE
docs: fix duplicated v0.73.0 tag in changelog

### DIFF
--- a/doc/changelog.d/4755.documentation.md
+++ b/doc/changelog.d/4755.documentation.md
@@ -1,0 +1,1 @@
+Fix duplicated v0.73.0 tag in changelog

--- a/doc/source/changelog.rst
+++ b/doc/source/changelog.rst
@@ -569,37 +569,6 @@ This document contains the release notes for the project.
 .. tab-set::
 
 
-  .. tab-item:: Dependencies
-
-    .. list-table::
-        :header-rows: 0
-        :widths: auto
-
-        * - Bump the testing group with 2 updates
-          - `#4555 <https://github.com/ansys/pymapdl/pull/4555>`_
-
-        * - Bump tox from 4.52.0 to 4.52.1
-          - `#4556 <https://github.com/ansys/pymapdl/pull/4556>`_
-
-
-  .. tab-item:: Maintenance
-
-    .. list-table::
-        :header-rows: 0
-        :widths: auto
-
-        * - Bump docker/login-action from 4.0.0 to 4.1.0 in the actions group
-          - `#4558 <https://github.com/ansys/pymapdl/pull/4558>`_
-
-
-.. _v0.73.0:
-
-`0.73.0 <https://github.com/ansys/pymapdl/releases/tag/v0.73.0>`_ - April 16, 2026
-=================================================================================================
-
-.. tab-set::
-
-
   .. tab-item:: Added
 
     .. list-table::
@@ -785,6 +754,12 @@ This document contains the release notes for the project.
         * - Bump the pip group across 3 directories with 1 update
           - `#4550 <https://github.com/ansys/pymapdl/pull/4550>`_
 
+        * - Bump the testing group with 2 updates
+          - `#4555 <https://github.com/ansys/pymapdl/pull/4555>`_
+
+        * - Bump tox from 4.52.0 to 4.52.1
+          - `#4556 <https://github.com/ansys/pymapdl/pull/4556>`_
+
 
   .. tab-item:: Documentation
 
@@ -847,6 +822,9 @@ This document contains the release notes for the project.
 
         * - Bump the actions group across 1 directory with 3 updates
           - `#4534 <https://github.com/ansys/pymapdl/pull/4534>`_
+
+        * - Bump docker/login-action from 4.0.0 to 4.1.0 in the actions group
+          - `#4558 <https://github.com/ansys/pymapdl/pull/4558>`_
 
 
   .. tab-item:: Test


### PR DESCRIPTION
Fixes #4712

The published changelog contained two separate `v0.73.0` sections (dated April 16 and April 20, 2026). This happened because the CI changelog-update automation (#4560) appended a new v0.73.0 block instead of merging into the existing one that had already been generated for that version.

There is only one actual `v0.73.0` GitHub release/tag (April 20, 2026), so this PR merges the two duplicated sections into a single one, combining PR references into their matching categories (Dependencies, Maintenance) and removing the duplicate anchor/heading.