### PR TITLE
test: add regression tests for wrong values in information class (#4540)

### DIFF
--- a/doc/changelog.d/4757.test.md
+++ b/doc/changelog.d/4757.test.md
@@ -1,0 +1,1 @@
+Add regression tests for wrong values in information class (#4540)

--- a/tests/test_information.py
+++ b/tests/test_information.py
@@ -131,6 +131,13 @@ def test_mapdl_info(mapdl, cleared, capfd):
     assert "UPDATE" in out
 
 
+@pytest.mark.xfail(
+    reason=(
+        "The '/STATUS' command does not populate the release/build/update "
+        "version fields on the MAPDL versions tested (v25.1, v25.2, v26.1 "
+        "'ubuntu-cicd' images). See #4760."
+    )
+)
 def test_mapdl_version_release_build_update_format(mapdl, cleared):
     """Regression test for #4540.
 
@@ -143,6 +150,10 @@ def test_mapdl_version_release_build_update_format(mapdl, cleared):
     server-side regression is caught instead of passing silently (the
     previous test only checked ``isinstance(value, str)``, which blank
     strings also satisfy).
+
+    Currently marked ``xfail`` because this is broken on every MAPDL
+    version tested so far (see #4760), not just a one-off regression.
+    Remove the ``xfail`` marker once that issue is resolved.
     """
     info = mapdl.info
 
@@ -180,6 +191,13 @@ def test_mapdl_version_release_build_update_format(mapdl, cleared):
     )
 
 
+@pytest.mark.xfail(
+    reason=(
+        "The '/STATUS'-parsed build number does not match 'mapdl.version' "
+        "on the MAPDL versions tested (v25.1, v25.2, v26.1 'ubuntu-cicd' "
+        "images). See #4760."
+    )
+)
 def test_mapdl_version_build_matches_reported_version(mapdl, cleared):
     """Cross-check the ``/STATUS``-parsed build number against ``mapdl.version``.
 
@@ -189,6 +207,10 @@ def test_mapdl_version_build_matches_reported_version(mapdl, cleared):
     ``/STATUS`` banner is broken or out of sync, which is exactly what
     happened in #4540 (``/STATUS`` reported ``BUILD  0.0`` while
     ``mapdl.version`` correctly reported ``26.1``).
+
+    Currently marked ``xfail`` because this is broken on every MAPDL
+    version tested so far (see #4760), not just a one-off regression.
+    Remove the ``xfail`` marker once that issue is resolved.
     """
     build = mapdl.info.mapdl_version_build
     reported_version = mapdl.version

--- a/tests/test_information.py
+++ b/tests/test_information.py
@@ -23,6 +23,7 @@
 """Test the information module"""
 
 import inspect
+import re
 
 import pytest
 
@@ -128,6 +129,75 @@ def test_mapdl_info(mapdl, cleared, capfd):
     assert "Product" in out
     assert "MAPDL Version" in out
     assert "UPDATE" in out
+
+
+def test_mapdl_version_release_build_update_format(mapdl, cleared):
+    """Regression test for #4540.
+
+    ``mapdl.info.mapdl_version_release``, ``mapdl_version_build`` and
+    ``mapdl_version_update`` are parsed from the ``/STATUS`` MAPDL command
+    output. If MAPDL stops reporting this banner correctly (for example,
+    returning blank/placeholder values such as ``RELEASE`` with nothing
+    after it, ``BUILD  0.0`` or ``UPDATE  0``), these fields silently
+    become useless. This test pins down the expected format so a
+    server-side regression is caught instead of passing silently (the
+    previous test only checked ``isinstance(value, str)``, which blank
+    strings also satisfy).
+    """
+    info = mapdl.info
+
+    release = info.mapdl_version_release
+    build = info.mapdl_version_build
+    update = info.mapdl_version_update
+
+    assert (
+        release
+    ), "MAPDL version release is empty. The '/STATUS' output format may have changed server-side."
+    assert re.fullmatch(
+        r"\d{4}\s*R\d+", release
+    ), f"Unexpected MAPDL version release format: {release!r}"
+
+    assert (
+        build
+    ), "MAPDL version build is empty. The '/STATUS' output format may have changed server-side."
+    assert re.fullmatch(
+        r"\d+(\.\d+)?", build
+    ), f"Unexpected MAPDL version build format: {build!r}"
+    assert build != "0.0", (
+        "MAPDL version build returned the placeholder value '0.0'. "
+        "This means the '/STATUS' command is no longer reporting the "
+        "real build number (see #4540)."
+    )
+
+    assert (
+        update
+    ), "MAPDL version update is empty. The '/STATUS' output format may have changed server-side."
+    assert update.isdigit(), f"Unexpected MAPDL version update format: {update!r}"
+    assert update != "0", (
+        "MAPDL version update returned the placeholder value '0'. "
+        "This means the '/STATUS' command is no longer reporting the "
+        "real update date (see #4540)."
+    )
+
+
+def test_mapdl_version_build_matches_reported_version(mapdl, cleared):
+    """Cross-check the ``/STATUS``-parsed build number against ``mapdl.version``.
+
+    ``mapdl.version`` (backed by ``mapdl.parameters.revision``) comes from a
+    completely different MAPDL query than ``mapdl.info.mapdl_version_build``
+    (parsed from ``/STATUS``). If the two disagree, it means MAPDL's
+    ``/STATUS`` banner is broken or out of sync, which is exactly what
+    happened in #4540 (``/STATUS`` reported ``BUILD  0.0`` while
+    ``mapdl.version`` correctly reported ``26.1``).
+    """
+    build = mapdl.info.mapdl_version_build
+    reported_version = mapdl.version
+
+    assert float(build) == pytest.approx(reported_version, abs=1e-6), (
+        f"MAPDL version build parsed from '/STATUS' ({build!r}) does not "
+        f"match 'mapdl.version' ({reported_version!r}). This indicates the "
+        "'/STATUS' command output is no longer reliable server-side."
+    )
 
 
 def test_info_title(mapdl, cleared):


### PR DESCRIPTION
## Description

Adds regression tests targeting #4540, where `mapdl.info.mapdl_version_release`, `mapdl_version_build`, and `mapdl_version_update` (parsed from the `/STATUS` MAPDL command output) can silently return blank or placeholder values (empty release, `BUILD  0.0`, `UPDATE  0`) when the server-side `/STATUS` banner doesn't populate the version fields as expected.

The pre-existing test only checked `isinstance(value, str)`, which blank strings satisfy, so this kind of regression went undetected.

### New tests

- `test_mapdl_version_release_build_update_format`: asserts the three fields are non-empty and match their expected formats (`YYYY RN` for release, numeric for build, digits for update), explicitly rejecting the known placeholder values `""`, `"0.0"`, and `"0"`.
- `test_mapdl_version_build_matches_reported_version`: cross-checks the `/STATUS`-parsed build number against `mapdl.version` (backed by `mapdl.parameters.revision`, a completely independent MAPDL query). Divergence between the two flags a broken `/STATUS` banner server-side.

## Verification

Tested against the `ghcr.io/ansys/mapdl` `*-ubuntu-cicd` Docker images for **v25.1**, **v25.2.7**, and **v26.1.0**. All three show the exact same broken `/STATUS` output (`RELEASE                    BUILD  0.0      UPDATE        0`) while `mapdl.version` correctly reports the real version (`25.1`, `25.2`, `26.1` respectively). This means the issue is not a one-off regression tied to a single MAPDL version, but a longstanding characteristic of at least these container builds.

Because of that broader scope, both new tests are marked `xfail` (see #4760 for the follow-up investigation/fix) instead of failing CI outright. They still document and pin the expected behavior, so the moment `/STATUS` is fixed server-side (or PyMAPDL switches to a more reliable source), the tests will start passing and the `xfail` markers can be removed.

## Issues linked

- Closes #4540
- Tracks the broader, version-independent breakage in #4760
