### PR TITLE
fix: quote XPL file paths that contain spaces

### DIFF
--- a/doc/changelog.d/4759.fixed.md
+++ b/doc/changelog.d/4759.fixed.md
@@ -1,0 +1,1 @@
+Quote XPL file paths that contain spaces

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -125,6 +125,41 @@ def check_valid_routine(routine: Union[str, ROUTINES]) -> bool:
     return True
 
 
+def quote_path_if_needed(path: Union[str, "os.PathLike[str]"]) -> str:
+    """Wrap a path in single quotes if it contains a space.
+
+    MAPDL/APDL command arguments are whitespace-sensitive, so a
+    path with a space must be quoted to be interpreted as a single
+    argument. If the path is already wrapped in single quotes, it is
+    returned unchanged.
+
+    Parameters
+    ----------
+    path : str or os.PathLike
+        Path (or any other command argument) to conditionally wrap in
+        single quotes.
+
+    Returns
+    -------
+    str
+        The path, wrapped in single quotes if it contains a space and
+        was not already wrapped.
+
+    Examples
+    --------
+    >>> quote_path_if_needed("file.rst")
+    'file.rst'
+    >>> quote_path_if_needed("my file.rst")
+    "'my file.rst'"
+    >>> quote_path_if_needed("'my file.rst'")
+    "'my file.rst'"
+    """
+    path = str(path)
+    if " " in path and not (path.startswith("'") and path.endswith("'")):
+        return f"'{path}'"
+    return path
+
+
 def is_float(input_string: str) -> bool:
     """Returns true when a string can be converted to a float"""
     try:

--- a/src/ansys/mapdl/core/misc.py
+++ b/src/ansys/mapdl/core/misc.py
@@ -160,6 +160,38 @@ def quote_path_if_needed(path: Union[str, "os.PathLike[str]"]) -> str:
     return path
 
 
+def unquote_path(path: Union[str, "os.PathLike[str]"]) -> str:
+    """Remove a single pair of wrapping single quotes from a path.
+
+    This is the counterpart of :func:`quote_path_if_needed`. Use it
+    before performing file-name inspection (for example, checking the
+    file suffix with :class:`pathlib.Path`) on a path that might have
+    been quoted to survive being passed as an MAPDL/APDL command
+    argument.
+
+    Parameters
+    ----------
+    path : str or os.PathLike
+        Path (or any other command argument) to conditionally unwrap.
+
+    Returns
+    -------
+    str
+        The path, without the wrapping single quotes if it had any.
+
+    Examples
+    --------
+    >>> unquote_path("file.rst")
+    'file.rst'
+    >>> unquote_path("'my file.rst'")
+    'my file.rst'
+    """
+    path = str(path)
+    if path.startswith("'") and path.endswith("'") and len(path) >= 2:
+        return path[1:-1]
+    return path
+
+
 def is_float(input_string: str) -> bool:
     """Returns true when a string can be converted to a float"""
     try:

--- a/src/ansys/mapdl/core/xpl.py
+++ b/src/ansys/mapdl/core/xpl.py
@@ -31,7 +31,7 @@ import numpy as np
 
 from .common_grpc import ANSYS_VALUE_TYPE
 from .errors import MapdlRuntimeError
-from .misc import quote_path_if_needed, random_string
+from .misc import quote_path_if_needed, random_string, unquote_path
 
 MYCTYPE = {
     np.int32: "I",
@@ -450,7 +450,7 @@ class ansXpl:
             num_last = -1
 
         dtype = np.double
-        file_extension = pathlib.Path(self._filename).suffix[1:]
+        file_extension = pathlib.Path(unquote_path(self._filename)).suffix[1:]
         if file_extension.lower() != "rst":
             raise MapdlRuntimeError(
                 "This method only supports extracting records from result files"

--- a/src/ansys/mapdl/core/xpl.py
+++ b/src/ansys/mapdl/core/xpl.py
@@ -31,7 +31,7 @@ import numpy as np
 
 from .common_grpc import ANSYS_VALUE_TYPE
 from .errors import MapdlRuntimeError
-from .misc import random_string
+from .misc import quote_path_if_needed, random_string
 
 MYCTYPE = {
     np.int32: "I",
@@ -102,7 +102,7 @@ class ansXpl:
         Opening the file.mode ANSYS File
         """
         self._filename = filename
-        out = self._mapdl.run(f"*XPL,OPEN,{filename},,{option}")
+        out = self._mapdl.run(f"*XPL,OPEN,{quote_path_if_needed(filename)},,{option}")
         self._open = True
         return out
 
@@ -365,7 +365,7 @@ class ansXpl:
          =====      ANSYS File Xplorer : Copy file.full ANSYS file to file tmpfile.full
             >>      Remove existing output file tmpfile.full
         """
-        return self._mapdl.run(f"*XPL,COPY,{newfile},{option}")
+        return self._mapdl.run(f"*XPL,COPY,{quote_path_if_needed(newfile)},{option}")
 
     def save(self):
         """Save the current file, ignoring the marked records."""
@@ -457,7 +457,8 @@ class ansXpl:
             )
 
         self._mapdl.run(
-            f"*DMAT,{rand_name},{MYCTYPE[dtype]},IMPORT,{file_extension},{self._filename},"
+            f"*DMAT,{rand_name},{MYCTYPE[dtype]},IMPORT,{file_extension},"
+            f"{quote_path_if_needed(self._filename)},"
             f"{num_first},{num_last},{recordname}",
             mute=False,
         )

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -36,6 +36,7 @@ from ansys.mapdl.core.misc import (
     last_created,
     load_file,
     no_return,
+    quote_path_if_needed,
     requires_package,
     run_as,
 )
@@ -53,6 +54,24 @@ from conftest import requires
 )
 def test_check_valid_ip(ip):
     check_valid_ip(ip)
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("file.rst", "file.rst"),
+        ("my file.rst", "'my file.rst'"),
+        ("'my file.rst'", "'my file.rst'"),
+        (
+            "C:/Users/some user/results/file.rst",
+            "'C:/Users/some user/results/file.rst'",
+        ),
+        ("C:/Users/some_user/results/file.rst", "C:/Users/some_user/results/file.rst"),
+        ("", ""),
+    ],
+)
+def test_quote_path_if_needed(path, expected):
+    assert quote_path_if_needed(path) == expected
 
 
 @pytest.mark.parametrize("ip", ["asdf", "300.2.2.2"])

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -39,6 +39,7 @@ from ansys.mapdl.core.misc import (
     quote_path_if_needed,
     requires_package,
     run_as,
+    unquote_path,
 )
 from conftest import requires
 
@@ -72,6 +73,29 @@ def test_check_valid_ip(ip):
 )
 def test_quote_path_if_needed(path, expected):
     assert quote_path_if_needed(path) == expected
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("file.rst", "file.rst"),
+        ("'my file.rst'", "my file.rst"),
+        ("my file.rst", "my file.rst"),
+        (
+            "'C:/Users/some user/results/file.rst'",
+            "C:/Users/some user/results/file.rst",
+        ),
+        ("", ""),
+        ("'", "'"),
+    ],
+)
+def test_unquote_path(path, expected):
+    assert unquote_path(path) == expected
+
+
+def test_quote_unquote_path_roundtrip():
+    path = "my file.rst"
+    assert unquote_path(quote_path_if_needed(path)) == path
 
 
 @pytest.mark.parametrize("ip", ["asdf", "300.2.2.2"])


### PR DESCRIPTION
## Description

When a path with spaces was passed to `ansXpl` (`mapdl.xpl`), the resulting `*XPL` (and `*DMAT`) MAPDL commands were sent unquoted. MAPDL parses commas as argument separators and can also misinterpret unquoted spaces, so paths such as `C:/.../XLP results Viewing/file.rst` caused a `FileError` because the file could not be found.

This PR adds a small helper, `quote_path_if_needed()`, in `misc.py` that wraps a path in single quotes only when it contains a space and is not already quoted (so it never double-wraps, and never strips or alters the path otherwise). It is now used in:

- `ansXpl.open()`
- `ansXpl.copy()`
- `ansXpl.extract()` (the `*DMAT` import command that also references the open file's path)

## Testing

- Added parametrized unit tests for `quote_path_if_needed()` in `tests/test_misc.py` covering: no spaces, spaces, already-quoted paths, and empty strings.
- `uv run pytest tests/test_misc.py -k quote_path_if_needed` passes.
- `uv run pre-commit run --all-files` on changed files passes.

Fixes #4246
