### PR TITLE
fix: parse RESOURCE_EXHAUSTED gRPC error details independent of message wording

### DIFF
--- a/doc/changelog.d/4767.fixed.md
+++ b/doc/changelog.d/4767.fixed.md
@@ -1,0 +1,1 @@
+Parse RESOURCE_EXHAUSTED gRPC error details independent of message wording

--- a/src/ansys/mapdl/core/errors.py
+++ b/src/ansys/mapdl/core/errors.py
@@ -24,6 +24,7 @@
 
 from enum import Enum
 from functools import cache, wraps
+import re
 import signal
 import sys
 import threading
@@ -505,9 +506,15 @@ def protect_grpc(func: Callable) -> Callable:
 
                 if error.code() == grpc.StatusCode.RESOURCE_EXHAUSTED:
                     if "Received message larger than max" in error.details():
-                        try:
-                            lim_ = int(error.details().split("(")[1].split("vs")[0])
-                        except IndexError:
+                        # Some gRPC versions wrap the message as
+                        # "Stream removed (CLIENT: Received message larger
+                        # than max (<received> vs. <limit>))", so the
+                        # received size is matched with a regex instead of
+                        # blindly splitting on "(".
+                        match = re.search(r"\((\d+)\s*vs\.?\s*\d+\)", error.details())
+                        if match:
+                            lim_ = int(match.group(1))
+                        else:
                             lim_ = int(512 * 1024**2)
 
                         raise MapdlgRPCError(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -25,11 +25,13 @@ from unittest.mock import MagicMock
 import grpc
 import pytest
 
+from ansys.mapdl.core import errors as errors_module
 from ansys.mapdl.core.errors import (
     MapdlCommandIgnoredError,
     MapdlConnectionError,
     MapdlException,
     MapdlExitedError,
+    MapdlgRPCError,
     MapdlInvalidRoutineError,
     MapdlRuntimeError,
     _build_unavailable_suggestion,
@@ -300,3 +302,58 @@ def test_protect_grpc_translates_future_cancelled_error():
 
     with pytest.raises(MapdlConnectionError, match="TRANSIENT_FAILURE"):
         raising(mock_mapdl)
+
+
+class _FakeRpcError(grpc.RpcError):
+    """Minimal 'grpc.RpcError' double exposing 'code()'/'details()'."""
+
+    def __init__(self, code, details):
+        self._code = code
+        self._details = details
+
+    def code(self):
+        return self._code
+
+    def details(self):
+        return self._details
+
+
+@pytest.mark.parametrize(
+    "details,expected_limit",
+    [
+        # Message format seen with streaming RPCs (gRPC wraps it with
+        # "Stream removed (CLIENT: ...)").
+        (
+            "Stream removed (CLIENT: Received message larger than max "
+            "(262152 vs. 1024))",
+            262152,
+        ),
+        # Message format seen with unary RPCs.
+        ("Received message larger than max (512 vs. 100)", 512),
+    ],
+)
+def test_protect_grpc_translates_resource_exhausted_error(
+    monkeypatch, details, expected_limit
+):
+    """A 'RESOURCE_EXHAUSTED' error whose details report a message that is
+    too large becomes a 'MapdlgRPCError' suggesting
+    'PYMAPDL_MAX_MESSAGE_LENGTH' set to the received message size, regardless
+    of whether gRPC wraps the details with a 'Stream removed' prefix."""
+    monkeypatch.setattr(errors_module, "sleep", lambda *args, **kwargs: None)
+
+    mock_mapdl = MagicMock(spec=MapdlGrpc)
+    mock_mapdl._log = MagicMock()
+    mock_mapdl._exited = False
+    mock_mapdl.exited = False
+    mock_mapdl.is_alive = True
+
+    @protect_grpc
+    def raising(self, n_attempts=0):
+        raise _FakeRpcError(grpc.StatusCode.RESOURCE_EXHAUSTED, details)
+
+    with pytest.raises(
+        MapdlgRPCError, match="Received message larger than max"
+    ) as excinfo:
+        raising(mock_mapdl, n_attempts=0)
+
+    assert f"PYMAPDL_MAX_MESSAGE_LENGTH={expected_limit}" in str(excinfo.value)


### PR DESCRIPTION
## Summary

The remote-test CI job (and PyMAPDL's own `protect_grpc` error handler) has started failing deterministically since `grpcio==1.83.1` was published on PyPI (2026-08-28). This is unrelated to any recent PyMAPDL change or workflow bump — it surfaced across multiple unrelated PRs (#4766, #4764) and the last several nightly scheduled builds on `main`, purely because `grpcio` is an unpinned runtime dependency (`grpcio>=1.30.0`), so any CI run executed after that release resolves the new wheel.

### Root cause

`protect_grpc` (in `errors.py`) translates a `RESOURCE_EXHAUSTED` "message larger than max" gRPC error into a descriptive `MapdlgRPCError`, extracting the received message size with:

```python
lim_ = int(error.details().split("(")[1].split("vs")[0])
```

This assumed `error.details()` always looks like:

```
Received message larger than max (X vs. Y)
```

Since `grpcio` 1.83.1 (a backport of [grpc/grpc#43227](https://github.com/grpc/grpc/pull/43227), which includes commit [`6d54d63`](https://github.com/grpc/grpc/commit/6d54d63fb13c91e7f28987253f8f679a5521f1a3)), the size check moved earlier into the HTTP/2 frame deframer, and the transport now wraps the message when it cancels the stream:

```
Stream removed (CLIENT: Received message larger than max (X vs. Y))
```

The old `split("(")` no longer isolates a number, so `int(...)` raises an unhandled `ValueError` instead of `MapdlgRPCError`, letting the raw `grpc.RpcError` escape to the caller (this is exactly what `tests/test_grpc.py::test_exception_message_length` caught).

### Fix

Replace the brittle string splitting with a regex (`\((\d+)\s*vs\.?\s*\d+\)`) that matches the `(X vs. Y)` pattern regardless of any surrounding wrapper text, so both the old and new `grpcio` message formats are handled identically. No behavior changes for callers; `MapdlgRPCError` is raised the same way in both cases.

## Testing

- Added `test_protect_grpc_translates_resource_exhausted_error` (mocked, no MAPDL required), parametrized over both the old and new `grpcio` message wording, verifying `protect_grpc` raises `MapdlgRPCError` with the correct suggested `PYMAPDL_MAX_MESSAGE_LENGTH` value in both cases.
- `uv run pytest tests/test_errors.py -k protect_grpc` → 5 passed.
- `uv run pre-commit run --all-files` on the changed files → all hooks pass.

## Related

- `grpc/grpc` commit: https://github.com/grpc/grpc/commit/6d54d63fb13c91e7f28987253f8f679a5521f1a3
- `grpc/grpc` backport PR: https://github.com/grpc/grpc/pull/43270
