### PR TITLE
docs: fix card layout and link clickability

### DIFF
--- a/doc/changelog.d/4771.documentation.md
+++ b/doc/changelog.d/4771.documentation.md
@@ -1,0 +1,1 @@
+Fix card layout and link clickability

--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -36,6 +36,15 @@
     box-shadow: 0 0rem 0rem rgba(250, 250, 250, 0.6) !important;
     }
 
+/* sphinx-design grid cards use a "stretched link" overlay (z-index: 1) so
+   the whole card is clickable. That overlay sits above any link nested in
+   the card body text, making it unclickable. Raise nested links above the
+   overlay so both the card link and the inline links stay clickable. */
+.sd-card .sd-card-body a:not(.sd-stretched-link) {
+    position: relative;
+    z-index: 2;
+}
+
 /* anything related to the light theme */
 html[data-theme="light"] {
     /* whatever you want to change */

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -336,11 +336,20 @@ html_theme_options = {
         "json_url": f"https://{cname}/versions.json",
         "version_match": switcher_version,
     },
-    # Removing the secondary sidebar for the MAPDL commands
+    # Keep the default right-column page navigation on every page, except
+    # for the very large, auto-generated MAPDL commands reference where a
+    # per-page table of contents is not useful, and the landing page, which
+    # has no headings and would otherwise reserve an empty column that
+    # pushes the card grid off-center.
+    #
+    # NOTE: when several patterns match a page, pydata-sphinx-theme uses the
+    # *last* matching entry (see ``_get_matching_sidebar_items`` in
+    # ``pydata_sphinx_theme.utils``), so the catch-all "**" pattern must be
+    # declared first and the more specific override(s) after it.
     "secondary_sidebar_items": {
-        # "mapdl_commands/**/**": [],
-        # "mapdl_commands/index": [],
-        "**": [],  # "page-toc", "edit-this-page", "sourcelink"]
+        "**": ["page-toc", "edit-this-page", "sourcelink"],
+        "mapdl_commands/**": [],
+        "index": [],
     },
     "navbar_persistent": [],
     "primary_sidebar_end": ["edit-this-page", "sourcelink"],


### PR DESCRIPTION
## Description
Align the PyMAPDL documentation layout with the PyAnsys ecosystem.
- Center the landing-page chapter cards in a 2x3 grid.
- Keep the right-column navigation for applicable documentation pages.
- Remove the empty right-column navigation from the landing page.
- Preserve clickable inline links inside grid cards.
- Add the required navigation-bar styling adjustments.

## Issue linked
Closes #4210

## Checklist

- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing).
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [ ] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [ ] I have marked this PR as `draft` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (for example, `docs: align PyMAPDL documentation style`).