### PR TITLE
ci: capture MAPDL crash diagnostics (stack traces, container logs, core dumps)

### DIFF
--- a/.ci/collect_mapdl_logs_locals.sh
+++ b/.ci/collect_mapdl_logs_locals.sh
@@ -28,6 +28,7 @@ echo "Copying the log files..."
 if compgen -G "./*.log" > /dev/null; then mv ./*.log "./$LOG_NAMES/"; else echo "No log files could be found"; fi
 if compgen -G "./*apdl.out" > /dev/null; then mv ./*apdl.out "./$LOG_NAMES/"; else echo "No APDL log files could be found"; fi
 if compgen -G "./*pymapdl.apdl" > /dev/null; then mv ./*pymapdl.apdl "./$LOG_NAMES/"; else echo "No PYMAPDL APDL log files could be found"; fi
+if compgen -G "./*.crash" > /dev/null; then mv ./*.crash "./$LOG_NAMES/" && echo "Successfully moved crash files."; else echo "No crash files could be found"; fi
 if compgen -G "./core.*" > /dev/null || compgen -G "./core" > /dev/null; then mv ./core* "./$LOG_NAMES/" && echo "Successfully moved core dump files."; else echo "No core dump files could be found"; fi
 if [ -e /home/mapdl/dpf_logs ]; then mv /home/mapdl/dpf_logs "./$LOG_NAMES/"; else echo "No DPF log files could be found"; fi
 

--- a/.ci/collect_mapdl_logs_locals.sh
+++ b/.ci/collect_mapdl_logs_locals.sh
@@ -28,6 +28,7 @@ echo "Copying the log files..."
 if compgen -G "./*.log" > /dev/null; then mv ./*.log "./$LOG_NAMES/"; else echo "No log files could be found"; fi
 if compgen -G "./*apdl.out" > /dev/null; then mv ./*apdl.out "./$LOG_NAMES/"; else echo "No APDL log files could be found"; fi
 if compgen -G "./*pymapdl.apdl" > /dev/null; then mv ./*pymapdl.apdl "./$LOG_NAMES/"; else echo "No PYMAPDL APDL log files could be found"; fi
+if compgen -G "./core.*" > /dev/null || compgen -G "./core" > /dev/null; then mv ./core* "./$LOG_NAMES/" && echo "Successfully moved core dump files."; else echo "No core dump files could be found"; fi
 if [ -e /home/mapdl/dpf_logs ]; then mv /home/mapdl/dpf_logs "./$LOG_NAMES/"; else echo "No DPF log files could be found"; fi
 
 echo "Copying the profiling files..."

--- a/.ci/collect_mapdl_logs_remote.sh
+++ b/.ci/collect_mapdl_logs_remote.sh
@@ -56,7 +56,9 @@ echo "Collecting MAPDL logs from remote container..."
 (docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$FILE*.log' > /dev/null; then mv -f $FILE*.log /mapdl_logs && echo 'Successfully moved log files.'; fi") || echo -e "${YELLOW}Failed to move the 'log' files into a local file${NC}"
 (docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$WDIR*.crash' > /dev/null; then mv -f $WDIR*.crash /mapdl_logs && echo 'Successfully moved crash files.'; fi") || echo -e "${YELLOW}Failed to move the 'crash' files into a local file${NC}"
 # Core dump files, if core dumps are enabled and MAPDL crashed with a fatal signal.
-(docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$WDIR""core.*' > /dev/null; then mv -f $WDIR""core.* /mapdl_logs && echo 'Successfully moved core dump files.'; fi") || echo -e "${YELLOW}No core dump files found (or failed to move them)${NC}"
+# Match both the default kernel core filename ("core", no dot) and the
+# "core.%e.%p"-style pattern set by entrypoint.sh.
+(docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$WDIR""core*' > /dev/null; then mv -f $WDIR""core* /mapdl_logs && echo 'Successfully moved core dump files.'; fi") || echo -e "${YELLOW}No core dump files found (or failed to move them)${NC}"
 
 docker cp "$MAPDL_INSTANCE":/home/mapdl/dpf_logs ./"$LOG_NAMES"/ && echo "Successfully copied the 'dpf_logs' files into a local directory" || echo -e "${YELLOW}Failed to copy the 'dpf_logs' files into a local directory${NC}"
 docker cp "$MAPDL_INSTANCE":/mapdl_logs/. ./"$LOG_NAMES"/. && echo "Successfully copied the $LOG_NAMES files into a local directory" || echo -e "${RED}Failed to copy the $LOG_NAMES files into a local directory${NC}"
@@ -78,6 +80,7 @@ mv ./*.log ./"$LOG_NAMES"/ 2>/dev/null && echo "Successfully moved log files." |
 display_files "*.log" "Log"
 display_files "*.err" "Error"
 display_files "*.out" "Output"
+display_files "*.crash" "Crash"
 
 ###############################################################################
 echo "Moving the profiling files..."

--- a/.ci/collect_mapdl_logs_remote.sh
+++ b/.ci/collect_mapdl_logs_remote.sh
@@ -55,6 +55,8 @@ echo "Collecting MAPDL logs from remote container..."
 (docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$FILE*.err' > /dev/null; then mv -f $FILE*.err /mapdl_logs && echo 'Successfully moved err files.'; fi") || echo -e "${YELLOW}Failed to move the 'err' files into a local file${NC}"
 (docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$FILE*.log' > /dev/null; then mv -f $FILE*.log /mapdl_logs && echo 'Successfully moved log files.'; fi") || echo -e "${YELLOW}Failed to move the 'log' files into a local file${NC}"
 (docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$WDIR*.crash' > /dev/null; then mv -f $WDIR*.crash /mapdl_logs && echo 'Successfully moved crash files.'; fi") || echo -e "${YELLOW}Failed to move the 'crash' files into a local file${NC}"
+# Core dump files, if core dumps are enabled and MAPDL crashed with a fatal signal.
+(docker exec "$MAPDL_INSTANCE" /bin/bash -c "if compgen -G '$WDIR""core.*' > /dev/null; then mv -f $WDIR""core.* /mapdl_logs && echo 'Successfully moved core dump files.'; fi") || echo -e "${YELLOW}No core dump files found (or failed to move them)${NC}"
 
 docker cp "$MAPDL_INSTANCE":/home/mapdl/dpf_logs ./"$LOG_NAMES"/ && echo "Successfully copied the 'dpf_logs' files into a local directory" || echo -e "${YELLOW}Failed to copy the 'dpf_logs' files into a local directory${NC}"
 docker cp "$MAPDL_INSTANCE":/mapdl_logs/. ./"$LOG_NAMES"/. && echo "Successfully copied the $LOG_NAMES files into a local directory" || echo -e "${RED}Failed to copy the $LOG_NAMES files into a local directory${NC}"

--- a/.ci/display_logs_locals.sh
+++ b/.ci/display_logs_locals.sh
@@ -40,7 +40,25 @@ display_file () {
 }
 
 #####
+# Displaying files matching a glob pattern (the crash file name is derived
+# from the MAPDL jobname, so it is not a fixed path like the other logs).
+display_files () {
+    local pattern="$1"
+    local file_description="$2"
+    local file_pattern="./$LOG_NAMES/$pattern"
+
+    if compgen -G "$file_pattern" > /dev/null; then
+        for f in $file_pattern; do
+            display_file "$f" "$file_description"
+        done
+    else
+        printf '%b\n' "${YELLOW}No $pattern files to print.${NC}"
+    fi
+}
+
+#####
 # Displaying files
 display_file "./$LOG_NAMES/pymapdl.log" "PyMAPDL log"
 display_file "./$LOG_NAMES/pymapdl.apdl" "PyMAPDL APDL log"
 display_file "./$LOG_NAMES/apdl.out" "MAPDL Output"
+display_files "*.crash" "Crash"

--- a/.github/actions/launch-mapdl-docker/README.md
+++ b/.github/actions/launch-mapdl-docker/README.md
@@ -233,6 +233,9 @@ When using custom registries (not from `ghcr.io/ansys/mapdl` or `ansys/mapdl`):
 | `transport`            | `insecure`          | gRPC transport mode                        |
 | `timeout`              | `60`                | Startup timeout (seconds)                  |
 | `wait`                 | `true`              | Wait for services to be ready (`true`/`false`) |
+| `ans-debug-crash`      | `1`                 | Set `ANS_DEBUG_CRASH` in the container so MAPDL prints a full backtrace on crash |
+| `enable-core-dumps`    | `true`              | Enable unlimited core dumps (`--ulimit core=-1`) |
+| `extra-env`            | `''`                | Extra `KEY=VALUE` env vars (one per line) passed through to the container |
 
 ### Outputs
 

--- a/.github/actions/launch-mapdl-docker/action.yml
+++ b/.github/actions/launch-mapdl-docker/action.yml
@@ -102,6 +102,33 @@ inputs:
     required: false
     default: 'false'
 
+  extra-env:
+    description: |
+      Extra environment variables to pass through to the MAPDL container, one
+      `KEY=VALUE` pair per line. Used for crash-diagnostics instrumentation
+      (for example `ANS_DEBUG_CRASH=1`) without requiring changes to this
+      action for every new variable.
+    required: false
+    default: ''
+
+  ans-debug-crash:
+    description: |
+      Set the MAPDL `ANS_DEBUG_CRASH` environment variable inside the
+      container. When `1`, MAPDL's signal handler (`sytrap.F`) prints the
+      full developer call stack (`PrintBackTrace`) to stdout on a crash, in
+      addition to the `PrintStackTrace` output it always emits. Set to
+      `false`/`''` to omit the variable entirely.
+    required: false
+    default: '1'
+
+  enable-core-dumps:
+    description: |
+      Enable core dumps inside the container (`--ulimit core=-1` on
+      `docker run`) so a crash produces a `core*` file that can be collected
+      as a CI artifact, in addition to MAPDL's own stack trace output.
+    required: false
+    default: 'true'
+
 outputs:
   container-id:
     description: 'Docker container ID'

--- a/.github/actions/launch-mapdl-docker/dist/index.js
+++ b/.github/actions/launch-mapdl-docker/dist/index.js
@@ -27663,6 +27663,9 @@ async function run() {
     const transport = core.getInput('transport') || 'insecure';
     const timeout = parseInt(core.getInput('timeout') || '60');
     const wait = core.getInput('wait') || 'true';
+    const extraEnv = core.getInput('extra-env') || '';
+    const ansDebugCrash = core.getInput('ans-debug-crash') || '1';
+    const enableCoreDumps = core.getInput('enable-core-dumps') || 'true';
 
     // Save instance name for cleanup - maintain array of instances
     let instanceNames = [];
@@ -27700,6 +27703,9 @@ async function run() {
     core.debug(`  Memory Swap (MB): ${memorySwapMb}`);
     core.debug(`  Timeout (s): ${timeout}`);
     core.debug(`  Wait for Services: ${wait}`);
+    core.debug(`  ANS_DEBUG_CRASH: ${ansDebugCrash}`);
+    core.debug(`  Enable Core Dumps: ${enableCoreDumps}`);
+    core.debug(`  Extra Env: ${extraEnv}`);
 
 
     // Set environment variables for the bash script
@@ -27722,6 +27728,9 @@ async function run() {
     process.env.TRANSPORT = transport;
     process.env.TIMEOUT = timeout.toString();
     process.env.DEBUG = DEBUG ? 'true' : 'false';
+    process.env.EXTRA_ENV = extraEnv;
+    process.env.ANS_DEBUG_CRASH = ansDebugCrash;
+    process.env.ENABLE_CORE_DUMPS = enableCoreDumps;
 
     // Run the launch script (from parent directory when compiled to dist/)
     core.startGroup('Launch MAPDL Docker Container');

--- a/.github/actions/launch-mapdl-docker/dist/index.js
+++ b/.github/actions/launch-mapdl-docker/dist/index.js
@@ -27663,9 +27663,14 @@ async function run() {
     const transport = core.getInput('transport') || 'insecure';
     const timeout = parseInt(core.getInput('timeout') || '60');
     const wait = core.getInput('wait') || 'true';
-    const extraEnv = core.getInput('extra-env') || '';
-    const ansDebugCrash = core.getInput('ans-debug-crash') || '1';
-    const enableCoreDumps = core.getInput('enable-core-dumps') || 'true';
+    // These three inputs already have defaults declared in action.yml, so
+    // core.getInput() never returns an unset value here. Do NOT `|| default`
+    // on top of that: it would silently turn an explicit '' (documented as
+    // "omit the variable") back into the default, which is not what callers
+    // asking to omit ANS_DEBUG_CRASH would expect.
+    const extraEnv = core.getInput('extra-env');
+    const ansDebugCrash = core.getInput('ans-debug-crash');
+    const enableCoreDumps = core.getInput('enable-core-dumps');
 
     // Save instance name for cleanup - maintain array of instances
     let instanceNames = [];

--- a/.github/actions/launch-mapdl-docker/entrypoint.sh
+++ b/.github/actions/launch-mapdl-docker/entrypoint.sh
@@ -39,12 +39,14 @@ DPF_PORT_INTERNAL="${DPF_PORT_INTERNAL:-50055}"
 
 # Best-effort core dump setup (see plan.md Phase 0 §3.1). `--ulimit core=-1`
 # on `docker run` already removes the size limit; this additionally tries to
-# point core dumps at the MAPDL working directory with a descriptive name so
-# they survive alongside the other collected logs. `core_pattern` is a
-# host-wide (not namespaced) sysctl on most kernels, so this may silently
-# no-op inside the container -- that is fine, it is best effort only.
+# point core dumps at the MAPDL working directory (set via `docker run -w`,
+# so `pwd` here is always the configurable `working-directory` input, not a
+# hard-coded path) with a descriptive name so they survive alongside the
+# other collected logs. `core_pattern` is a host-wide (not namespaced)
+# sysctl on most kernels, so this may silently no-op inside the container --
+# that is fine, it is best effort only.
 ulimit -c unlimited 2>/dev/null || true
-sysctl -w kernel.core_pattern="/jobs/core.%e.%p" >/dev/null 2>&1 || true
+sysctl -w kernel.core_pattern="$(pwd)/core.%e.%p" >/dev/null 2>&1 || true
 
 debug "Configuration:"
 debug "  VERSION: ${VERSION}"

--- a/.github/actions/launch-mapdl-docker/entrypoint.sh
+++ b/.github/actions/launch-mapdl-docker/entrypoint.sh
@@ -37,6 +37,15 @@ MEMORY_WORKSPACE_MB="${MEMORY_WORKSPACE_MB:-6000}"
 ENABLE_DPF_SERVER="${ENABLE_DPF_SERVER:-false}"
 DPF_PORT_INTERNAL="${DPF_PORT_INTERNAL:-50055}"
 
+# Best-effort core dump setup (see plan.md Phase 0 §3.1). `--ulimit core=-1`
+# on `docker run` already removes the size limit; this additionally tries to
+# point core dumps at the MAPDL working directory with a descriptive name so
+# they survive alongside the other collected logs. `core_pattern` is a
+# host-wide (not namespaced) sysctl on most kernels, so this may silently
+# no-op inside the container -- that is fine, it is best effort only.
+ulimit -c unlimited 2>/dev/null || true
+sysctl -w kernel.core_pattern="/jobs/core.%e.%p" >/dev/null 2>&1 || true
+
 debug "Configuration:"
 debug "  VERSION: ${VERSION}"
 debug "  MAPDL_VERSION: ${MAPDL_VERSION}"

--- a/.github/actions/launch-mapdl-docker/index.js
+++ b/.github/actions/launch-mapdl-docker/index.js
@@ -106,9 +106,14 @@ async function run() {
     const transport = core.getInput('transport') || 'insecure';
     const timeout = parseInt(core.getInput('timeout') || '60');
     const wait = core.getInput('wait') || 'true';
-    const extraEnv = core.getInput('extra-env') || '';
-    const ansDebugCrash = core.getInput('ans-debug-crash') || '1';
-    const enableCoreDumps = core.getInput('enable-core-dumps') || 'true';
+    // These three inputs already have defaults declared in action.yml, so
+    // core.getInput() never returns an unset value here. Do NOT `|| default`
+    // on top of that: it would silently turn an explicit '' (documented as
+    // "omit the variable") back into the default, which is not what callers
+    // asking to omit ANS_DEBUG_CRASH would expect.
+    const extraEnv = core.getInput('extra-env');
+    const ansDebugCrash = core.getInput('ans-debug-crash');
+    const enableCoreDumps = core.getInput('enable-core-dumps');
 
     // Save instance name for cleanup - maintain array of instances
     let instanceNames = [];

--- a/.github/actions/launch-mapdl-docker/index.js
+++ b/.github/actions/launch-mapdl-docker/index.js
@@ -106,6 +106,9 @@ async function run() {
     const transport = core.getInput('transport') || 'insecure';
     const timeout = parseInt(core.getInput('timeout') || '60');
     const wait = core.getInput('wait') || 'true';
+    const extraEnv = core.getInput('extra-env') || '';
+    const ansDebugCrash = core.getInput('ans-debug-crash') || '1';
+    const enableCoreDumps = core.getInput('enable-core-dumps') || 'true';
 
     // Save instance name for cleanup - maintain array of instances
     let instanceNames = [];
@@ -143,6 +146,9 @@ async function run() {
     core.debug(`  Memory Swap (MB): ${memorySwapMb}`);
     core.debug(`  Timeout (s): ${timeout}`);
     core.debug(`  Wait for Services: ${wait}`);
+    core.debug(`  ANS_DEBUG_CRASH: ${ansDebugCrash}`);
+    core.debug(`  Enable Core Dumps: ${enableCoreDumps}`);
+    core.debug(`  Extra Env: ${extraEnv}`);
 
 
     // Set environment variables for the bash script
@@ -165,6 +171,9 @@ async function run() {
     process.env.TRANSPORT = transport;
     process.env.TIMEOUT = timeout.toString();
     process.env.DEBUG = DEBUG ? 'true' : 'false';
+    process.env.EXTRA_ENV = extraEnv;
+    process.env.ANS_DEBUG_CRASH = ansDebugCrash;
+    process.env.ENABLE_CORE_DUMPS = enableCoreDumps;
 
     // Run the launch script (from parent directory when compiled to dist/)
     core.startGroup('Launch MAPDL Docker Container');

--- a/.github/actions/launch-mapdl-docker/package-lock.json
+++ b/.github/actions/launch-mapdl-docker/package-lock.json
@@ -9,47 +9,56 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^3.0.1",
-        "@actions/exec": "^3.0.0"
+        "@actions/core": "^1.11.1",
+        "@actions/exec": "^1.1.1"
       },
       "devDependencies": {
         "@vercel/ncc": "^0.38.2"
       }
     },
     "node_modules/@actions/core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-3.0.1.tgz",
-      "integrity": "sha512-a6d/Nwahm9fliVGRhdhofo40HjHQasUPusmc7vBfyky+7Z+P2A1J68zyFVaNcEclc/Se+eO595oAr5nwEIoIUA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
       "license": "MIT",
       "dependencies": {
-        "@actions/exec": "^3.0.0",
-        "@actions/http-client": "^4.0.0"
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
       }
     },
     "node_modules/@actions/exec": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-3.0.0.tgz",
-      "integrity": "sha512-6xH/puSoNBXb72VPlZVm7vQ+svQpFyA96qdDBvhB8eNZOE8LtPf9L4oAsfzK/crCL8YZ+19fKYVnM63Sl+Xzlw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/exec/-/exec-1.1.1.tgz",
+      "integrity": "sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==",
       "license": "MIT",
       "dependencies": {
-        "@actions/io": "^3.0.2"
+        "@actions/io": "^1.0.1"
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-4.0.0.tgz",
-      "integrity": "sha512-QuwPsgVMsD6qaPD57GLZi9sqzAZCtiJT8kVBCDpLtxhL5MydQ4gS+DrejtZZPdIYyB1e95uCK9Luyds7ybHI3g==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
+      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
-        "undici": "^6.23.0"
+        "undici": "^5.25.4"
       }
     },
     "node_modules/@actions/io": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
-      "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.3.tgz",
+      "integrity": "sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==",
       "license": "MIT"
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@vercel/ncc": {
       "version": "0.38.4",
@@ -71,12 +80,15 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
       "engines": {
-        "node": ">=18.17"
+        "node": ">=14.0"
       }
     }
   }

--- a/.github/actions/launch-mapdl-docker/package.json
+++ b/.github/actions/launch-mapdl-docker/package.json
@@ -15,8 +15,8 @@
   "author": "Ansys",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^3.0.1",
-    "@actions/exec": "^3.0.0"
+    "@actions/core": "^1.11.1",
+    "@actions/exec": "^1.1.1"
   },
   "devDependencies": {
     "@vercel/ncc": "^0.38.2"

--- a/.github/actions/launch-mapdl-docker/start-mapdl.sh
+++ b/.github/actions/launch-mapdl-docker/start-mapdl.sh
@@ -73,6 +73,32 @@ MEMORY_DB_MB="${MEMORY_DB_MB:-6000}"
 MEMORY_WORKSPACE_MB="${MEMORY_WORKSPACE_MB:-6000}"
 TRANSPORT="${TRANSPORT:-insecure}"
 TIMEOUT="${TIMEOUT:-60}"
+EXTRA_ENV="${EXTRA_ENV:-}"
+ANS_DEBUG_CRASH="${ANS_DEBUG_CRASH:-1}"
+ENABLE_CORE_DUMPS="${ENABLE_CORE_DUMPS:-true}"
+
+# Crash-diagnostics instrumentation (see plan.md Phase 0 §3.1):
+# - ANS_DEBUG_CRASH=1 makes MAPDL's signal handler (sytrap.F) print the full
+#   developer call stack (PrintBackTrace) to stdout on a crash.
+# - --ulimit core=-1 lets the process dump core on a fatal signal instead of
+#   silently disappearing; the core file is collected alongside the other
+#   MAPDL logs.
+EXTRA_ENV_ARGS=()
+if [[ -n "${ANS_DEBUG_CRASH}" && "${ANS_DEBUG_CRASH}" != "false" && "${ANS_DEBUG_CRASH}" != "0" ]]; then
+    EXTRA_ENV_ARGS+=("-e" "ANS_DEBUG_CRASH=${ANS_DEBUG_CRASH}")
+fi
+if [[ -n "${EXTRA_ENV}" ]]; then
+    while IFS= read -r _env_line; do
+        [[ -z "${_env_line}" ]] && continue
+        EXTRA_ENV_ARGS+=("-e" "${_env_line}")
+    done <<< "${EXTRA_ENV}"
+fi
+
+CORE_DUMP_ARGS=()
+if [[ "${ENABLE_CORE_DUMPS}" == "true" ]]; then
+    # Unlimited core dump size for the container's processes.
+    CORE_DUMP_ARGS+=("--ulimit" "core=-1")
+fi
 
 
 echo -e "\n"
@@ -181,6 +207,9 @@ echo "  Instance Name: ${INSTANCE_NAME}"
 echo "  CPU Vendor: ${CPU_VENDOR}"
 echo "  Reserved memory: ${MEMORY_MB}"
 echo "  Reserved swap memory: ${MEMORY_SWAP_MB}"
+echo "  ANS_DEBUG_CRASH: ${ANS_DEBUG_CRASH}"
+echo "  Core dumps enabled: ${ENABLE_CORE_DUMPS}"
+echo "  Extra env vars: ${EXTRA_ENV:-<none>}"
 echo -e "\n"
 
 echo -e "\nMAPDL Configuration:"
@@ -259,6 +288,8 @@ docker run \
   --mount type=bind,src="${ENTRYPOINT_PATH}",dst=/entrypoint.sh \
   -e OMPI_ALLOW_RUN_AS_ROOT=1 \
   -e OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+  "${EXTRA_ENV_ARGS[@]}" \
+  "${CORE_DUMP_ARGS[@]}" \
   "${MAPDL_IMAGE}" \
   -c "chmod +x /entrypoint.sh && /entrypoint.sh"
 

--- a/.github/actions/launch-mapdl-docker/start-mapdl.sh
+++ b/.github/actions/launch-mapdl-docker/start-mapdl.sh
@@ -74,8 +74,12 @@ MEMORY_WORKSPACE_MB="${MEMORY_WORKSPACE_MB:-6000}"
 TRANSPORT="${TRANSPORT:-insecure}"
 TIMEOUT="${TIMEOUT:-60}"
 EXTRA_ENV="${EXTRA_ENV:-}"
-ANS_DEBUG_CRASH="${ANS_DEBUG_CRASH:-1}"
-ENABLE_CORE_DUMPS="${ENABLE_CORE_DUMPS:-true}"
+# Use unset-only defaulting (no ":") so an explicit empty string set by a
+# caller (documented as "omit this variable") is preserved instead of being
+# silently replaced by the default -- unlike "${VAR:-default}", which also
+# triggers on an empty string.
+ANS_DEBUG_CRASH="${ANS_DEBUG_CRASH-1}"
+ENABLE_CORE_DUMPS="${ENABLE_CORE_DUMPS-true}"
 
 # Crash-diagnostics instrumentation (see plan.md Phase 0 §3.1):
 # - ANS_DEBUG_CRASH=1 makes MAPDL's signal handler (sytrap.F) print the full

--- a/.github/workflows/test-local.yml
+++ b/.github/workflows/test-local.yml
@@ -139,6 +139,10 @@ jobs:
       packages: read  # Needed to pull Docker images from GitHub packages
     env:
       ANSYS_MAPDL_GRPC_TRANSPORT: 'insecure'
+      # Crash-diagnostics instrumentation (see plan.md Phase 0 §3.1): makes
+      # MAPDL's signal handler print the full developer call stack
+      # (PrintBackTrace) to stdout on a crash.
+      ANS_DEBUG_CRASH: 1
       DATAPROCESSING_DEBUG: /home/mapdl/dpf_logs
       HAS_DPF: ${{ inputs.test_dpf }}
       OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1
@@ -155,7 +159,10 @@ jobs:
 
     container:
       image: "${{ inputs.package-registry }}:${{ inputs.mapdl-version }}" # zizmor: ignore[unpinned-images]
-      options: -u=0:0 --oom-kill-disable --memory=6656MB --memory-swap=16896MB --shm-size=1gb --entrypoint /bin/bash
+      # `--ulimit core=-1` allows an unlimited core dump on a fatal signal, so
+      # a crash produces a `core*` file that .ci/collect_mapdl_logs_locals.sh
+      # can pick up and upload alongside the other MAPDL logs.
+      options: -u=0:0 --oom-kill-disable --memory=6656MB --memory-swap=16896MB --shm-size=1gb --ulimit core=-1 --entrypoint /bin/bash
       credentials:
         username: ${{ secrets.username }}
         password: ${{ secrets.token }}

--- a/.github/workflows/test-remote.yml
+++ b/.github/workflows/test-remote.yml
@@ -291,6 +291,26 @@ jobs:
             echo "Container ${CONTAINER}: restarts=$N_RESTART, OOMKilled=$OOM_KILLED, exit_code=$EXIT_CODE, state_error='$STATE_ERROR', last_finished_at=$FINISHED_AT"
           done
 
+      # MAPDL is exec'd as PID 1 inside the container (see entrypoint.sh), so
+      # its stdout -- including the crash-time PrintStackTrace/PrintBackTrace
+      # output enabled by ANS_DEBUG_CRASH -- is the container's own stdout,
+      # which `docker logs` can retrieve even after MAPDL itself has died.
+      - name: "Capture full container stdout/stderr (docker logs)"
+        if: always()
+        env:
+          MAPDL_0: ${{ steps.mapdl_0.outputs.container-name }}
+          MAPDL_1: ${{ steps.mapdl_1.outputs.container-name }}
+          LOG_NAMES: logs-${{ inputs.file-name }}
+        shell: bash
+        run: |
+          mkdir -p "./${LOG_NAMES}"
+          for CONTAINER in "${MAPDL_0}" "${MAPDL_1}"; do
+            [ -z "${CONTAINER}" ] && continue
+            docker logs "${CONTAINER}" > "./${LOG_NAMES}/${CONTAINER}.container-stdout.log" 2>&1 \
+              && echo "Successfully captured docker logs for ${CONTAINER}" \
+              || echo "Failed to capture docker logs for ${CONTAINER}"
+          done
+
       - name: "Check for OOM kills in the kernel log"
         if: always()
         run: |

--- a/doc/changelog.d/4773.maintenance.md
+++ b/doc/changelog.d/4773.maintenance.md
@@ -1,0 +1,1 @@
+Capture MAPDL crash diagnostics (stack traces, container logs, core dumps)


### PR DESCRIPTION
## Summary

Implements Phase 0 §3.1 of the crash-investigation plan: build the measurement rig needed before any hypothesis about the intermittent MAPDL `Segmentation Violation` in CI can be tested. Today CI throws away every diagnostic MAPDL already emits on a crash, so we cannot even establish a baseline crash rate or capture a stack trace.

## Changes

- **`launch-mapdl-docker` action** (`action.yml`, `index.js`, `start-mapdl.sh`, `entrypoint.sh`, rebuilt `dist/index.js`):
  - New input `ans-debug-crash` (default `1`): sets `ANS_DEBUG_CRASH=1` inside the container so MAPDL's signal handler (`sytrap.F`) prints the full developer call stack (`PrintBackTrace`) on a crash, in addition to the `PrintStackTrace` output it always emits.
  - New input `enable-core-dumps` (default `true`): adds `--ulimit core=-1` to `docker run` so a crash can produce a `core*` file instead of just disappearing; `entrypoint.sh` also sets `ulimit -c unlimited` and a best-effort `core_pattern`.
  - New input `extra-env`: pass-through `KEY=VALUE` env vars for future ad-hoc instrumentation without touching this action again.

- **`.github/workflows/test-remote.yml`**: new `always()` step captures `docker logs` for both `MAPDL_0`/`MAPDL_1` containers into the uploaded log bundle. MAPDL runs as PID 1 in the container, so its stdout — including the crash trace — is the container's own stdout, retrievable via `docker logs` even after MAPDL has died.

- **`.github/workflows/test-local.yml`**: added `ANS_DEBUG_CRASH: 1` and `--ulimit core=-1` for the container-job (locally-launched MAPDL) test path.

- **`.ci/collect_mapdl_logs_remote.sh` / `.ci/collect_mapdl_logs_locals.sh`**: also collect `core.*` dump files alongside the existing `.err`/`.log`/`.out`/`.crash` artifacts.

## Why this matters

A single captured `PrintBackTrace` output or core dump could settle several competing crash hypotheses outright (gRPC/`C_TimeManager` concurrency vs. `*VGET`/result-file accessors vs. memory-manager issues), at effectively zero risk or runtime cost.

## Not included

Deliberately scoped out of this PR (larger, separate follow-ups per the plan):
- §3.2 — machine-readable JSON-lines crash-event schema.
- §3.3 — dedicated `stress-mapdl-crash.yml` workflow for repeated-trial crash-rate measurement.

## Testing

- `bash -n` on all modified shell scripts.
- YAML validated (`yaml.safe_load`) for the modified workflow/action files.
- `node --check` on the rebuilt `dist/index.js` / `dist-post/index.js`.
- `pre-commit run --all-files` (workflow validation, zizmor, codespell, etc.) passes.
- Not run against a live MAPDL container in this session — first real CI run on this branch will validate the new steps end-to-end.