### PR TITLE
refactor: migrate example download to ansys-tools-common

### DIFF
--- a/doc/changelog.d/4774.miscellaneous.md
+++ b/doc/changelog.d/4774.miscellaneous.md
@@ -1,0 +1,1 @@
+Migrate example download to ansys-tools-common

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "ansys-mapdl-reader>=0.51.7",
   "ansys-math-core>=0.1.2",
   "ansys-platform-instancemanagement~=1.0",
-  "ansys-tools-common>=0.3.0",
+  "ansys-tools-common>=0.5.0",                 # example_download.download_manager with retries
   "click>=8.1.3",                              # for CLI interface
   "grpcio>=1.30.0",                            # tested up to grpcio==1.35
   "numpy>=1.14.0,<3.0.0",

--- a/src/ansys/mapdl/core/examples/downloads.py
+++ b/src/ansys/mapdl/core/examples/downloads.py
@@ -29,10 +29,10 @@ from typing import Callable, Dict, Optional
 import zipfile
 
 from ansys.mapdl import core as pymapdl
-from ansys.mapdl.core import _HAS_REQUESTS
+from ansys.mapdl.core import _HAS_ATC
 
-if _HAS_REQUESTS:
-    import requests
+if _HAS_ATC:
+    from ansys.tools.common.example_download import download_manager
 
 
 def check_directory_exist(directory: str) -> Callable:
@@ -79,25 +79,24 @@ def _get_file_url(filename: str, directory: Optional[str] = None) -> str:
     return f"https://github.com/ansys/example-data/raw/master/{filename}"
 
 
-def _check_url_exist(url: str) -> bool:
-    response = requests.get(url, timeout=10)  # 10 seconds timeout
-    return response.status_code == 200
-
-
 @check_directory_exist(pymapdl.EXAMPLES_PATH)
-def _retrieve_file(url: str, filename: str) -> str:
-    # First check if file has already been downloaded
+def _retrieve_file(filename: str, directory: Optional[str] = None) -> str:
+    # First check if file has already been downloaded (and, if applicable,
+    # already decompressed), so we avoid hitting the network again.
     local_path = os.path.join(pymapdl.EXAMPLES_PATH, os.path.basename(filename))
     local_path_no_zip = local_path.replace(".zip", "")
     if os.path.isfile(local_path_no_zip) or os.path.isdir(local_path_no_zip):
         return local_path_no_zip
 
-    # Perform download
-    requested_file = requests.get(url, timeout=10)
-    requested_file.raise_for_status()
-
-    with open(local_path, "wb") as f:
-        f.write(requested_file.content)
+    # Delegate the actual download (with retries and caching) to the shared
+    # ``ansys-tools-common`` example downloader, storing files in PyMAPDL's
+    # own persistent cache directory instead of the library's default temp
+    # directory.
+    local_path = download_manager.download_file(
+        filename=os.path.basename(filename),
+        directory=directory or "",
+        destination=pymapdl.EXAMPLES_PATH,
+    )
 
     if get_ext(local_path) in [".zip"]:
         _decompress(local_path)
@@ -108,16 +107,16 @@ def _retrieve_file(url: str, filename: str) -> str:
 def _download_file(filename: str, directory: Optional[str] = None) -> str:
     url = _get_file_url(filename, directory)
     try:
-        return _retrieve_file(url, filename)
-    except requests.exceptions.HTTPError as e:
-        raise requests.exceptions.HTTPError(
+        return _retrieve_file(filename, directory)
+    except RuntimeError as e:
+        raise RuntimeError(
             "Retrieving the file from internet failed.\n"
             "You can download this file from:\n"
             f"{url}\n"
             "\n"
             "The reported error message is:\n"
             f"{str(e)}"
-        )
+        ) from e
 
 
 def download_bracket() -> str:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -114,11 +114,92 @@ def test_download_example_data_true_download():
 
 @requires("requests")
 def test_failed_download():
-    from requests.exceptions import HTTPError
-
+    # ansys.tools.common.example_download.DownloadManager raises RuntimeError
+    # (rather than requests.exceptions.HTTPError) on download failures.
     filename = "non_existing_file"
-    with pytest.raises(HTTPError):
+    with pytest.raises(RuntimeError):
         _download_file(filename, directory=None)
+
+
+@requires("ansys.tools.common")
+def test_retrieve_file_skips_download_when_already_cached():
+    from ansys.mapdl.core.examples.downloads import _retrieve_file
+
+    filename = "unique_test_cached_file.txt"
+    os.makedirs(EXAMPLES_PATH, exist_ok=True)
+    local_path = os.path.join(EXAMPLES_PATH, filename)
+
+    try:
+        with open(local_path, "w") as fid:
+            fid.write("already downloaded")
+
+        with patch(
+            "ansys.mapdl.core.examples.downloads.download_manager"
+        ) as mock_manager:
+            result = _retrieve_file(filename, "some/dir")
+
+        mock_manager.download_file.assert_not_called()
+        assert result == local_path
+    finally:
+        if os.path.isfile(local_path):
+            os.remove(local_path)
+
+
+@requires("ansys.tools.common")
+def test_retrieve_file_uses_examples_path_as_destination():
+    from ansys.mapdl.core.examples.downloads import _retrieve_file
+
+    filename = "unique_test_destination_file.txt"
+    expected_local_path = os.path.join(EXAMPLES_PATH, filename)
+
+    with patch("ansys.mapdl.core.examples.downloads.download_manager") as mock_manager:
+        mock_manager.download_file.return_value = expected_local_path
+
+        result = _retrieve_file(filename, "some/dir")
+
+        mock_manager.download_file.assert_called_once_with(
+            filename=filename,
+            directory="some/dir",
+            destination=EXAMPLES_PATH,
+        )
+        assert result == expected_local_path
+
+
+@requires("ansys.tools.common")
+def test_retrieve_file_decompresses_zip(tmp_path):
+    import shutil
+    import zipfile
+
+    from ansys.mapdl.core.examples.downloads import _retrieve_file
+
+    zip_name = "unique_test_archive.zip"
+    os.makedirs(EXAMPLES_PATH, exist_ok=True)
+    zip_local_path = os.path.join(EXAMPLES_PATH, zip_name)
+
+    # `_decompress` extracts the archive contents directly into
+    # `EXAMPLES_PATH`, so the archive must contain a top-level entry
+    # matching the zip's own name (minus the ".zip" extension) for the
+    # returned path to resolve to an extracted directory.
+    inner_file = tmp_path / "inner.txt"
+    inner_file.write_text("hello")
+    with zipfile.ZipFile(zip_local_path, "w") as zip_ref:
+        zip_ref.write(inner_file, arcname="unique_test_archive/inner.txt")
+
+    try:
+        with patch(
+            "ansys.mapdl.core.examples.downloads.download_manager"
+        ) as mock_manager:
+            mock_manager.download_file.return_value = zip_local_path
+
+            result = _retrieve_file(zip_name, "some/dir")
+
+        assert result == zip_local_path[:-4]
+        assert os.path.isdir(result)
+        assert os.path.isfile(os.path.join(result, "inner.txt"))
+    finally:
+        shutil.rmtree(zip_local_path[:-4], ignore_errors=True)
+        if os.path.isfile(zip_local_path):
+            os.remove(zip_local_path)
 
 
 @requires("requests")


### PR DESCRIPTION
## Description
Migrates the example dataset downloader in `ansys.mapdl.core.examples.downloads`
from a custom, hand-rolled `requests`-based implementation to the shared
`ansys.tools.common.example_download.download_manager` utility (`ansys-tools-common`
is already a runtime dependency of PyMAPDL, bumped here from `>=0.3.0` to
`>=0.5.0` to guarantee the retry/robustness improvements added in that
version).

Key points:
- All public download functions (`download_bracket`, `download_vtk_rotor`,
  `download_tech_demo_data`, `download_example_data`,
  `download_manifold_example_data`, `download_cfx_mapping_example_data`,
  `delete_downloads`) keep their existing signatures and return types, no
  breaking changes.
- Downloads still land in PyMAPDL's persistent `EXAMPLES_PATH` cache (passed
  explicitly as `destination`) instead of the library's default temp
  directory, and are skipped entirely if already cached.
- ZIP decompression is preserved locally via the existing `zipfile`-based
  `_decompress` helper, since `ansys-tools-common` does not extract archives.
- Download failures now raise `RuntimeError` instead of
  `requests.exceptions.HTTPError` (the exception type used by
  `DownloadManager`); the friendly error message pointing to the direct
  GitHub URL is preserved.
- Removed the now-unused `_check_url_exist` helper (dead code, not used
  anywhere in the codebase).

## Issue linked

Closes #4595

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [ ] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [ ] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)