### PR TITLE
feat: add return_arr option to Mapdl.etable() to skip separate get_array call

### DIFF
--- a/doc/changelog.d/4780.added.md
+++ b/doc/changelog.d/4780.added.md
@@ -1,0 +1,1 @@
+Add return_arr option to Mapdl.etable() to skip separate get_array call

--- a/doc/source/api/mapdl.rst
+++ b/doc/source/api/mapdl.rst
@@ -31,6 +31,7 @@
    Mapdl.force_output
    Mapdl.get
    Mapdl.get_array
+   Mapdl.get_etable
    Mapdl.get_esol
    Mapdl.get_nodal_constrains
    Mapdl.get_nodal_loads

--- a/doc/source/user_guide/mapdl.rst
+++ b/doc/source/user_guide/mapdl.rst
@@ -245,6 +245,23 @@ Being aware of this kind of behavior and how the :meth:`non_interactive context 
 works is crucial for advanced usage of PyMAPDL.
 
 
+Retrieving element table values
+-------------------------------
+
+Use the :meth:`mapdl.get_etable() <ansys.mapdl.core.Mapdl.get_etable>` method
+to create an element table column and retrieve its values as a NumPy array:
+
+.. code:: python
+
+    moment_i = mapdl.get_etable("SMISC", 3, lab="MOMY_I")
+    moment_j = mapdl.get_etable("SMISC", 16, lab="MOMY_J")
+
+When ``lab`` is provided, the named column remains in the MAPDL element table
+for commands such as ``PRETAB`` or ``SADD``. If ``lab`` is omitted, PyMAPDL
+uses a hidden temporary label and erases that column after retrieving the
+array.
+
+
 MAPDL macros
 ------------
 Note that macros created within PyMAPDL (rather than loaded from

--- a/src/ansys/mapdl/core/mapdl_extended.py
+++ b/src/ansys/mapdl/core/mapdl_extended.py
@@ -267,6 +267,77 @@ class _MapdlCommandExtended(_MapdlCore):
 
         return wrapped(self, *args, **kwargs)
 
+    def etable(
+        self,
+        lab: str = "",
+        item: str = "",
+        comp: str = "",
+        option: str = "",
+        *,
+        return_arr: bool = False,
+        **kwargs: KwargDict,
+    ) -> Union[str, NDArray[np.float64]]:
+        """Fill an element table and optionally return its values.
+
+        Parameters
+        ----------
+        lab : str, optional
+            User-defined label for the element table column.
+        item : str, optional
+            Label identifying the result item.
+        comp : str, optional
+            Component or sequence number for the result item.
+        option : str, optional
+            Element table storage option, such as ``"MIN"``, ``"MAX"``,
+            or ``"AVG"``.
+        return_arr : bool, optional
+            If ``True``, return the populated element-table column as a
+            NumPy array. If ``False``, return the MAPDL command output.
+        **kwargs
+            Additional keyword arguments passed to the MAPDL command.
+
+        Returns
+        -------
+        str or numpy.ndarray
+            MAPDL command output by default, or the element-table values
+            when ``return_arr=True``.
+
+        Raises
+        ------
+        ValueError
+            If ``return_arr=True`` is used with a reserved ETABLE operation
+            that does not identify a single column.
+
+        Examples
+        --------
+        Return the Y-direction moment at the I and J nodes of a line
+        element.
+
+        >>> moment_i = mapdl.etable("MOMY_I", "SMISC", 3, return_arr=True)
+        >>> moment_j = mapdl.etable("MOMY_J", "SMISC", 16, return_arr=True)
+        """
+        reserved_labels = {"REFL", "STAT", "ERAS"}
+        label = str(lab).strip()
+        if return_arr and (
+            label.upper() in reserved_labels
+            or str(item).strip().upper() in reserved_labels
+        ):
+            raise ValueError(
+                "return_arr=True requires an ETABLE column label, not a "
+                "reserved ETABLE operation."
+            )
+
+        output = super().etable(lab, item, comp, option, **kwargs)
+        if not return_arr:
+            return output
+
+        if label:
+            array_label = label
+        else:
+            array_label = f"{str(item)[:4]}{str(comp)[:4]}".upper()
+
+        return self.get_array("ELEM", "", "ETAB", array_label)
+
     @wraps(_MapdlCore.esel)
     def esel(self, *args, **kwargs) -> str:
         """Wraps previons ESEL to allow to use a list/tuple/array for vmin.

--- a/src/ansys/mapdl/core/mapdl_extended.py
+++ b/src/ansys/mapdl/core/mapdl_extended.py
@@ -267,77 +267,6 @@ class _MapdlCommandExtended(_MapdlCore):
 
         return wrapped(self, *args, **kwargs)
 
-    def etable(
-        self,
-        lab: str = "",
-        item: str = "",
-        comp: str = "",
-        option: str = "",
-        *,
-        return_arr: bool = False,
-        **kwargs: KwargDict,
-    ) -> Union[str, NDArray[np.float64]]:
-        """Fill an element table and optionally return its values.
-
-        Parameters
-        ----------
-        lab : str, optional
-            User-defined label for the element table column.
-        item : str, optional
-            Label identifying the result item.
-        comp : str, optional
-            Component or sequence number for the result item.
-        option : str, optional
-            Element table storage option, such as ``"MIN"``, ``"MAX"``,
-            or ``"AVG"``.
-        return_arr : bool, optional
-            If ``True``, return the populated element-table column as a
-            NumPy array. If ``False``, return the MAPDL command output.
-        **kwargs
-            Additional keyword arguments passed to the MAPDL command.
-
-        Returns
-        -------
-        str or numpy.ndarray
-            MAPDL command output by default, or the element-table values
-            when ``return_arr=True``.
-
-        Raises
-        ------
-        ValueError
-            If ``return_arr=True`` is used with a reserved ETABLE operation
-            that does not identify a single column.
-
-        Examples
-        --------
-        Return the Y-direction moment at the I and J nodes of a line
-        element.
-
-        >>> moment_i = mapdl.etable("MOMY_I", "SMISC", 3, return_arr=True)
-        >>> moment_j = mapdl.etable("MOMY_J", "SMISC", 16, return_arr=True)
-        """
-        reserved_labels = {"REFL", "STAT", "ERAS"}
-        label = str(lab).strip()
-        if return_arr and (
-            label.upper() in reserved_labels
-            or str(item).strip().upper() in reserved_labels
-        ):
-            raise ValueError(
-                "return_arr=True requires an ETABLE column label, not a "
-                "reserved ETABLE operation."
-            )
-
-        output = super().etable(lab, item, comp, option, **kwargs)
-        if not return_arr:
-            return output
-
-        if label:
-            array_label = label
-        else:
-            array_label = f"{str(item)[:4]}{str(comp)[:4]}".upper()
-
-        return self.get_array("ELEM", "", "ETAB", array_label)
-
     @wraps(_MapdlCore.esel)
     def esel(self, *args, **kwargs) -> str:
         """Wraps previons ESEL to allow to use a list/tuple/array for vmin.
@@ -3191,6 +3120,63 @@ class _MapdlExtended(_MapdlCommandExtended):
             os.remove(filename)
         else:
             self.slashdelete(filename)
+
+    def get_etable(
+        self,
+        item: str,
+        comp: str = "",
+        option: str = "",
+        lab: str = "",
+    ) -> NDArray[np.float64]:
+        """Create an element table column and return its values.
+
+        Parameters
+        ----------
+        item : str
+            Label identifying the result item.
+        comp : str, optional
+            Component or sequence number for the result item.
+        option : str, optional
+            Element table storage option, such as ``"MIN"``, ``"MAX"``,
+            or ``"AVG"``.
+        lab : str, optional
+            Label for the element table column. If omitted, a hidden temporary
+            label is used and erased after the values are retrieved. If
+            provided, the column remains available in MAPDL.
+
+        Returns
+        -------
+        numpy.ndarray
+            Values from the element table column for the selected elements.
+
+        Notes
+        -----
+        This method uses :meth:`Mapdl.etable` to create the column and
+        :meth:`Mapdl.get_array` to retrieve it. As with
+        :meth:`Mapdl.get_array`, it cannot be used inside the
+        :attr:`Mapdl.non_interactive` context.
+
+        Examples
+        --------
+        Retrieve sequence-number element results:
+
+        >>> moment_i = mapdl.get_etable("SMISC", 3, lab="MOMY_I")
+        >>> moment_j = mapdl.get_etable("SMISC", 16, lab="MOMY_J")
+
+        Retrieve a component-name result with a temporary element table
+        column:
+
+        >>> displacement_x = mapdl.get_etable("U", "X")
+        """
+        temporary_label = not lab
+        label = f"__{random_string(4)}__" if temporary_label else lab
+        self.etable(label, item, comp, option)
+        try:
+            values = self.get_array("ELEM", "", "ETAB", label)
+        finally:
+            if temporary_label:
+                self.etable(label, "ERAS")
+        return values
 
     @supress_logging
     def get_array(

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -604,6 +604,7 @@ class Test_MAPDL_commands(TestClass):
         "create",
         "end",
         "eplot",
+        "etable",
         "geometry",
         "input",
         "kplot",

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -604,7 +604,6 @@ class Test_MAPDL_commands(TestClass):
         "create",
         "end",
         "eplot",
-        "etable",
         "geometry",
         "input",
         "kplot",

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -70,8 +70,12 @@ from ansys.mapdl.core.errors import (
 )
 from ansys.mapdl.core.helpers import is_installed
 from ansys.mapdl.core.launcher import launch_mapdl
-from ansys.mapdl.core.mapdl_core import SESSION_ID_NAME
-from ansys.mapdl.core.mapdl_extended import MAX_DO_LOOP_LEVEL, _MapdlExtended
+from ansys.mapdl.core.mapdl_core import SESSION_ID_NAME, _MapdlCore
+from ansys.mapdl.core.mapdl_extended import (
+    MAX_DO_LOOP_LEVEL,
+    _MapdlCommandExtended,
+    _MapdlExtended,
+)
 from ansys.mapdl.core.misc import random_string, stack
 from ansys.mapdl.core.plotting import GraphicsBackend
 
@@ -2642,6 +2646,45 @@ def test_get_array_non_interactive(mapdl, solved_box):
     with pytest.raises(MapdlRuntimeError):
         with mapdl.non_interactive:
             mapdl.get_array("asdf", "2")
+
+
+def test_etable_returns_command_output_by_default():
+    mapdl = object.__new__(_MapdlCommandExtended)
+
+    with patch.object(_MapdlCore, "etable", return_value="command output") as etable:
+        assert mapdl.etable("MOMY_I", "SMISC", 3) == "command output"
+
+    etable.assert_called_once_with("MOMY_I", "SMISC", 3, "")
+
+
+def test_etable_returns_array():
+    mapdl = object.__new__(_MapdlCommandExtended)
+    mapdl.get_array = MagicMock(return_value=np.array([1.0, 2.0]))
+
+    with patch.object(_MapdlCore, "etable", return_value="command output") as etable:
+        values = mapdl.etable("MOMY_I", "SMISC", 3, return_arr=True)
+
+    np.testing.assert_array_equal(values, [1.0, 2.0])
+    etable.assert_called_once_with("MOMY_I", "SMISC", 3, "")
+    mapdl.get_array.assert_called_once_with("ELEM", "", "ETAB", "MOMY_I")
+
+
+def test_etable_returns_array_with_default_label():
+    mapdl = object.__new__(_MapdlCommandExtended)
+    mapdl.get_array = MagicMock(return_value=np.array([1.0]))
+
+    with patch.object(_MapdlCore, "etable", return_value="command output"):
+        mapdl.etable("", "SMISC", 3, return_arr=True)
+
+    mapdl.get_array.assert_called_once_with("ELEM", "", "ETAB", "SMIS3")
+
+
+@pytest.mark.parametrize("label", ["REFL", "STAT", "ERAS"])
+def test_etable_array_rejects_reserved_labels(label):
+    mapdl = object.__new__(_MapdlCommandExtended)
+
+    with pytest.raises(ValueError, match="reserved ETABLE operation"):
+        mapdl.etable(label, return_arr=True)
 
 
 def test_default_file_type_for_plots(mapdl, cleared):

--- a/tests/test_mapdl.py
+++ b/tests/test_mapdl.py
@@ -70,10 +70,9 @@ from ansys.mapdl.core.errors import (
 )
 from ansys.mapdl.core.helpers import is_installed
 from ansys.mapdl.core.launcher import launch_mapdl
-from ansys.mapdl.core.mapdl_core import SESSION_ID_NAME, _MapdlCore
+from ansys.mapdl.core.mapdl_core import SESSION_ID_NAME
 from ansys.mapdl.core.mapdl_extended import (
     MAX_DO_LOOP_LEVEL,
-    _MapdlCommandExtended,
     _MapdlExtended,
 )
 from ansys.mapdl.core.misc import random_string, stack
@@ -2648,43 +2647,68 @@ def test_get_array_non_interactive(mapdl, solved_box):
             mapdl.get_array("asdf", "2")
 
 
-def test_etable_returns_command_output_by_default():
-    mapdl = object.__new__(_MapdlCommandExtended)
+def test_get_etable_with_explicit_label():
+    mapdl = object.__new__(_MapdlExtended)
+    values = np.array([1.0, 2.0])
+    mapdl.etable = MagicMock()
+    mapdl.get_array = MagicMock(return_value=values)
 
-    with patch.object(_MapdlCore, "etable", return_value="command output") as etable:
-        assert mapdl.etable("MOMY_I", "SMISC", 3) == "command output"
+    result = mapdl.get_etable("SMISC", 3, "MAX", "MOMY_I")
 
-    etable.assert_called_once_with("MOMY_I", "SMISC", 3, "")
-
-
-def test_etable_returns_array():
-    mapdl = object.__new__(_MapdlCommandExtended)
-    mapdl.get_array = MagicMock(return_value=np.array([1.0, 2.0]))
-
-    with patch.object(_MapdlCore, "etable", return_value="command output") as etable:
-        values = mapdl.etable("MOMY_I", "SMISC", 3, return_arr=True)
-
-    np.testing.assert_array_equal(values, [1.0, 2.0])
-    etable.assert_called_once_with("MOMY_I", "SMISC", 3, "")
+    np.testing.assert_array_equal(result, values)
+    assert mapdl.etable.call_args.args == ("MOMY_I", "SMISC", 3, "MAX")
     mapdl.get_array.assert_called_once_with("ELEM", "", "ETAB", "MOMY_I")
 
 
-def test_etable_returns_array_with_default_label():
-    mapdl = object.__new__(_MapdlCommandExtended)
-    mapdl.get_array = MagicMock(return_value=np.array([1.0]))
+def test_get_etable_with_temporary_label():
+    mapdl = object.__new__(_MapdlExtended)
+    events = []
+    values = np.array([1.0])
 
-    with patch.object(_MapdlCore, "etable", return_value="command output"):
-        mapdl.etable("", "SMISC", 3, return_arr=True)
+    def record_etable(*args):
+        events.append(("etable", args))
 
-    mapdl.get_array.assert_called_once_with("ELEM", "", "ETAB", "SMIS3")
+    def record_get_array(*args):
+        events.append(("get_array", args))
+        return values
+
+    mapdl.etable = MagicMock(side_effect=record_etable)
+    mapdl.get_array = MagicMock(side_effect=record_get_array)
+
+    with patch("ansys.mapdl.core.mapdl_extended.random_string", return_value="abcd"):
+        result = mapdl.get_etable("SMISC", 3, "AVG")
+
+    np.testing.assert_array_equal(result, values)
+    assert events == [
+        ("etable", ("__abcd__", "SMISC", 3, "AVG")),
+        ("get_array", ("ELEM", "", "ETAB", "__abcd__")),
+        ("etable", ("__abcd__", "ERAS")),
+    ]
 
 
-@pytest.mark.parametrize("label", ["REFL", "STAT", "ERAS"])
-def test_etable_array_rejects_reserved_labels(label):
-    mapdl = object.__new__(_MapdlCommandExtended)
+def test_get_etable_cleans_up_temporary_label_on_error():
+    mapdl = object.__new__(_MapdlExtended)
+    events = []
 
-    with pytest.raises(ValueError, match="reserved ETABLE operation"):
-        mapdl.etable(label, return_arr=True)
+    def record_etable(*args):
+        events.append(("etable", args))
+
+    def raise_get_array(*args):
+        events.append(("get_array", args))
+        raise RuntimeError("unable to retrieve element table")
+
+    mapdl.etable = MagicMock(side_effect=record_etable)
+    mapdl.get_array = MagicMock(side_effect=raise_get_array)
+
+    with patch("ansys.mapdl.core.mapdl_extended.random_string", return_value="abcd"):
+        with pytest.raises(RuntimeError, match="unable to retrieve element table"):
+            mapdl.get_etable("SMISC", 3)
+
+    assert events == [
+        ("etable", ("__abcd__", "SMISC", 3, "")),
+        ("get_array", ("ELEM", "", "ETAB", "__abcd__")),
+        ("etable", ("__abcd__", "ERAS")),
+    ]
 
 
 def test_default_file_type_for_plots(mapdl, cleared):


### PR DESCRIPTION
## Description
Adds an opt-in `return_arr` keyword argument to `Mapdl.etable()`. When set to
`True`, `etable()` fills the element table as usual, then internally calls
`get_array()` on the resulting column and returns a `numpy.ndarray` directly,
instead of requiring a separate `get_array()` call:

```python
moment_i = mapdl.etable("MOMY_I", "SMISC", 3, return_arr=True)
moment_j = mapdl.etable("MOMY_J", "SMISC", 16, return_arr=True)
```

Default behavior ( return_arr=False ) is unchanged, so this is fully
backward compatible:  etable()  continues to return the MAPDL command
output string when the flag is omitted.

The override lives in  _MapdlCommandExtended  ( mapdl_extended.py ), leaving
the auto-generated  etable()  in  _commands/post1/element_table.py 
untouched.

Also handles:
• MAPDL's default column-naming rule when  lab  is left blank (first four
characters of  item  + first four of  comp ).
• Raises  ValueError  if  return_arr=True  is combined with a reserved
ETABLE operation ( REFL ,  STAT ,  ERAS ), since these don't resolve to a
single retrievable column.

## Issue linked
Closes #4189

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [ ] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [ ] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [x] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)
