### PR TITLE
feat: lazily download VGET array results via LazyArray

### DIFF
--- a/doc/changelog.d/4781.added.md
+++ b/doc/changelog.d/4781.added.md
@@ -1,0 +1,1 @@
+Lazily download VGET array results via LazyArray

--- a/src/ansys/mapdl/core/lazy_array.py
+++ b/src/ansys/mapdl/core/lazy_array.py
@@ -1,0 +1,140 @@
+# Copyright (C) 2016 - 2026 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2016 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Lazily-evaluated array proxy for MAPDL parameters.
+
+See issue #4190: some MAPDL commands (for example ``VGET``) only need to
+run server-side to produce a value, but the corresponding PyMAPDL wrapper
+downloads that value immediately, even if the caller never uses it. The
+:class:`LazyArray` class defers that download until the value is actually
+used.
+"""
+
+from typing import TYPE_CHECKING, Any, Optional
+
+import numpy as np
+from numpy.lib.mixins import NDArrayOperatorsMixin
+from numpy.typing import NDArray
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ansys.mapdl.core.mapdl import MapdlBase
+
+
+class LazyArray(NDArrayOperatorsMixin):
+    """Array-like object whose data is fetched from MAPDL only when used.
+
+    An instance of this class is returned instead of a
+    :class:`numpy.ndarray` by methods that populate an APDL array
+    parameter server-side (for example :meth:`Mapdl.vget
+    <ansys.mapdl.core.Mapdl.vget>`). The underlying MAPDL command has
+    already run and the parameter exists in the MAPDL database, but its
+    values are not downloaded until this object is used as an array
+    (indexing, iteration, ``len()``, ``repr()``, or any NumPy operation).
+
+    This avoids the network and CPU cost of downloading the parameter
+    values when the caller does not use the returned value, while keeping
+    the common usage patterns (indexing, NumPy functions, arithmetic)
+    working exactly as they would with a plain :class:`numpy.ndarray`.
+
+    The resolved value is cached after the first use, so repeated access
+    does not trigger repeated downloads. Because of this cache, if the
+    underlying MAPDL parameter is overwritten between the creation of a
+    :class:`LazyArray` and its first use, only the value present at the
+    time of the first use is captured.
+
+    .. note::
+        Unlike a real :class:`numpy.ndarray`, ``isinstance(value,
+        np.ndarray)`` is ``False`` for a :class:`LazyArray`. Use
+        ``np.asarray(value)`` to obtain an actual array when needed.
+
+    Parameters
+    ----------
+    mapdl : Mapdl
+        MAPDL instance the parameter belongs to.
+    parameter_name : str
+        Name of the APDL parameter to retrieve lazily.
+
+    Examples
+    --------
+    >>> arr = mapdl.vget(par="A", ir=2)  # no data downloaded yet
+    >>> arr[0]  # doctest: +SKIP
+    0.0  # downloads the parameter values on first use
+    """
+
+    def __init__(self, mapdl: "MapdlBase", parameter_name: str) -> None:
+        self._mapdl = mapdl
+        self._parameter_name = parameter_name
+        self._cached: Optional[NDArray[np.float64]] = None
+
+    def _resolve(self) -> NDArray[np.float64]:
+        """Download and cache the actual parameter values."""
+        if self._cached is None:
+            self._cached = self._mapdl.parameters[self._parameter_name]
+        return self._cached
+
+    def __array__(self, dtype: Any = None) -> NDArray[np.float64]:
+        array = self._resolve()
+        return array.astype(dtype) if dtype is not None else array
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        """Delegate NumPy ufuncs (arithmetic operators) to the resolved array.
+
+        This is what allows expressions such as ``lazy_array + 1`` or
+        ``lazy_array * other_array`` to work transparently, resolving
+        (and caching) the underlying data on first use.
+        """
+        resolved_inputs = tuple(
+            input_.resolve() if isinstance(input_, LazyArray) else input_
+            for input_ in inputs
+        )
+        return getattr(ufunc, method)(*resolved_inputs, **kwargs)
+
+    def resolve(self) -> NDArray[np.float64]:
+        """Download and cache the actual parameter values.
+
+        Returns
+        -------
+        numpy.ndarray
+            Resolved array retrieved from the MAPDL parameter.
+
+        Examples
+        --------
+        >>> arr = mapdl.vget(par="A", ir=2)  # no data downloaded yet
+        >>> arr.resolve()  # doctest: +SKIP
+        array([0., 1., 2.])
+        """
+        return self._resolve()
+
+    def __getitem__(self, index: Any) -> Any:
+        return self._resolve()[index]
+
+    def __len__(self) -> int:
+        return len(self._resolve())
+
+    def __iter__(self):
+        return iter(self._resolve())
+
+    def __eq__(self, other: Any) -> Any:
+        return self._resolve() == other
+
+    def __repr__(self) -> str:
+        return repr(self._resolve())

--- a/src/ansys/mapdl/core/lazy_array.py
+++ b/src/ansys/mapdl/core/lazy_array.py
@@ -29,7 +29,7 @@ downloads that value immediately, even if the caller never uses it. The
 used.
 """
 
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import numpy as np
 from numpy.lib.mixins import NDArrayOperatorsMixin
@@ -56,10 +56,11 @@ class LazyArray(NDArrayOperatorsMixin):
     working exactly as they would with a plain :class:`numpy.ndarray`.
 
     The resolved value is cached after the first use, so repeated access
-    does not trigger repeated downloads. Because of this cache, if the
-    underlying MAPDL parameter is overwritten between the creation of a
-    :class:`LazyArray` and its first use, only the value present at the
-    time of the first use is captured.
+    does not trigger repeated downloads. A caller that creates the proxy
+    directly from a mutable MAPDL parameter observes the value present when
+    the proxy is first used. Commands such as ``VGET`` provide a private
+    server-side snapshot so that their results remain independent of later
+    changes to the user-visible parameter.
 
     .. note::
         Unlike a real :class:`numpy.ndarray`, ``isinstance(value,
@@ -72,24 +73,52 @@ class LazyArray(NDArrayOperatorsMixin):
         MAPDL instance the parameter belongs to.
     parameter_name : str
         Name of the APDL parameter to retrieve lazily.
+    cleanup : callable, optional
+        Callback used to release a private server-side snapshot. The callback
+        is called after materialization or when
+        :meth:`close() <ansys.mapdl.core.lazy_array.LazyArray.close>` is called.
 
     Examples
     --------
-    >>> arr = mapdl.vget(par="A", ir=2)  # no data downloaded yet
+    >>> arr = mapdl.vget(par="A", ir=2)  # doctest: +SKIP
     >>> arr[0]  # doctest: +SKIP
-    0.0  # downloads the parameter values on first use
+    0.0
     """
 
-    def __init__(self, mapdl: "MapdlBase", parameter_name: str) -> None:
+    def __init__(
+        self,
+        mapdl: "MapdlBase",
+        parameter_name: str,
+        cleanup: Optional[Callable[[], None]] = None,
+    ) -> None:
         self._mapdl = mapdl
         self._parameter_name = parameter_name
+        self._cleanup = cleanup
         self._cached: Optional[NDArray[np.float64]] = None
 
     def _resolve(self) -> NDArray[np.float64]:
         """Download and cache the actual parameter values."""
         if self._cached is None:
-            self._cached = self._mapdl.parameters[self._parameter_name]
+            try:
+                value = self._mapdl.parameters[self._parameter_name]
+            except Exception as exc:
+                try:
+                    self._release_snapshot()
+                except Exception as cleanup_exc:
+                    raise cleanup_exc from exc
+                raise
+            self._cached = value
+        # If cleanup failed after a successful download, retry it on the next
+        # access rather than silently retaining the server-side snapshot.
+        self._release_snapshot()
         return self._cached
+
+    def _release_snapshot(self) -> None:
+        """Release the server-side snapshot, if this proxy owns one."""
+        if self._cleanup is not None:
+            cleanup = self._cleanup
+            cleanup()
+            self._cleanup = None
 
     def __array__(self, dtype: Any = None) -> NDArray[np.float64]:
         array = self._resolve()
@@ -118,11 +147,25 @@ class LazyArray(NDArrayOperatorsMixin):
 
         Examples
         --------
-        >>> arr = mapdl.vget(par="A", ir=2)  # no data downloaded yet
+        >>> arr = mapdl.vget(par="A", ir=2)  # doctest: +SKIP
         >>> arr.resolve()  # doctest: +SKIP
         array([0., 1., 2.])
         """
         return self._resolve()
+
+    def close(self) -> None:
+        """Release an unused server-side snapshot.
+
+        This method does not download the array. It is useful when a lazy
+        result is known not to be needed before the associated MAPDL
+        connection is closed.
+
+        Raises
+        ------
+        Exception
+            Any exception raised while deleting the server-side snapshot.
+        """
+        self._release_snapshot()
 
     def __getitem__(self, index: Any) -> Any:
         return self._resolve()[index]

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -91,6 +91,7 @@ from ansys.mapdl.core.errors import (
     protect_from,
     protect_grpc,
 )
+from ansys.mapdl.core.lazy_array import LazyArray
 from ansys.mapdl.core.mapdl import MapdlBase
 from ansys.mapdl.core.mapdl_types import KwargDict, MapdlFloat, MapdlInt
 from ansys.mapdl.core.misc import (
@@ -4541,11 +4542,21 @@ class MapdlGrpc(MapdlBase):
         tstrt: MapdlFloat = "",
         kcplx: MapdlInt = "",
         **kwargs: KwargDict,
-    ) -> NDArray[np.float64]:
-        """Wraps VGET"""
+    ) -> Union[NDArray[np.float64], LazyArray]:
+        """Wraps VGET
+
+        .. note::
+            The MAPDL ``VGET`` command runs immediately, but the array
+            values are not downloaded until the returned
+            :class:`LazyArray <ansys.mapdl.core.lazy_array.LazyArray>` is
+            used (indexing, iteration, ``len()``, or any NumPy operation).
+            This avoids an unnecessary download when the return value is
+            not used. Use ``np.asarray(result)`` to force materialization
+            into a plain :class:`numpy.ndarray`.
+        """
         super().vget(par=par, ir=ir, tstrt=tstrt, kcplx=kcplx, **kwargs)
         if not self._store_commands:
-            return self.parameters[par]
+            return LazyArray(self, par)
 
     def get_variable(
         self,

--- a/src/ansys/mapdl/core/mapdl_grpc.py
+++ b/src/ansys/mapdl/core/mapdl_grpc.py
@@ -93,6 +93,7 @@ from ansys.mapdl.core.errors import (
 )
 from ansys.mapdl.core.lazy_array import LazyArray
 from ansys.mapdl.core.mapdl import MapdlBase
+from ansys.mapdl.core.mapdl_core import MAX_PARAM_CHARS
 from ansys.mapdl.core.mapdl_types import KwargDict, MapdlFloat, MapdlInt
 from ansys.mapdl.core.misc import (
     check_valid_ip,
@@ -428,6 +429,7 @@ class MapdlGrpc(MapdlBase):
     # Required by `_name` method to be defined before __init__ be
     _ip: Optional[str] = None
     _port: Optional[int] = None
+    _lazy_array_prefix = "_PYMAPDL_LAZY_"
 
     def __init__(
         self,
@@ -512,6 +514,8 @@ class MapdlGrpc(MapdlBase):
         # gRPC request specific locks as these gRPC request are not thread safe
         self._vget_lock: bool = False
         self._get_lock: bool = False
+        self._lazy_array_counter: int = 0
+        self._lazy_array_snapshots: set[str] = set()
 
         self._prioritize_thermal: bool = False
         self._locked: bool = False  # being used within MapdlPool
@@ -2151,6 +2155,14 @@ class MapdlGrpc(MapdlBase):
                 self._disconnect_but_leave_mapdl_running()
                 return
 
+            cleanup_error = None
+            try:
+                self._cleanup_lazy_array_snapshots()
+            except Exception as error:
+                # Continue tearing down the connection, then report the
+                # cleanup failure to the caller.
+                cleanup_error = error
+
             if save:
                 self._log.debug("Saving MAPDL database")
                 self.save()
@@ -2162,16 +2174,22 @@ class MapdlGrpc(MapdlBase):
                         "Ignoring exit due to PYMAPDL_START_INSTANCE=False or because PyMAPDL didn't launch the instance."
                     )
                     self._disconnect_but_leave_mapdl_running()
+                    if cleanup_error is not None:
+                        raise cleanup_error
                     return
 
                 # or building the gallery
                 if pymapdl.BUILDING_GALLERY:
                     self._log.info("Ignoring exit due as BUILDING_GALLERY=True")
                     self._disconnect_but_leave_mapdl_running()
+                    if cleanup_error is not None:
+                        raise cleanup_error
                     return
 
             # Step 3 of '_release_resources' closes the gRPC channel.
             self._release_resources(path=self._path)
+            if cleanup_error is not None:
+                raise cleanup_error
 
         finally:
             self._exiting = False
@@ -4534,6 +4552,62 @@ class MapdlGrpc(MapdlBase):
             self.__distributed = self.parameters.numcpu > 1
         return self.__distributed
 
+    def _new_lazy_array_snapshot(self) -> str:
+        """Return an unused, valid MAPDL parameter name."""
+        prefix = self._lazy_array_prefix
+        while True:
+            self._lazy_array_counter += 1
+            candidate = f"{prefix}{self._lazy_array_counter:016X}"
+            if len(candidate) > MAX_PARAM_CHARS:  # pragma: no cover
+                raise MapdlRuntimeError("Unable to generate a valid lazy-array name.")
+
+            # Leading-underscore parameters are hidden by default. Include
+            # them while checking so a user parameter cannot be overwritten.
+            with self.parameters.full_parameters_output:
+                if candidate not in self.parameters:
+                    return candidate
+
+    def _lazy_array_snapshot_shape(self, parameter_name: str) -> tuple[int, int, int]:
+        """Return the dimensions of an APDL array without downloading it."""
+        parameter_name = parameter_name.split("(", 1)[0].strip().upper()
+        with self.parameters.full_parameters_output:
+            parameter = self.parameters._parm.get(parameter_name)
+
+        if parameter is None or "shape" not in parameter:
+            raise MapdlRuntimeError(
+                f"Unable to determine the dimensions of VGET parameter "
+                f"'{parameter_name}'."
+            )
+
+        shape = tuple(int(dimension) for dimension in parameter["shape"])
+        if len(shape) != 3:
+            raise MapdlRuntimeError(
+                f"Unexpected dimensions for VGET parameter '{parameter_name}': "
+                f"{shape}."
+            )
+        return shape[0], shape[1], shape[2]
+
+    def _delete_lazy_array_snapshot(self, parameter_name: str) -> None:
+        """Delete a private lazy-array snapshot and unregister it."""
+        self.run(f"{parameter_name}=", mute=True)
+        self._lazy_array_snapshots.remove(parameter_name)
+
+    def _cleanup_lazy_array_snapshots(self) -> None:
+        """Delete all unresolved lazy-array snapshots.
+
+        Cleanup is attempted for every snapshot. If one or more deletions
+        fail, the first error is raised after the remaining snapshots have
+        had a chance to be released.
+        """
+        errors = []
+        for parameter_name in tuple(self._lazy_array_snapshots):
+            try:
+                self._delete_lazy_array_snapshot(parameter_name)
+            except Exception as error:
+                errors.append(error)
+        if errors:
+            raise errors[0]
+
     @wraps(MapdlBase.vget)
     def vget(  # numpydoc ignore=RT01
         self,
@@ -4555,8 +4629,37 @@ class MapdlGrpc(MapdlBase):
             into a plain :class:`numpy.ndarray`.
         """
         super().vget(par=par, ir=ir, tstrt=tstrt, kcplx=kcplx, **kwargs)
-        if not self._store_commands:
-            return LazyArray(self, par)
+        if self._store_commands:
+            return None
+
+        shape = self._lazy_array_snapshot_shape(par)
+        snapshot_name = self._new_lazy_array_snapshot()
+        self._lazy_array_snapshots.add(snapshot_name)
+        try:
+            self.dim(
+                snapshot_name,
+                type_="ARRAY",
+                imax=shape[0],
+                jmax=shape[1],
+                kmax=shape[2],
+                mute=True,
+            )
+            # *MFUN,COPY is MAPDL's array-parameter copy operation. Unlike a
+            # Python read, this preserves the VGET result and its dimensions
+            # on the server before the caller can reuse ``par``.
+            self.mfun(snapshot_name, "COPY", par, mute=True)
+        except Exception as error:
+            try:
+                self._delete_lazy_array_snapshot(snapshot_name)
+            except Exception as cleanup_error:
+                raise cleanup_error from error
+            raise
+
+        return LazyArray(
+            self,
+            snapshot_name,
+            cleanup=lambda: self._delete_lazy_array_snapshot(snapshot_name),
+        )
 
     def get_variable(
         self,
@@ -4586,11 +4689,16 @@ class MapdlGrpc(MapdlBase):
 
         Returns
         -------
-        np.array
-            Variable values as array.
+        numpy.ndarray
+            Variable values as an array. The temporary VGET parameter is
+            copied to a private snapshot before it is deleted.
         """
         par = "temp_var"
         variable = self.vget(par=par, ir=ir, tstrt=tstrt, kcplx=kcplx, **kwargs)
+        if isinstance(variable, LazyArray):
+            # VGET has already copied the result to a private parameter, so
+            # materializing before deleting the temporary source is safe.
+            variable = variable.resolve()
         del self.parameters[par]
         return variable
 
@@ -4604,7 +4712,7 @@ class MapdlGrpc(MapdlBase):
         name: str = "",
         sector: MapdlInt = "",
         **kwargs: KwargDict,
-    ):
+    ) -> NDArray[np.float64]:
         """Wraps NSOL to return the variable as an array."""
         super().nsol(
             nvar=nvar,  # type: ignore[arg-type]
@@ -4615,7 +4723,8 @@ class MapdlGrpc(MapdlBase):
             sector=sector,
             **kwargs,
         )
-        return self.vget("_temp", nvar)  # type: ignore[arg-type]
+        variable = self.vget("_temp", nvar)  # type: ignore[arg-type]
+        return variable.resolve() if isinstance(variable, LazyArray) else variable
 
     @wraps(MapdlBase.esol)
     def esol(  # numpydoc ignore=RT01
@@ -4638,7 +4747,8 @@ class MapdlGrpc(MapdlBase):
             name=name,
             **kwargs,
         )
-        return self.vget("_temp", nvar)  # type: ignore[arg-type]
+        variable = self.vget("_temp", nvar)  # type: ignore[arg-type]
+        return variable.resolve() if isinstance(variable, LazyArray) else variable
 
     @wraps(MapdlBase.rpsd)
     def rpsd(  # numpydoc ignore=RT01
@@ -4663,7 +4773,8 @@ class MapdlGrpc(MapdlBase):
             signif=signif,
             **kwargs,
         )
-        return self.vget("_temp", ir)  # type: ignore[arg-type]
+        variable = self.vget("_temp", ir)  # type: ignore[arg-type]
+        return variable.resolve() if isinstance(variable, LazyArray) else variable
 
     def get_nsol(
         self,
@@ -4701,7 +4812,7 @@ class MapdlGrpc(MapdlBase):
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             Variable values
 
         Notes
@@ -4785,7 +4896,7 @@ class MapdlGrpc(MapdlBase):
 
         Returns
         -------
-        np.array
+        numpy.ndarray
             Variable values
 
         Notes

--- a/tests/test_lazy_array.py
+++ b/tests/test_lazy_array.py
@@ -39,9 +39,7 @@ def mock_mapdl():
     """Return a mock MAPDL instance with a mocked ``parameters`` mapping."""
     mapdl = MagicMock()
     mapdl.parameters = MagicMock()
-    mapdl.parameters.__getitem__ = MagicMock(
-        return_value=np.array([1.0, 2.0, 3.0])
-    )
+    mapdl.parameters.__getitem__ = MagicMock(return_value=np.array([1.0, 2.0, 3.0]))
     return mapdl
 
 

--- a/tests/test_lazy_array.py
+++ b/tests/test_lazy_array.py
@@ -1,0 +1,112 @@
+# Copyright (C) 2016 - 2026 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2016 - 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Unit tests for ansys.mapdl.core.lazy_array.LazyArray (issue #4190).
+
+These tests use a mocked ``Mapdl`` object (via ``mapdl.parameters``) and do
+not require a running MAPDL instance.
+"""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from ansys.mapdl.core.lazy_array import LazyArray
+
+
+@pytest.fixture
+def mock_mapdl():
+    """Return a mock MAPDL instance with a mocked ``parameters`` mapping."""
+    mapdl = MagicMock()
+    mapdl.parameters = MagicMock()
+    mapdl.parameters.__getitem__ = MagicMock(
+        return_value=np.array([1.0, 2.0, 3.0])
+    )
+    return mapdl
+
+
+def test_no_download_on_creation(mock_mapdl):
+    """Creating a LazyArray must not trigger any parameter retrieval."""
+    LazyArray(mock_mapdl, "A")
+    mock_mapdl.parameters.__getitem__.assert_not_called()
+
+
+def test_resolve_on_array_conversion(mock_mapdl):
+    """np.asarray(...) must trigger exactly one retrieval."""
+    lazy = LazyArray(mock_mapdl, "A")
+    result = np.asarray(lazy)
+    np.testing.assert_array_equal(result, [1.0, 2.0, 3.0])
+    mock_mapdl.parameters.__getitem__.assert_called_once_with("A")
+
+
+def test_resolve_is_cached(mock_mapdl):
+    """Repeated usage must only download the parameter once."""
+    lazy = LazyArray(mock_mapdl, "A")
+    np.asarray(lazy)
+    _ = lazy[0]
+    _ = len(lazy)
+    list(lazy)
+    repr(lazy)
+    mock_mapdl.parameters.__getitem__.assert_called_once_with("A")
+
+
+def test_getitem(mock_mapdl):
+    lazy = LazyArray(mock_mapdl, "A")
+    assert lazy[0] == 1.0
+    assert lazy[1] == 2.0
+
+
+def test_len(mock_mapdl):
+    lazy = LazyArray(mock_mapdl, "A")
+    assert len(lazy) == 3
+
+
+def test_iter(mock_mapdl):
+    lazy = LazyArray(mock_mapdl, "A")
+    assert list(lazy) == [1.0, 2.0, 3.0]
+
+
+def test_repr(mock_mapdl):
+    lazy = LazyArray(mock_mapdl, "A")
+    assert repr(lazy) == repr(np.array([1.0, 2.0, 3.0]))
+
+
+def test_numpy_operations(mock_mapdl):
+    """LazyArray must behave like a ndarray for common NumPy operations."""
+    lazy = LazyArray(mock_mapdl, "A")
+    assert np.sum(lazy) == 6.0
+    assert np.mean(lazy) == 2.0
+    np.testing.assert_array_equal(lazy + 1, [2.0, 3.0, 4.0])
+
+
+def test_dtype_conversion(mock_mapdl):
+    lazy = LazyArray(mock_mapdl, "A")
+    result = np.asarray(lazy, dtype=np.int32)
+    assert result.dtype == np.int32
+    np.testing.assert_array_equal(result, [1, 2, 3])
+
+
+def test_not_instance_of_ndarray(mock_mapdl):
+    """LazyArray is intentionally not an ndarray subclass (see docstring)."""
+    lazy = LazyArray(mock_mapdl, "A")
+    assert not isinstance(lazy, np.ndarray)

--- a/tests/test_lazy_array.py
+++ b/tests/test_lazy_array.py
@@ -26,12 +26,14 @@ These tests use a mocked ``Mapdl`` object (via ``mapdl.parameters``) and do
 not require a running MAPDL instance.
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import numpy as np
 import pytest
 
 from ansys.mapdl.core.lazy_array import LazyArray
+from ansys.mapdl.core.mapdl import MapdlBase
+from ansys.mapdl.core.mapdl_grpc import MapdlGrpc
 
 
 @pytest.fixture
@@ -108,3 +110,153 @@ def test_not_instance_of_ndarray(mock_mapdl):
     """LazyArray is intentionally not an ndarray subclass (see docstring)."""
     lazy = LazyArray(mock_mapdl, "A")
     assert not isinstance(lazy, np.ndarray)
+
+
+def _mock_grpc_mapdl():
+    """Create the small portion of MapdlGrpc needed by the VGET wrapper."""
+    mapdl = object.__new__(MapdlGrpc)
+    mapdl._store_commands = False
+    mapdl._lazy_array_counter = 0
+    mapdl._lazy_array_snapshots = set()
+    mapdl._parameters = MagicMock()
+    mapdl._parameters.__contains__.return_value = False
+    mapdl._parameters.full_parameters_output = MagicMock()
+    mapdl._parameters._parm = {
+        "NODE": {"type": "ARRAY", "shape": (2, 1, 1)},
+    }
+    mapdl.dim = MagicMock()
+    mapdl.mfun = MagicMock()
+    mapdl.run = MagicMock()
+    return mapdl
+
+
+def test_unresolved_vgets_use_distinct_server_snapshots(monkeypatch):
+    """Repeated VGET calls must not alias an unresolved result."""
+    mapdl = _mock_grpc_mapdl()
+    monkeypatch.setattr(MapdlBase, "vget", lambda self, **kwargs: None)
+
+    before = mapdl.vget(par="NODE")
+    after = mapdl.vget(par="NODE")
+
+    assert before._parameter_name != after._parameter_name
+    assert mapdl.dim.call_args_list == [
+        call(
+            before._parameter_name,
+            type_="ARRAY",
+            imax=2,
+            jmax=1,
+            kmax=1,
+            mute=True,
+        ),
+        call(
+            after._parameter_name,
+            type_="ARRAY",
+            imax=2,
+            jmax=1,
+            kmax=1,
+            mute=True,
+        ),
+    ]
+    assert mapdl.mfun.call_args_list == [
+        call(before._parameter_name, "COPY", "NODE", mute=True),
+        call(after._parameter_name, "COPY", "NODE", mute=True),
+    ]
+    assert mapdl._lazy_array_snapshots == {
+        before._parameter_name,
+        after._parameter_name,
+    }
+
+    values = {
+        before._parameter_name: np.array([1.0, 2.0]),
+        after._parameter_name: np.array([4.0, 7.0]),
+    }
+    mapdl.parameters.__getitem__.side_effect = values.__getitem__
+
+    np.testing.assert_array_equal(np.asarray(before), [1.0, 2.0])
+    np.testing.assert_array_equal(np.asarray(after), [4.0, 7.0])
+    np.testing.assert_array_equal(after - before, [3.0, 5.0])
+    assert mapdl.run.call_count == 2
+    assert not mapdl._lazy_array_snapshots
+
+
+def test_lazy_array_close_deletes_unused_snapshot():
+    """An unused snapshot can be released without downloading its values."""
+    mapdl = _mock_grpc_mapdl()
+    snapshot = "_PYMAPDL_LAZY_0000000000000001"
+    mapdl._lazy_array_snapshots.add(snapshot)
+    lazy = LazyArray(
+        mapdl,
+        snapshot,
+        cleanup=lambda: mapdl._delete_lazy_array_snapshot(snapshot),
+    )
+
+    lazy.close()
+
+    mapdl.run.assert_called_once_with(f"{snapshot}=", mute=True)
+    mapdl.parameters.__getitem__.assert_not_called()
+    assert not mapdl._lazy_array_snapshots
+
+
+def test_snapshot_names_skip_existing_parameters():
+    """Snapshot names must be bounded and avoid existing MAPDL parameters."""
+    mapdl = _mock_grpc_mapdl()
+    mapdl.parameters.__contains__.side_effect = [True, False]
+
+    name = mapdl._new_lazy_array_snapshot()
+
+    assert name == "_PYMAPDL_LAZY_0000000000000002"
+    assert len(name) <= 32
+
+
+def test_snapshot_cleanup_propagates_errors():
+    """Cleanup errors must remain visible to the caller."""
+    mapdl = _mock_grpc_mapdl()
+    mapdl._lazy_array_snapshots.add("_PYMAPDL_LAZY_0000000000000001")
+    mapdl.run.side_effect = RuntimeError("delete failed")
+
+    with pytest.raises(RuntimeError, match="delete failed"):
+        mapdl._cleanup_lazy_array_snapshots()
+
+    assert mapdl._lazy_array_snapshots
+
+
+def test_vget_preserves_store_commands(monkeypatch):
+    """Command storage must not add a server snapshot."""
+    mapdl = _mock_grpc_mapdl()
+    mapdl._store_commands = True
+    monkeypatch.setattr(MapdlBase, "vget", lambda self, **kwargs: None)
+
+    assert mapdl.vget(par="NODE") is None
+    mapdl.mfun.assert_not_called()
+    assert not mapdl._lazy_array_snapshots
+
+
+def test_temporary_result_wrappers_materialize_snapshots(monkeypatch):
+    """NSOL, ESOL, and RPSD retain their ndarray-returning API."""
+    mapdl = _mock_grpc_mapdl()
+    mapdl.parameters.__getitem__.return_value = np.array([1.0, 2.0])
+    mapdl.vget = MagicMock(
+        side_effect=lambda *args, **kwargs: LazyArray(mapdl, "SNAPSHOT")
+    )
+
+    for wrapper, command in (("nsol", "nsol"), ("esol", "esol"), ("rpsd", "rpsd")):
+        monkeypatch.setattr(MapdlBase, command, lambda self, **kwargs: None)
+        result = getattr(MapdlGrpc, wrapper)(mapdl)
+        np.testing.assert_array_equal(result, [1.0, 2.0])
+
+    assert mapdl.parameters.__getitem__.call_count == 3
+
+
+def test_get_variable_deletes_source_after_vget():
+    """Deleting the temporary VGET parameter must not invalidate its result."""
+    mapdl = _mock_grpc_mapdl()
+    snapshot = "_PYMAPDL_LAZY_0000000000000001"
+    mapdl.parameters.__getitem__.return_value = np.array([1.0, 2.0])
+    mapdl.vget = MagicMock(return_value=LazyArray(mapdl, snapshot))
+
+    result = MapdlGrpc.get_variable(mapdl, ir=2)
+
+    np.testing.assert_array_equal(result, [1.0, 2.0])
+    mapdl.parameters.__getitem__.assert_called_once_with(snapshot)
+    mapdl.vget.assert_called_once_with(par="temp_var", ir=2, tstrt="", kcplx="")
+    mapdl.parameters.__delitem__.assert_called_once_with("temp_var")


### PR DESCRIPTION
## Description
Introduces `ansys.mapdl.core.lazy_array.LazyArray`, an array-like proxy
that defers downloading MAPDL parameter values until they are actually
used (indexing, iteration, `len()`, `repr()`, or any NumPy operation
via `NDArrayOperatorsMixin`/`__array_ufunc__`).

`Mapdl.vget()` currently runs the `VGET` command server-side and then
*unconditionally* downloads the resulting array through
`self.parameters[par]`, even when the caller never uses the returned
value. This change makes `vget()` return a `LazyArray` instead: the
MAPDL command still runs immediately, but the actual data transfer
only happens on first use, and the result is cached to avoid repeated
downloads.

Changes:
- New `src/ansys/mapdl/core/lazy_array.py` with the `LazyArray` class
  (numpydoc docstrings, `resolve()` method, NumPy operator support).
- `Mapdl.vget()` in `src/ansys/mapdl/core/mapdl_grpc.py` returns a
  `LazyArray` instead of eagerly resolving `self.parameters[par]`.
- New unit tests in `tests/test_lazy_array.py` (fully mocked, no
  MAPDL instance required) covering deferred resolution, caching,
  indexing, iteration, `len()`, `repr()`, and NumPy arithmetic.

**Note:** `isinstance(result, np.ndarray)` is intentionally `False`
for a `LazyArray`; use `np.asarray(result)` to materialize a plain
`numpy.ndarray` when needed. This is documented in the class and
method docstrings.

## Issue linked
Resolves #4190 — some methods (for example `Mapdl.vget`) return
arrays by default, which is convenient but expensive when the
returned array is never used.

## Checklist
- [x] I have visited and read [Develop PyMAPDL](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#develop-pymapdl).
- [x] I have [tested my changes locally](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing)
- [x] I have added necessary [documentation or updated existing documentation](https://mapdl.docs.pyansys.com/version/stable/getting_started/write_documentation.html#id2).
- [x] I have followed the [PyMAPDL coding style guidelines](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-style).
- [x] I have added appropriate [unit tests](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#unit-testing) that also ensure the [minimal coverage criteria](https://mapdl.docs.pyansys.com/version/stable/getting_started/develop_pymapdl.html#code-coverage).
- [x] I have reviewed my changes before submitting this pull request.
- [x] I have [linked the issue or issues](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2) that are solved to the PR if any.
- [x] I have [assigned this PR to myself](https://dev.docs.pyansys.com/content-writing/content-how-tos/create-PR.html#id2).
- [ ] I have marked this PR as ``draft`` if it is not ready to be reviewed yet.
- [x] I have made sure that the title of my PR follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new MAPDL command``)
